### PR TITLE
fix: plan filename search

### DIFF
--- a/pkg/configuration/digger_config.go
+++ b/pkg/configuration/digger_config.go
@@ -199,6 +199,15 @@ func ConvertDiggerYamlToConfig(diggerYaml *DiggerConfigYaml, workingDir string, 
 		}
 	}
 
+	projectNames := make(map[string]bool)
+
+	for _, project := range diggerConfig.Projects {
+		if projectNames[project.Name] {
+			return nil, fmt.Errorf("project name '%s' is duplicated", project.Name)
+		}
+		projectNames[project.Name] = true
+	}
+
 	return &diggerConfig, nil
 }
 

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -20,11 +20,15 @@ func (z *Zipper) GetFileFromZip(zipFile string, filename string) (string, error)
 		return "", err
 	}
 	defer reader.Close()
-
+	println(zipFile)
+	println(len(reader.File))
+	println(filename)
 	for _, file := range reader.File {
 		if file.FileInfo().IsDir() {
 			continue
 		}
+		println(file.Name)
+
 		if file.Name == filename {
 			rc, err := file.Open()
 			if err != nil {

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"strings"
 )
 
 type Zip interface {
@@ -20,16 +21,12 @@ func (z *Zipper) GetFileFromZip(zipFile string, filename string) (string, error)
 		return "", err
 	}
 	defer reader.Close()
-	println(zipFile)
-	println(len(reader.File))
-	println(filename)
 	for _, file := range reader.File {
 		if file.FileInfo().IsDir() {
 			continue
 		}
-		println(file.Name)
 
-		if file.Name == filename {
+		if strings.HasSuffix(file.Name, filename) {
 			rc, err := file.Open()
 			if err != nil {
 				return "", err


### PR DESCRIPTION
When github action uploads files it includes relative path.
To match that we can just match the name of the file instead of the whole path, given that project names are unique. Which they should be
