### PR TITLE
chore: don't post comments regarding executed workflow commands

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -375,8 +375,7 @@ func (d DiggerExecutor) Plan(prNumber int) error {
 			}
 			if step.Action == "run" {
 				stdout, stderr, err := d.commandRunner.Run(step.Value)
-				comment := "Running " + step.Value + " for **" + d.lock.LockId() + "**\n" + stdout + stderr
-				d.prManager.PublishComment(prNumber, comment)
+				log.Printf("Running %v for **%v**\n%v%v", step.Value, d.lock.LockId(), stdout, stderr)
 				if err != nil {
 					return fmt.Errorf("error running command: %v", err)
 				}
@@ -456,8 +455,7 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 				}
 				if step.Action == "run" {
 					stdout, stderr, err := d.commandRunner.Run(step.Value)
-					comment := "Running " + step.Value + " for **" + d.lock.LockId() + "**\n" + stdout + stderr
-					d.prManager.PublishComment(prNumber, comment)
+					log.Printf("Running %v for **%v**\n%v%v", step.Value, d.lock.LockId(), stdout, stderr)
 					if err != nil {
 						return fmt.Errorf("error running command: %v", err)
 					}

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -2,12 +2,13 @@ package digger
 
 import (
 	"digger/pkg/configuration"
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type RunInfo struct {
@@ -155,7 +156,7 @@ func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock)
 
-	assert.Equal(t, []string{"DownloadLatestPlans 1", "IsMergeable 1", "Lock 1", "Init ", "Apply  plan", "LockId ", "PublishComment 1 Apply for ****\n```terraform\n\n```", "Unlock 1", "Run echo", "LockId ", "PublishComment 1 Running echo for ****\n"}, commandStrings)
+	assert.Equal(t, []string{"DownloadLatestPlans 1", "IsMergeable 1", "Lock 1", "Init ", "Apply  plan", "LockId ", "PublishComment 1 Apply for ****\n```terraform\n\n```", "Unlock 1", "Run echo", "LockId "}, commandStrings)
 }
 
 func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
@@ -196,7 +197,7 @@ func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock)
 
-	assert.Equal(t, []string{"Lock 1", "Init ", "Plan -out .tfplan", "LockId ", "PublishComment 1 Plan for ****\n```terraform\n\n```", "Run echo", "LockId ", "PublishComment 1 Running echo for ****\n"}, commandStrings)
+	assert.Equal(t, []string{"Lock 1", "Init ", "Plan -out .tfplan", "LockId ", "PublishComment 1 Plan for ****\n```terraform\n\n```", "Run echo", "LockId "}, commandStrings)
 }
 
 func allCommandsInOrderWithParams(terraformExecutor *MockTerraformExecutor, commandRunner *MockCommandRunner, prManager *MockPRManager, lock *MockProjectLock) []string {


### PR DESCRIPTION
From testing, I found that posting comments regarding every executed workflow custom command with their output would clutter the PR in general and make it less readable. Proposing to only log this content and only post comments regarding `terraform plan/apply` output content and locks being acquired/released instead by default.

For example

![image](https://user-images.githubusercontent.com/17277004/234446266-cbf37b8e-8515-4e22-b04e-c208a50cb012.png)
