### PR TITLE
[ISS-94] require GOOGLE_STORAGE_BUCKET env var to be set if using gcp

### DIFF
--- a/pkg/utils/locking.go
+++ b/pkg/utils/locking.go
@@ -153,7 +153,7 @@ func GetLock() (Lock, error) {
 
 		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
 		if bucketName == "" {
-			bucketName = "digger-lock"
+			return nil, errors.New("GOOGLE_STORAGE_BUCKET is not set")
 		}
 		bucket := client.Bucket(bucketName)
 		lock := gcp.GoogleStorageLock{Client: client, Bucket: bucket, Context: ctx}


### PR DESCRIPTION
We used to default to digger-lock as a bucket name, however gcp bucket names are supposed to be unique

closes #94 