### PR TITLE
feat: add support for disabling locking with NoOp lock provider

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
     description: Checkov version
     required: false
     default: '2.3.245'
+  disable-locking:
+    description: Disable locking
+    required: false
+    default: 'false'
 
 outputs:
   output:
@@ -150,6 +154,7 @@ runs:
       env:
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
         ACTIVATE_VENV: ${{ inputs.setup-checkov == 'true' }}
+        DISABLE_LOCKING: ${{ inputs.disable-locking == 'true' }}
       run: |
           cd ${{ github.action_path }}
           go build -o digger ./cmd/digger
@@ -162,6 +167,7 @@ runs:
       env:
         actionref: ${{ github.action_ref }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        DISABLE_LOCKING: ${{ inputs.disable-locking == 'true' }}
       id: digger
       shell: bash
       run: |


### PR DESCRIPTION
This pull request introduces the ability to disable locking functionality by adding a new action input called `disable-locking`. When set to `true`, it utilizes the NoOp lock provider, which performs no actual locking operations.

The logic code has been implemented to support this new feature, ensuring the appropriate environment is utilized based on the `disable-locking` input value.

For more details, please refer to the linked issue.

Linked Issue: #99