### PR TITLE
select last match

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -631,7 +631,7 @@ func cleanupTerraformOutput(nonEmptyOutput bool, planError error, stdout string,
 		regex := regexp.MustCompile(*regexStr)
 		matches := regex.FindStringSubmatch(stdout)
 		if len(matches) > 0 {
-			endPos = strings.Index(stdout, matches[0]) + len(matches[0])
+			endPos = strings.Index(stdout, matches[len(matches)-1]) + len(matches[len(matches)-1])
 		}
 	}
 

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -631,8 +631,8 @@ func cleanupTerraformOutput(nonEmptyOutput bool, planError error, stdout string,
 		regex := regexp.MustCompile(*regexStr)
 		matches := regex.FindStringSubmatch(stdout)
 		if len(matches) > 0 {
-			lastMatch := matches[len(matches)-1]
-			endPos = strings.Index(stdout, lastMatch) + len(lastMatch)
+			firstMatch := matches[0]
+			endPos = strings.LastIndex(stdout, firstMatch) + len(firstMatch)
 		}
 	}
 

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -631,7 +631,8 @@ func cleanupTerraformOutput(nonEmptyOutput bool, planError error, stdout string,
 		regex := regexp.MustCompile(*regexStr)
 		matches := regex.FindStringSubmatch(stdout)
 		if len(matches) > 0 {
-			endPos = strings.Index(stdout, matches[len(matches)-1]) + len(matches[len(matches)-1])
+			lastMatch := matches[len(matches)-1]
+			endPos = strings.Index(stdout, lastMatch) + len(lastMatch)
 		}
 	}
 


### PR DESCRIPTION
In some cases terraform outputs mutliple lines containing `--------` and in this case we should always select the last matching line matching the regex for cleanup (this is in the case of terraform plan). Otherwise it leads to errors such as:

```
        }
        # (21 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

....
....
....

Plan: 17 to add, 4 to change, 4 to destroy.

Changes to Outputs:
  ~ core_api_url            = "elb.amazonaws.com" -> (known after apply)

───────────────────────

Saved the plan to: serene-hospital-infra#dev.tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "serene-hospital-infra#dev.tfplan"
Releasing state lock. This may take a few moments...
panic: runtime error: slice bounds out of range [8870:8631]

goroutine 1 [running]:
digger/pkg/digger.cleanupTerraformOutput(0x1, {0x0, 0x0?}, {0xc00065e000, 0x85db}, {0x0, 0x0}, 0xc000571288)
	/home/runner/work/digger/digger/pkg/digger/digger.go:577 +0x1d1
digger/pkg/digger.cleanupTerraformPlan(...)
	/home/runner/work/digger/digger/pkg/digger/digger.go:586
digger/pkg/digger.DiggerExecutor.Plan({{0xc000646040, 0x8}, {0xc000646049, 0x15}, {0xc0006412bc, 0x3}, {0xc000458960, 0x3}, 0xc00044b140, 0xc00044b170, ...}, ...)
	/home/runner/work/digger/digger/pkg/digger/digger.go:439 +0x6fc
digger/pkg/digger.RunCommandsPerProject({0xc000130a10, 0x1, 0x8?}, {0xc000646040, 0x8}, {0xc000646049, 0x15}, {0xc0006404d0, 0xd}, 0x5, ...)
	/home/runner/work/digger/digger/pkg/digger/digger.go:103 +0x7e5
main.main()
	/home/runner/work/digger/digger/cmd/digger/main.go:94 +0x991
Error: Process completed with exit code 2.
```
