### PR TITLE
fix: auto-merge logic when apply is executed with no specific project

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -46,6 +46,7 @@ func ProcessGitHubEvent(ghEvent models.Event, diggerConfig *configuration.Digger
 			}
 			impactedProjects = newImpactedProjects
 		} else {
+			mergePrIfCmdSuccessfull = true
 			changedFiles, err := prManager.GetChangedFiles(prNumber)
 			if err != nil {
 				log.Fatalf("Could not get changed files")


### PR DESCRIPTION
digger would not auto-merge the PR when commenting `digger apply` without specifying a project