### PR TITLE
feat: post collapsible plan and apply output PR comments

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -370,7 +370,7 @@ func (d DiggerExecutor) Plan(prNumber int) error {
 					return fmt.Errorf("error executing plan: %v", err)
 				}
 				plan := cleanupTerraformPlan(isNonEmptyPlan, err, stdout, stderr)
-				comment := "Plan for **" + d.lock.LockId() + "**\n" + plan
+				comment := utils.GetCollapsibleComment("Plan for **"+d.lock.LockId()+"**", plan)
 				d.prManager.PublishComment(prNumber, comment)
 			}
 			if step.Action == "run" {
@@ -442,7 +442,7 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 				if step.Action == "apply" {
 					stdout, stderr, err := d.terraformExecutor.Apply(step.ExtraArgs, plansFilename)
 					applyOutput := cleanupTerraformApply(true, err, stdout, stderr)
-					comment := "Apply for **" + d.lock.LockId() + "**\n" + applyOutput
+					comment := utils.GetCollapsibleComment("Apply for **"+d.lock.LockId()+"**", applyOutput)
 					d.prManager.PublishComment(prNumber, comment)
 					if err == nil {
 						_, err := d.lock.Unlock(prNumber)
@@ -483,7 +483,7 @@ func (d DiggerExecutor) Lock(prNumber int) error {
 }
 
 func cleanupTerraformOutput(nonEmptyOutput bool, planError error, stdout string, stderr string, regexStr string) string {
-	var errorStr, result, start string
+	var errorStr, start string
 
 	// removes output of terraform -version command that terraform-exec executes on every run
 	i := strings.Index(stdout, "Initializing the backend...")
@@ -498,7 +498,7 @@ func cleanupTerraformOutput(nonEmptyOutput bool, planError error, stdout string,
 		} else if stderr != "" {
 			errorStr = stderr
 		}
-		return "```terraform\n" + errorStr + "\n```"
+		return errorStr
 	} else if nonEmptyOutput {
 		start = "Terraform will perform the following actions:"
 	} else {
@@ -516,8 +516,7 @@ func cleanupTerraformOutput(nonEmptyOutput bool, planError error, stdout string,
 		endPos = strings.Index(stdout, matches[0]) + len(matches[0])
 	}
 
-	result = stdout[startPos:endPos]
-	return "```terraform\n" + result + "\n```"
+	return stdout[startPos:endPos]
 }
 
 func cleanupTerraformApply(nonEmptyPlan bool, planError error, stdout string, stderr string) string {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -370,7 +370,7 @@ func (d DiggerExecutor) Plan(prNumber int) error {
 					return fmt.Errorf("error executing plan: %v", err)
 				}
 				plan := cleanupTerraformPlan(isNonEmptyPlan, err, stdout, stderr)
-				comment := utils.GetCollapsibleComment("Plan for **"+d.lock.LockId()+"**", plan)
+				comment := utils.GetTerraformOutputAsCollapsibleComment("Plan for **"+d.lock.LockId()+"**", plan)
 				d.prManager.PublishComment(prNumber, comment)
 			}
 			if step.Action == "run" {
@@ -442,7 +442,7 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 				if step.Action == "apply" {
 					stdout, stderr, err := d.terraformExecutor.Apply(step.ExtraArgs, plansFilename)
 					applyOutput := cleanupTerraformApply(true, err, stdout, stderr)
-					comment := utils.GetCollapsibleComment("Apply for **"+d.lock.LockId()+"**", applyOutput)
+					comment := utils.GetTerraformOutputAsCollapsibleComment("Apply for **"+d.lock.LockId()+"**", applyOutput)
 					d.prManager.PublishComment(prNumber, comment)
 					if err == nil {
 						_, err := d.lock.Unlock(prNumber)

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -156,7 +156,7 @@ func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock)
 
-	assert.Equal(t, []string{"DownloadLatestPlans 1", "IsMergeable 1", "Lock 1", "Init ", "Apply  plan", "LockId ", "PublishComment 1 Apply for ****\n```terraform\n\n```", "Unlock 1", "Run echo", "LockId "}, commandStrings)
+	assert.Equal(t, []string{"DownloadLatestPlans 1", "IsMergeable 1", "Lock 1", "Init ", "Apply  plan", "LockId ", "PublishComment 1 <details>\n  <summary>Apply for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Unlock 1", "Run echo", "LockId "}, commandStrings)
 }
 
 func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
@@ -197,7 +197,7 @@ func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock)
 
-	assert.Equal(t, []string{"Lock 1", "Init ", "Plan -out .tfplan", "LockId ", "PublishComment 1 Plan for ****\n```terraform\n\n```", "Run echo", "LockId "}, commandStrings)
+	assert.Equal(t, []string{"Lock 1", "Init ", "Plan -out .tfplan", "LockId ", "PublishComment 1 <details>\n  <summary>Plan for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
 }
 
 func allCommandsInOrderWithParams(terraformExecutor *MockTerraformExecutor, commandRunner *MockCommandRunner, prManager *MockPRManager, lock *MockProjectLock) []string {

--- a/pkg/utils/comments.go
+++ b/pkg/utils/comments.go
@@ -1,11 +1,11 @@
 package utils
 
-func GetCollapsibleComment(summary string, collapedComment string) string {
+func GetTerraformOutputAsCollapsibleComment(summary string, collapsedComment string) string {
 	str := `<details>
   <summary>` + summary + `</summary>
-  
-  ` + "```" + `
-` + collapedComment + `
+
+  ` + "```terraform" + `
+` + collapsedComment + `
   ` + "```" + `
 </details>`
 

--- a/pkg/utils/comments.go
+++ b/pkg/utils/comments.go
@@ -1,0 +1,13 @@
+package utils
+
+func GetCollapsibleComment(summary string, collapedComment string) string {
+	str := `<details>
+  <summary>` + summary + `</summary>
+  
+  ` + "```" + `
+` + collapedComment + `
+  ` + "```" + `
+</details>`
+
+	return str
+}


### PR DESCRIPTION
The output of `terraform plan` and `terraform apply` commands can be very big, and could clutter the PR everytime being posted in comments. Therefore making use of collapsible comments instead:

![image](https://user-images.githubusercontent.com/17277004/234440539-96472320-f5b2-4ac4-8b0e-e4ce68e38730.png)

![image](https://user-images.githubusercontent.com/17277004/234440948-82b87c16-f94a-41ca-91a5-4b233275ed9b.png)
