### PR TITLE
Allow using AWS OIDC credentials

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   aws-secret-access-key:
     description: AWS secret access key
     required: false
+  aws-role-to-assume:
+    description: ARN of AWS IAM role to assume using OIDC
+    required: false
   aws-region:
     description: AWS region
     required: false
@@ -123,7 +126,14 @@ runs:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
-      if: inputs.setup-aws == 'true'
+      if: ${{ inputs.setup-aws == 'true' && inputs.aws-role-to-assume == '' }}
+
+    - name: Configure OIDC AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+      if: ${{ inputs.setup-aws == 'true' && inputs.aws-role-to-assume != '' }}
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
Adds an optional `aws-role-to-assume` parameter which is passed to `configure-aws-credentials` to use GitHub OIDC authentication.

Fixes #288 
Fixes #148 