### PR TITLE
fix: utils.projectId() now also returns the project name

### DIFF
--- a/pkg/utils/locking.go
+++ b/pkg/utils/locking.go
@@ -127,7 +127,7 @@ func (projectLock *ProjectLockImpl) ForceUnlock(lockId string, prNumber int) err
 }
 
 func (projectLock *ProjectLockImpl) projectId() string {
-	return projectLock.RepoOwner + "/" + projectLock.RepoName
+	return projectLock.RepoOwner + "/" + projectLock.RepoName + "#" + projectLock.ProjectName
 }
 
 func GetLock() (Lock, error) {


### PR DESCRIPTION
Adding the project name to `utils.projectId()` so that is it included in the comment about the lock being acquired.

The example below changes 2 different projects while the comments regarding the acquired lock is the same,

![image](https://user-images.githubusercontent.com/17277004/232538686-53b9abcd-afd7-4a2a-8226-210c3a2dc98e.png)

