### PR TITLE
fix: post error comment when specifying an invalid project name with digger comment

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -38,6 +38,9 @@ func ProcessGitHubEvent(ghEvent models.Event, diggerConfig *configuration.Digger
 		requestedProject := parseProjectName(ghEvent.(models.IssueCommentEvent).Comment.Body)
 		if requestedProject != "" {
 			impactedProjects = diggerConfig.GetProjects(requestedProject)
+			if len(impactedProjects) == 0 {
+				prManager.PublishComment(prNumber, "Error: Invalid project name '"+requestedProject+"'. The requested operation cannot be performed.")
+			}
 		} else {
 			changedFiles, err := prManager.GetChangedFiles(prNumber)
 			if err != nil {


### PR DESCRIPTION
closes #52 