### PR TITLE
fix: change CIService.IsMergeable() signature and github implementation

### DIFF
--- a/pkg/ci/main.go
+++ b/pkg/ci/main.go
@@ -6,6 +6,6 @@ type CIService interface {
 	SetStatus(prNumber int, status string, statusContext string) error
 	GetCombinedPullRequestStatus(prNumber int) (string, error)
 	MergePullRequest(prNumber int) error
-	IsMergeable(prNumber int) (bool, string, error)
+	IsMergeable(prNumber int) (bool, error)
 	IsClosed(prNumber int) (bool, error)
 }

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -158,14 +158,14 @@ func MergePullRequest(githubPrService ci.CIService, prNumber int) {
 		log.Fatalf("PR is not mergeable. Status: %v", combinedStatus)
 	}
 
-	prIsMergeable, mergeableState, err := githubPrService.IsMergeable(prNumber)
+	prIsMergeable, err := githubPrService.IsMergeable(prNumber)
 
 	if err != nil {
 		log.Fatalf("failed to check if PR is mergeable, %v", err)
 	}
 
 	if !prIsMergeable {
-		log.Fatalf("PR is not mergeable. State: %v", mergeableState)
+		log.Fatalf("PR is not mergeable")
 	}
 
 	err = githubPrService.MergePullRequest(prNumber)
@@ -463,11 +463,10 @@ func (d DiggerExecutor) Apply(prNumber int) error {
 		}
 	}
 
-	isMergeable, _, err := d.CIService.IsMergeable(prNumber)
+	isMergeable, err := d.CIService.IsMergeable(prNumber)
 	if err != nil {
 		return fmt.Errorf("error validating is PR is mergeable: %v", err)
 	}
-
 	if !isMergeable {
 		comment := "Cannot perform Apply since the PR is not currently mergeable."
 		d.CIService.PublishComment(prNumber, comment)

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -76,9 +76,9 @@ func (m *MockPRManager) MergePullRequest(prNumber int) error {
 	return nil
 }
 
-func (m *MockPRManager) IsMergeable(prNumber int) (bool, string, error) {
+func (m *MockPRManager) IsMergeable(prNumber int) (bool, error) {
 	m.Commands = append(m.Commands, RunInfo{"IsMergeable", strconv.Itoa(prNumber), time.Now()})
-	return true, "", nil
+	return true, nil
 }
 
 func (m *MockPRManager) DownloadLatestPlans(prNumber int) (string, error) {

--- a/pkg/github/pullrequestmanager_mock.go
+++ b/pkg/github/pullrequestmanager_mock.go
@@ -28,9 +28,9 @@ func (mockGithubPullrequestManager *MockGithubPullrequestManager) MergePullReque
 	return nil
 }
 
-func (mockGithubPullrequestManager *MockGithubPullrequestManager) IsMergeable(prNumber int) (bool, string, error) {
+func (mockGithubPullrequestManager *MockGithubPullrequestManager) IsMergeable(prNumber int) (bool, error) {
 	mockGithubPullrequestManager.commands = append(mockGithubPullrequestManager.commands, "IsMergeable")
-	return true, "", nil
+	return true, nil
 }
 
 func (mockGithubPullrequestManager *MockGithubPullrequestManager) DownloadLatestPlans(prNumber int) (string, error) {

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -7,11 +7,12 @@ import (
 	"digger/pkg/terraform"
 	"digger/pkg/utils"
 	"fmt"
-	"github.com/caarlos0/env/v7"
-	go_gitlab "github.com/xanzy/go-gitlab"
 	"log"
 	"path"
 	"strings"
+
+	"github.com/caarlos0/env/v7"
+	go_gitlab "github.com/xanzy/go-gitlab"
 )
 
 // based on https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
@@ -175,7 +176,7 @@ func (gitlabService GitLabService) MergePullRequest(mergeRequestID int) error {
 	return nil
 }
 
-func (gitlabService GitLabService) IsMergeable(mergeRequestID int) (bool, string, error) {
+func (gitlabService GitLabService) IsMergeable(mergeRequestID int) (bool, error) {
 	projectId := *gitlabService.Context.ProjectId
 	mergeRequestIID := *gitlabService.Context.MergeRequestIId
 
@@ -190,9 +191,9 @@ func (gitlabService GitLabService) IsMergeable(mergeRequestID int) (bool, string
 	}
 
 	if mergeRequest.DetailedMergeStatus == "mergeable" {
-		return true, "", nil
+		return true, nil
 	}
-	return false, "", nil
+	return false, nil
 }
 
 func (gitlabService GitLabService) IsClosed(mergeRequestID int) (bool, error) {

--- a/pkg/utils/mocks.go
+++ b/pkg/utils/mocks.go
@@ -62,8 +62,8 @@ func (t MockPullRequestManager) MergePullRequest(prNumber int) error {
 	return nil
 }
 
-func (t MockPullRequestManager) IsMergeable(prNumber int) (bool, string, error) {
-	return true, "", nil
+func (t MockPullRequestManager) IsMergeable(prNumber int) (bool, error) {
+	return true, nil
 }
 
 func (t MockPullRequestManager) DownloadLatestPlans(prNumber int) (string, error) {


### PR DESCRIPTION
From testing, found out that when a Github PR requires approvals to get merged and does not have it, `pr.GetMergeable()` will return `true` while `pr.GetMergeableState()` will return `blocked`.

I don't think there is much value in returning both values from the `CIService.IsMergeable()` VS a single boolean with logic based on the mergeable state's value, and therefore proposing this change.

The possible values for Github PR mergeable states seem to be documented here:  https://docs.github.com/en/github-ae@latest/graphql/reference/enums#mergestatestatus