### PR TITLE
fix: change regex used to parse project names

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -285,7 +285,7 @@ func parseWorkspace(comment string) (string, error) {
 }
 
 func parseProjectName(comment string) string {
-	re := regexp.MustCompile(`-p (.*)`)
+	re := regexp.MustCompile(`-p ([0-9a-zA-Z\-_]+)`)
 	match := re.FindStringSubmatch(comment)
 	if len(match) > 1 {
 		return match[1]

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -285,7 +285,7 @@ func parseWorkspace(comment string) (string, error) {
 }
 
 func parseProjectName(comment string) string {
-	re := regexp.MustCompile(`-p ([a-zA-Z\-]+)`)
+	re := regexp.MustCompile(`-p (.*)`)
 	match := re.FindStringSubmatch(comment)
 	if len(match) > 1 {
 		return match[1]


### PR DESCRIPTION
Using a generic regex to match anything after a `digger plan/apply -p` comment, instead of specific characters. Or else permitted characters for projects names declared in digger.yml need to be documented and the project names need to be validated using the same regex.


Fixes the current issue
![image](https://user-images.githubusercontent.com/17277004/235391491-6eb43231-9e81-451f-b23d-70feeb37b184.png)
