### PR TITLE
fix: remove pr comment about lock being already acquired

### DIFF
--- a/pkg/utils/locking.go
+++ b/pkg/utils/locking.go
@@ -55,8 +55,6 @@ func (projectLock *ProjectLockImpl) Lock(lockId string, prNumber int) (bool, err
 			projectLock.PrManager.PublishComment(prNumber, comment)
 			return false, nil
 		}
-		comment := "Project " + projectLock.projectId() + " locked by this PR #" + transactionIdStr + " already."
-		projectLock.PrManager.PublishComment(prNumber, comment)
 		return true, nil
 	}
 


### PR DESCRIPTION
Remove PR comment about lock already being acquired by the current PR.

closes #117 