### PR TITLE
chore: configure renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":automergeMinor"
+  ],
+  "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
- Minor and patch dependency updates should not introduce breaking changes: Configure [automergeminor](https://docs.renovatebot.com/presets-default/#automergeminor)
- add the `dependencies` label to PRs created by renovate
- add the `security` label to PRs created by renovate to address a vulnerability