### PR TITLE
create dynamodb table if it does not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ With Digger terraform jobs natively in your CI runners. It takes care of locks, 
 [Demo video](https://www.loom.com/share/e201e639a73941e0b5508710377a6106)
 
 ## Features
-- Runner-less. Terraform runs in the compute environment of your existing CI such as Github Actions, Gitlab, Argo etc.
-- Minimal backend, or none at all. Digger's own backend is a serverless function; it is only needed for certain CI environments (eg Gitlab)
-- Code-level locks. Avoid race conditions across multiple PRs. Similar to Atlantis workflow.
-- Multi-cloud. At the moment Digger supports AWS and GCP; Azure support coming in April 2023 (yes, in a few weeks).
-- Projects. Allow to isolate terraform runs and locks to a specific directory
-- Terragrunt support
-- Workspaces support
+- 👟 Runner-less. Terraform runs in the compute environment of your existing CI such as Github Actions, Gitlab, Argo etc.
+- 🪶 Minimal / no backend. Digger's own backend is a serverless function; it is only needed for certain CI environments (eg Gitlab)
+- 🔒 Code-level locks. Avoid race conditions across multiple PRs. Similar to Atlantis workflow.
+- ☁️ Multi-cloud. At the moment Digger supports AWS and GCP; Azure support coming in April 2023 (yes, in a few weeks).
+- 💥 Projects. Allow to isolate terraform runs and locks to a specific directory
+- 💥 Terragrunt support
+- 💥 Workspaces support
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Need a feature that's not listed? Book a [community feedback call](https://calen
 - ⌛ Azure Support. Use Azure Cosmos DB for PR Locks. ETA April 2023
 - ⌛ Bitbucket Support
 - ⌛ Jenkins Support
+- ⌛ Digital Ocean Support
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ With Digger terraform jobs natively in your CI runners. It takes care of locks, 
 - Terragrunt support
 - Workspaces support
 
+## Roadmap
+
+Need a feature that's not listed? Book a [community feedback call](https://calendly.com/diggerdev/digger-community-feedback) - we ship fast ✅
+
+- ✅ GCP support. Store PR locks in GCP storage buckets. Shipped in [#50](https://github.com/diggerhq/digger/pull/50)
+- ✅ Workspaces support. Allow usage of Terraform CLI Workspaces. Shipped in [#72](https://github.com/diggerhq/digger/pull/72)
+- ✅ Terragrunt support. Config option to run terragrunt wrapper. Shipped in [#76](https://github.com/diggerhq/digger/pull/76)
+- ⌛ Configurable workflows. In addition to Atlantis-style (apply, then merge) also support "apply-only" and "no-lock"
+- ⌛ Gitlab Support. ETA April 2023
+- ⌛ Azure Support. Use Azure Cosmos DB for PR Locks. ETA April 2023
+- ⌛ Bitbucket Support
+- ⌛ Jenkins Support
+
 ## How to use
 
 This is demo flow with a sample repo using local state - for real world scenario you'll need to configure remote backend (S3 + DynamoDB) and add a [workflow file](https://github.com/diggerhq/digger_demo/blob/main/.github/workflows/plan.yml) to the root of the repo.
@@ -55,16 +68,6 @@ Digger also doesn't differentiate locks based on statefiles - if a PR is locked,
 
 state-level locks will keep working normally because are handled by terraform itself ([same as in Atlantis](https://www.runatlantis.io/docs/locking.html#relationship-to-terraform-state-locking))
 
-
-## Roadmap
-
-- Support for multiple modes of locking (apply-only, no-lock + queing)
-- 🔍 GCP Support
-    - Supporting of GCP storage buckets for PR locks
-- 🔍 Azure Support 
-    - Supporting of Azure Cosmos DB for PR Locks
-- 🔍 Gitlab Support
-- 🔍 Jenkins Support
 
 ## Notes
 - We perform anonymous usage tracking. No sensitive or personal / identifyable data is logged. You can see what is tracked in [`pkg/utils/usage.go`](https://github.com/diggerhq/digger/blob/main/pkg/utils/usage.go)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ With Digger terraform jobs natively in your CI runners. It takes care of locks, 
 [Demo video](https://www.loom.com/share/e201e639a73941e0b5508710377a6106)
 
 ## Features
-- code-level locks - only 1 open PR can run plan / apply. This avoids conflicts
-- no need to install any backend into your infra - locks are stored in DynamoDB
+- Runner-less. Terraform runs in the compute environment of your existing CI such as Github Actions, Gitlab, Argo etc.
+- Minimal backend, or none at all. Digger's own backend is a serverless function; it is only needed for certain CI environments (eg Gitlab)
+- Code-level locks. Avoid race conditions across multiple PRs. Similar to Atlantis workflow.
+- Multi-cloud. At the moment Digger supports AWS and GCP; Azure support coming in April 2023 (yes, in a few weeks).
+- Projects. Allow to isolate terraform runs and locks to a specific directory
+- Terragrunt support
+- Workspaces support
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img width="733" alt="Screenshot 2023-02-28 at 11 25 48" src="https://user-images.githubusercontent.com/1280498/221849642-ae6cb056-5b5b-478f-8cfb-42790e1739e7.png">
 </h1>
 <h2 align="center">
-  <a href="https://join.slack.com/t/diggertalk/shared_invite/zt-1q6npg7ib-9dwRbJp8sQpSr2fvWzt9aA">Slack</a> |
+  <a href="https://join.slack.com/t/diggertalk/shared_invite/zt-1sqckde6q-iRNgEQDjsLW6l5Z~Bwwt6g">Slack</a> |
   <a href="https://digger.dev">Website</a> |
   <a href="https://diggerhq.gitbook.io/digger-docs/">Docs</a>
 </h2>

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ CI/CD for Terraform is [not easy](https://itnext.io/pains-in-terraform-collabora
 
 But why have 2 CI systems? Why not reuse the existing CI infrastructure? Digger does just that.
 
-With Digger terraform jobs natively in your CI runners. It takes care of locks, state, outputs etc.
+With Digger terraform jobs natively in your CI runners. It takes care of locks, state, outputs etc. [Demo video](https://www.loom.com/share/e201e639a73941e0b5508710377a6106)
 
-[Demo video](https://www.loom.com/share/e201e639a73941e0b5508710377a6106)
 
 ## Features
 - 👟 Runner-less. Terraform runs in the compute environment of your existing CI such as Github Actions, Gitlab, Argo etc.

--- a/pkg/aws/dynamo_locking.go
+++ b/pkg/aws/dynamo_locking.go
@@ -35,7 +35,7 @@ func (dynamoDbLock *DynamoDbLock) createTableIfNotExists() {
 			},
 			{
 				AttributeName: aws.String("SK"),
-				KeyType:       aws.String("HASH"),
+				KeyType:       aws.String("RANGE"),
 			},
 		},
 		BillingMode: aws.String("PAY_PER_REQUEST"),

--- a/pkg/aws/dynamo_locking.go
+++ b/pkg/aws/dynamo_locking.go
@@ -17,7 +17,17 @@ type DynamoDbLock struct {
 }
 
 func (dynamoDbLock *DynamoDbLock) createTableIfNotExists() {
-	input := &dynamodb.CreateTableInput{
+	input := &dynamodb.DescribeTableInput{
+		TableName: aws.String(TABLE_NAME),
+	}
+
+	_, err := dynamoDbLock.DynamoDb.DescribeTable(input)
+	// table already exists
+	if err == nil {
+		return
+	}
+
+	createtbl_input := &dynamodb.CreateTableInput{
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
 			{
 				AttributeName: aws.String("PK"),
@@ -41,9 +51,11 @@ func (dynamoDbLock *DynamoDbLock) createTableIfNotExists() {
 		BillingMode: aws.String("PAY_PER_REQUEST"),
 		TableName:   aws.String(TABLE_NAME),
 	}
-	_, err := dynamoDbLock.DynamoDb.CreateTable(input)
+	_, err = dynamoDbLock.DynamoDb.CreateTable(createtbl_input)
 	if err != nil && os.Getenv("DEBUG") != "" {
 		fmt.Printf("%v\n", err)
+	} else {
+		fmt.Printf("DynamoDB Table %v has ben created\n", TABLE_NAME)
 	}
 }
 


### PR DESCRIPTION
DynamoDB table is not being created during the first run as mentioned in #111 resulting in `ResourceNotFound` Exception. This Pull request creates the table during any of the locking operations if it does not yet exist already. 

TODO: 

- Make the table creation only the first time (maybe using a flag of some sort?) Since otherwise there will be too much AWS calls happening for every action to check if the table exists.
- Write additional tests for this 
- Ensure there is no race conditions for the first run since this often occurs due to eventual consistency of AWS
