### PR TITLE
fix: disable project unlock on apply default functionality

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,10 +56,6 @@ inputs:
   upload-plan-destination:
     description: Destination to upload the plan to. gcp and github are currently supported
     required: false
-  unlock-on-apply:
-    description: Whether or not to release a project's lock when changes have been applied
-    required: false
-    default: 'true'
 
 outputs:
   output:
@@ -145,7 +141,6 @@ runs:
       shell: bash
       env:
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
-        UNLOCK_ON_APPLY: ${{ inputs.unlock-on-apply }}
       run: |
           cd ${{ github.action_path }}
           go build -o digger ./cmd/digger
@@ -158,7 +153,6 @@ runs:
       env:
         actionref: ${{ github.action_ref }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
-        UNLOCK_ON_APPLY: ${{ inputs.unlock-on-apply }}
       id: digger
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
   upload-plan-destination:
     description: Destination to upload the plan to. gcp and github are currently supported
     required: false
+  unlock-on-apply:
+    description: Whether or not to release a project's lock when changes have been applied
+    required: false
+    default: 'true'
 
 outputs:
   output:
@@ -141,6 +145,7 @@ runs:
       shell: bash
       env:
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        UNLOCK_ON_APPLY: ${{ inputs.unlock-on-apply }}
       run: |
           cd ${{ github.action_path }}
           go build -o digger ./cmd/digger
@@ -153,6 +158,7 @@ runs:
       env:
         actionref: ${{ github.action_ref }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        UNLOCK_ON_APPLY: ${{ inputs.unlock-on-apply }}
       id: digger
       shell: bash
       run: |

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -445,13 +445,15 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 					applyOutput := cleanupTerraformApply(true, err, stdout, stderr)
 					comment := utils.GetTerraformOutputAsCollapsibleComment("Apply for **"+d.lock.LockId()+"**", applyOutput)
 					d.prManager.PublishComment(prNumber, comment)
-					if err == nil {
-						_, err := d.lock.Unlock(prNumber)
-						if err != nil {
-							return fmt.Errorf("error unlocking project: %v", err)
+					if strings.EqualFold(os.Getenv("UNLOCK_ON_APPLY"), "true") {
+						if err == nil {
+							_, err := d.lock.Unlock(prNumber)
+							if err != nil {
+								return fmt.Errorf("error unlocking project: %v", err)
+							}
+						} else {
+							d.prManager.PublishComment(prNumber, "Error during applying. Project lock will persist")
 						}
-					} else {
-						d.prManager.PublishComment(prNumber, "Error during applying. Project lock will persist")
 					}
 				}
 				if step.Action == "run" {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -445,6 +445,9 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 					applyOutput := cleanupTerraformApply(true, err, stdout, stderr)
 					comment := utils.GetTerraformOutputAsCollapsibleComment("Apply for **"+d.lock.LockId()+"**", applyOutput)
 					d.prManager.PublishComment(prNumber, comment)
+					if err != nil {
+						d.prManager.PublishComment(prNumber, "Error during applying.")
+					}
 				}
 				if step.Action == "run" {
 					stdout, stderr, err := d.commandRunner.Run(step.Value)

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -445,16 +445,6 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 					applyOutput := cleanupTerraformApply(true, err, stdout, stderr)
 					comment := utils.GetTerraformOutputAsCollapsibleComment("Apply for **"+d.lock.LockId()+"**", applyOutput)
 					d.prManager.PublishComment(prNumber, comment)
-					if strings.EqualFold(os.Getenv("UNLOCK_ON_APPLY"), "true") {
-						if err == nil {
-							_, err := d.lock.Unlock(prNumber)
-							if err != nil {
-								return fmt.Errorf("error unlocking project: %v", err)
-							}
-						} else {
-							d.prManager.PublishComment(prNumber, "Error during applying. Project lock will persist")
-						}
-					}
 				}
 				if step.Action == "run" {
 					stdout, stderr, err := d.commandRunner.Run(step.Value)

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -2,7 +2,6 @@ package digger
 
 import (
 	"digger/pkg/configuration"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -134,18 +133,8 @@ func (m *MockPlanStorage) RetrievePlan(planFileName string) (*string, error) {
 	return nil, nil
 }
 
-func TestCorrectCommandExecutionWhenApplyingWithoutUnlock(t *testing.T) {
-	commandStrings := RetrieveCommandExecutionWhenApplying()
-	assert.Equal(t, []string{"RetrievePlan .tfplan", "IsMergeable 1", "Lock 1", "Init ", "Apply ", "LockId ", "PublishComment 1 <details>\n  <summary>Apply for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
-}
+func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
 
-func TestCorrectCommandExecutionWhenApplyingWithUnlock(t *testing.T) {
-	os.Setenv("UNLOCK_ON_APPLY", "true")
-	commandStrings := RetrieveCommandExecutionWhenApplying()
-	assert.Equal(t, []string{"RetrievePlan .tfplan", "IsMergeable 1", "Lock 1", "Init ", "Apply ", "LockId ", "PublishComment 1 <details>\n  <summary>Apply for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Unlock 1", "Run echo", "LockId "}, commandStrings)
-}
-
-func RetrieveCommandExecutionWhenApplying() []string {
 	commandRunner := &MockCommandRunner{}
 	terraformExecutor := &MockTerraformExecutor{}
 	prManager := &MockPRManager{}
@@ -181,7 +170,9 @@ func RetrieveCommandExecutionWhenApplying() []string {
 
 	executor.Apply(1)
 
-	return allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage)
+	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage)
+
+	assert.Equal(t, []string{"RetrievePlan .tfplan", "IsMergeable 1", "Lock 1", "Init ", "Apply ", "LockId ", "PublishComment 1 <details>\n  <summary>Apply for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
 }
 
 func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -2,6 +2,7 @@ package digger
 
 import (
 	"digger/pkg/configuration"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -134,7 +135,7 @@ func (m *MockPlanStorage) RetrievePlan(planFileName string) (*string, error) {
 }
 
 func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
-
+	os.Setenv("UNLOCK_ON_APPLY", "true")
 	commandRunner := &MockCommandRunner{}
 	terraformExecutor := &MockTerraformExecutor{}
 	prManager := &MockPRManager{}
@@ -176,7 +177,6 @@ func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
 }
 
 func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
-
 	commandRunner := &MockCommandRunner{}
 	terraformExecutor := &MockTerraformExecutor{}
 	prManager := &MockPRManager{}


### PR DESCRIPTION
This behavior does not exist with Atlantis, so removing it accordingly,

In digger.yml, `on_commit_to_default` can be configured to release locks when the PR is merged instead.
```
    workflow_configuration:
      on_commit_to_default: [digger unlock]

```

closes #185 