### PR TITLE
fix: planstorage functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 venv/
 **/__pycache__/
 __azurite*
+digger

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -128,14 +128,19 @@ type MockPlanStorage struct {
 	Commands []RunInfo
 }
 
-func (m *MockPlanStorage) StorePlan(planFileName string) error {
-	m.Commands = append(m.Commands, RunInfo{"StorePlan", planFileName, time.Now()})
+func (m *MockPlanStorage) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
+	m.Commands = append(m.Commands, RunInfo{"StorePlan", localPlanFilePath, time.Now()})
 	return nil
 }
 
-func (m *MockPlanStorage) RetrievePlan(planFileName string) (*string, error) {
-	m.Commands = append(m.Commands, RunInfo{"RetrievePlan", planFileName, time.Now()})
+func (m *MockPlanStorage) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
+	m.Commands = append(m.Commands, RunInfo{"RetrievePlan", localPlanFilePath, time.Now()})
 	return nil, nil
+}
+
+func (m *MockPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
+	m.Commands = append(m.Commands, RunInfo{"DeleteStoredPlan", storedPlanFilePath, time.Now()})
+	return nil
 }
 
 func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
@@ -177,7 +182,7 @@ func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage)
 
-	assert.Equal(t, []string{"RetrievePlan .tfplan", "IsMergeable 1", "Lock 1", "Init ", "Apply ", "LockId ", "PublishComment 1 <details>\n  <summary>Apply for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
+	assert.Equal(t, []string{"RetrievePlan #.tfplan", "IsMergeable 1", "Lock 1", "Init ", "Apply ", "LockId ", "PublishComment 1 <details>\n  <summary>Apply for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
 }
 
 func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
@@ -219,7 +224,7 @@ func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage)
 
-	assert.Equal(t, []string{"Lock 1", "Init ", "Plan -out .tfplan", "StorePlan .tfplan", "LockId ", "PublishComment 1 <details>\n  <summary>Plan for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
+	assert.Equal(t, []string{"Lock 1", "Init ", "Plan -out #.tfplan", "StorePlan #.tfplan", "LockId ", "PublishComment 1 <details>\n  <summary>Plan for ****</summary>\n\n  ```terraform\n\n  ```\n</details>", "Run echo", "LockId "}, commandStrings)
 }
 
 func allCommandsInOrderWithParams(terraformExecutor *MockTerraformExecutor, commandRunner *MockCommandRunner, prManager *MockPRManager, lock *MockProjectLock, planStorage *MockPlanStorage) []string {

--- a/pkg/utils/mocks.go
+++ b/pkg/utils/mocks.go
@@ -77,10 +77,14 @@ func (t MockPullRequestManager) IsClosed(prNumber int) (bool, error) {
 type MockPlanStorage struct {
 }
 
-func (t MockPlanStorage) StorePlan(planfile string) error {
+func (t MockPlanStorage) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
 	return nil
 }
 
-func (t MockPlanStorage) RetrievePlan(planfile string) (*string, error) {
+func (t MockPlanStorage) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
 	return nil, nil
+}
+
+func (t MockPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
+	return nil
 }

--- a/pkg/utils/plan_storage.go
+++ b/pkg/utils/plan_storage.go
@@ -14,8 +14,9 @@ import (
 )
 
 type PlanStorage interface {
-	StorePlan(planFileName string) error
-	RetrievePlan(planFileName string) (*string, error)
+	StorePlan(localPlanFilePath string, storedPlanFilePath string) error
+	RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error)
+	DeleteStoredPlan(storedPlanFilePath string) error
 }
 
 type PlanStorageGcp struct {
@@ -32,14 +33,14 @@ type GithubPlanStorage struct {
 	ZipManager        Zipper
 }
 
-func (psg *PlanStorageGcp) StorePlan(planFileName string) error {
-	file, err := os.Open(planFileName)
+func (psg *PlanStorageGcp) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
+	file, err := os.Open(localPlanFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to open file: %v", err)
 	}
 	defer file.Close()
 
-	obj := psg.Bucket.Object(planFileName)
+	obj := psg.Bucket.Object(storedPlanFilePath)
 	wc := obj.NewWriter(psg.Context)
 
 	if _, err = io.Copy(wc, file); err != nil {
@@ -54,15 +55,15 @@ func (psg *PlanStorageGcp) StorePlan(planFileName string) error {
 	return nil
 }
 
-func (psg *PlanStorageGcp) RetrievePlan(planFileName string) (*string, error) {
-	obj := psg.Bucket.Object(planFileName)
+func (psg *PlanStorageGcp) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
+	obj := psg.Bucket.Object(storedPlanFilePath)
 	rc, err := obj.NewReader(psg.Context)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read data from bucket: %v", err)
 	}
 	defer rc.Close()
 
-	file, err := os.Create(planFileName)
+	file, err := os.Create(localPlanFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create file: %v", err)
 	}
@@ -72,15 +73,25 @@ func (psg *PlanStorageGcp) RetrievePlan(planFileName string) (*string, error) {
 		return nil, fmt.Errorf("unable to write data to file: %v", err)
 	}
 
-	return &planFileName, nil
+	return &localPlanFilePath, nil
 }
 
-func (gps *GithubPlanStorage) StorePlan(planFileName string) error {
-	_ = fmt.Sprintf("Skipping storing plan %s. It should be achieved using actions/upload-artifact@v3", planFileName)
+func (psg *PlanStorageGcp) DeleteStoredPlan(storedPlanFilePath string) error {
+	obj := psg.Bucket.Object(storedPlanFilePath)
+	err := obj.Delete(psg.Context)
+
+	if err != nil {
+		return fmt.Errorf("unable to delete file '%v' from bucket: %v", storedPlanFilePath, err)
+	}
 	return nil
 }
 
-func (gps *GithubPlanStorage) RetrievePlan(planFileName string) (*string, error) {
+func (gps *GithubPlanStorage) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
+	_ = fmt.Sprintf("Skipping storing plan %s. It should be achieved using actions/upload-artifact@v3", localPlanFilePath)
+	return nil
+}
+
+func (gps *GithubPlanStorage) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
 	plansFilename, err := gps.DownloadLatestPlans()
 
 	if err != nil {
@@ -91,12 +102,16 @@ func (gps *GithubPlanStorage) RetrievePlan(planFileName string) (*string, error)
 		return nil, fmt.Errorf("no plans found for this PR")
 	}
 
-	plansFilename, err = gps.ZipManager.GetFileFromZip(plansFilename, planFileName)
+	plansFilename, err = gps.ZipManager.GetFileFromZip(plansFilename, storedPlanFilePath)
 
 	if err != nil {
 		return nil, fmt.Errorf("error extracting plan: %v", err)
 	}
 	return &plansFilename, nil
+}
+
+func (gps *GithubPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
+	return nil
 }
 
 func (gps *GithubPlanStorage) DownloadLatestPlans() (string, error) {


### PR DESCRIPTION
closes #217 

- `planStorage.StorePlan()` now stores plan files along the lock files in storage buckets
![image](https://github.com/diggerhq/digger/assets/17277004/5dfc31c2-1d60-4cc5-a9db-c27cc6625cb2)

- stored plan files are deleted when a project's lock is released