### PR TITLE
refactor project namespace

### DIFF
--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -180,7 +180,7 @@ func gitLabCI(lock locking.Lock) {
 	//planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, prNumber)
 	planStorage := newPlanStorage(gitlabToken, projectNamespace, projectName, *gitLabContext.MergeRequestIId)
 
-	allAppliesSuccess, err := gitlab.RunCommandsPerProject(commandsToRunPerProject, *gitLabContext, diggerConfig, gitlabService, lock, planStorage, currentDir)
+	allAppliesSuccess, _, err := digger.RunCommandsPerProject(commandsToRunPerProject, gitLabContext.ProjectNamespace, gitLabContext.ProjectName, gitLabContext.EventType.String(), *gitLabContext.MergeRequestIId, gitlabService, lock, planStorage, currentDir)
 	if err != nil {
 		fmt.Printf("failed to execute command, %v", err)
 		os.Exit(8)

--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -23,26 +23,26 @@ import (
 
 func gitHubCI(lock locking.Lock) {
 	println("Using GitHub.")
-	githubRepositoryOwner := os.Getenv("GITHUB_REPOSITORY_OWNER")
-	if githubRepositoryOwner != "" {
-		usage.SendUsageRecord(githubRepositoryOwner, "log", "initialize")
+	githubActor := os.Getenv("GITHUB_ACTOR")
+	if githubActor != "" {
+		usage.SendUsageRecord(githubActor, "log", "initialize")
 	} else {
 		usage.SendUsageRecord("", "log", "non github initialisation")
 	}
 
 	ghToken := os.Getenv("GITHUB_TOKEN")
 	if ghToken == "" {
-		reportErrorAndExit(githubRepositoryOwner, "GITHUB_TOKEN is not defined", 1)
+		reportErrorAndExit(githubActor, "GITHUB_TOKEN is not defined", 1)
 	}
 
 	ghContext := os.Getenv("GITHUB_CONTEXT")
 	if ghContext == "" {
-		reportErrorAndExit(githubRepositoryOwner, "GITHUB_CONTEXT is not defined", 2)
+		reportErrorAndExit(githubActor, "GITHUB_CONTEXT is not defined", 2)
 	}
 
 	parsedGhContext, err := github_models.GetGitHubContext(ghContext)
 	if err != nil {
-		reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Failed to parse GitHub context. %s", err), 3)
+		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to parse GitHub context. %s", err), 3)
 	}
 	println("GitHub context parsed successfully")
 
@@ -50,13 +50,13 @@ func gitHubCI(lock locking.Lock) {
 
 	diggerConfig, err := configuration.NewDiggerConfig("./", &walker)
 	if err != nil {
-		reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Failed to read Digger config. %s", err), 4)
+		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to read Digger config. %s", err), 4)
 	}
 	println("Digger config read successfully")
 
 	lock, err = locking.GetLock()
 	if err != nil {
-		reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Failed to create lock provider. %s", err), 5)
+		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to create lock provider. %s", err), 5)
 	}
 	println("Lock provider has been created successfully")
 
@@ -68,7 +68,7 @@ func gitHubCI(lock locking.Lock) {
 
 	impactedProjects, requestedProject, prNumber, err := dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, githubPrService)
 	if err != nil {
-		reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Failed to process GitHub event. %s", err), 6)
+		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to process GitHub event. %s", err), 6)
 	}
 	logImpactedProjects(impactedProjects, prNumber)
 	println("GitHub event processed successfully")
@@ -77,26 +77,26 @@ func gitHubCI(lock locking.Lock) {
 		reply := utils.GetCommands()
 		err := githubPrService.PublishComment(prNumber, reply)
 		if err != nil {
-			reportErrorAndExit(githubRepositoryOwner, "Failed to publish help command output", 1)
+			reportErrorAndExit(githubActor, "Failed to publish help command output", 1)
 		}
 	}
 
 	if len(impactedProjects) == 0 {
-		reportErrorAndExit(githubRepositoryOwner, "No projects impacted", 0)
+		reportErrorAndExit(githubActor, "No projects impacted", 0)
 	}
 
 	commandsToRunPerProject, coversAllImpactedProjects, err := dg_github.ConvertGithubEventToCommands(ghEvent, impactedProjects, requestedProject, diggerConfig.Workflows)
 	if err != nil {
-		reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Failed to convert GitHub event to commands. %s", err), 7)
+		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to convert GitHub event to commands. %s", err), 7)
 	}
 	println("GitHub event converted to commands successfully")
 	logCommands(commandsToRunPerProject)
 
-	planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, prNumber)
+	planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, githubActor, prNumber)
 
-	allAppliesSuccessful, atLeastOneApply, err := digger.RunCommandsPerProject(commandsToRunPerProject, repoOwner, repositoryName, eventName, prNumber, githubPrService, lock, planStorage, "")
+	allAppliesSuccessful, atLeastOneApply, err := digger.RunCommandsPerProject(commandsToRunPerProject, parsedGhContext.Repository, githubActor, eventName, prNumber, githubPrService, lock, planStorage, "")
 	if err != nil {
-		reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Failed to run commands. %s", err), 8)
+		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to run commands. %s", err), 8)
 	}
 
 	if diggerConfig.AutoMerge && allAppliesSuccessful && atLeastOneApply && coversAllImpactedProjects {
@@ -106,11 +106,11 @@ func gitHubCI(lock locking.Lock) {
 
 	println("Commands executed successfully")
 
-	reportErrorAndExit(githubRepositoryOwner, "Digger finished successfully", 0)
+	reportErrorAndExit(githubActor, "Digger finished successfully", 0)
 
 	defer func() {
 		if r := recover(); r != nil {
-			reportErrorAndExit(githubRepositoryOwner, fmt.Sprintf("Panic occurred. %s", r), 1)
+			reportErrorAndExit(githubActor, fmt.Sprintf("Panic occurred. %s", r), 1)
 		}
 	}()
 }
@@ -177,10 +177,10 @@ func gitLabCI(lock locking.Lock) {
 		fmt.Printf("command: %s, project: %s\n", strings.Join(v.Commands, ", "), v.ProjectName)
 	}
 
-	//planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, prNumber)
-	planStorage := newPlanStorage(gitlabToken, projectNamespace, projectName, *gitLabContext.MergeRequestIId)
+	diggerProjectNamespace := gitLabContext.ProjectNamespace + "/" + gitLabContext.ProjectName
+	planStorage := newPlanStorage("", "", "", gitLabContext.GitlabUserName, *gitLabContext.MergeRequestIId)
 
-	allAppliesSuccess, atLeastOneApply, err := digger.RunCommandsPerProject(commandsToRunPerProject, gitLabContext.ProjectNamespace, gitLabContext.ProjectName, gitLabContext.EventType.String(), *gitLabContext.MergeRequestIId, gitlabService, lock, planStorage, currentDir)
+	allAppliesSuccess, atLeastOneApply, err := digger.RunCommandsPerProject(commandsToRunPerProject, diggerProjectNamespace, gitLabContext.GitlabUserName, gitLabContext.EventType.String(), *gitLabContext.MergeRequestIId, gitlabService, lock, planStorage, currentDir)
 	if err != nil {
 		fmt.Printf("failed to execute command, %v", err)
 		os.Exit(8)
@@ -251,8 +251,9 @@ func azureCI(lock locking.Lock) {
 	}
 
 	var planStorage storage.PlanStorage
+	diggerProjectNamespace := parsedAzureContext.BaseUrl + "/" + parsedAzureContext.ProjectName
 
-	allAppliesSuccess, atLeastOneApply, err := digger.RunCommandsPerProject(commandsToRunPerProject, parsedAzureContext.ProjectName, parsedAzureContext.ProjectName, parsedAzureContext.EventType, prNumber, azureService, lock, planStorage, currentDir)
+	allAppliesSuccess, atLeastOneApply, err := digger.RunCommandsPerProject(commandsToRunPerProject, diggerProjectNamespace, parsedAzureContext.BaseUrl, parsedAzureContext.EventType, prNumber, azureService, lock, planStorage, currentDir)
 	if err != nil {
 		reportErrorAndExit(parsedAzureContext.BaseUrl, fmt.Sprintf("Failed to run commands. %s", err), 8)
 	}
@@ -320,7 +321,7 @@ func main() {
 	}
 }
 
-func newPlanStorage(ghToken string, repoOwner string, repositoryName string, prNumber int) storage.PlanStorage {
+func newPlanStorage(ghToken string, ghRepoOwner string, ghRepositoryName string, requestedBy string, prNumber int) storage.PlanStorage {
 	var planStorage storage.PlanStorage
 
 	uploadDestination := strings.ToLower(os.Getenv("PLAN_UPLOAD_DESTINATION"))
@@ -328,8 +329,8 @@ func newPlanStorage(ghToken string, repoOwner string, repositoryName string, prN
 		zipManager := utils.Zipper{}
 		planStorage = &storage.GithubPlanStorage{
 			Client:            github.NewTokenClient(context.Background(), ghToken),
-			Owner:             repoOwner,
-			RepoName:          repositoryName,
+			Owner:             ghRepoOwner,
+			RepoName:          ghRepositoryName,
 			PullRequestNumber: prNumber,
 			ZipManager:        zipManager,
 		}
@@ -337,7 +338,7 @@ func newPlanStorage(ghToken string, repoOwner string, repositoryName string, prN
 		ctx, client := gcp.GetGoogleStorageClient()
 		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
 		if bucketName == "" {
-			reportErrorAndExit(repoOwner, fmt.Sprintf("GOOGLE_STORAGE_BUCKET is not defined"), 9)
+			reportErrorAndExit(requestedBy, fmt.Sprintf("GOOGLE_STORAGE_BUCKET is not defined"), 9)
 		}
 		bucket := client.Bucket(bucketName)
 		planStorage = &storage.PlanStorageGcp{

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -28,6 +28,7 @@ type GitLabContext struct {
 	ProjectNamespaceId *int            `env:"CI_PROJECT_NAMESPACE_ID"`
 	OpenMergeRequests  []string        `env:"CI_OPEN_MERGE_REQUESTS"`
 	Token              string          `env:"GITLAB_TOKEN"`
+	GitlabUserName     string          `env:"GITLAB_USER_NAME"`
 	DiggerCommand      string          `env:"DIGGER_COMMAND"`
 	DiscussionID       string          `env:"DISCUSSION_ID"`
 	IsMeargeable       bool            `env:"IS_MERGEABLE"`

--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -23,11 +23,10 @@ import (
 )
 
 type ProjectLockImpl struct {
-	InternalLock Lock
-	CIService    ci.CIService
-	ProjectName  string
-	RepoName     string
-	RepoOwner    string
+	InternalLock     Lock
+	CIService        ci.CIService
+	ProjectName      string
+	ProjectNamespace string
 }
 
 type Lock interface {
@@ -82,7 +81,7 @@ func (projectLock *ProjectLockImpl) Lock(prNumber int) (bool, error) {
 			return true, nil
 		} else {
 			transactionIdStr := strconv.Itoa(*existingLockTransactionId)
-			comment := "Project " + projectLock.projectId() + " locked by another PR #" + transactionIdStr + " (failed to acquire lock " + projectLock.RepoName + "). The locking plan must be applied or discarded before future plans can execute"
+			comment := "Project " + projectLock.projectId() + " locked by another PR #" + transactionIdStr + " (failed to acquire lock " + projectLock.ProjectNamespace + "). The locking plan must be applied or discarded before future plans can execute"
 			projectLock.CIService.PublishComment(prNumber, comment)
 			return false, nil
 		}
@@ -184,11 +183,11 @@ func (projectLock *ProjectLockImpl) ForceUnlock(prNumber int) error {
 }
 
 func (projectLock *ProjectLockImpl) projectId() string {
-	return projectLock.RepoOwner + "/" + projectLock.RepoName + "#" + projectLock.ProjectName
+	return projectLock.ProjectNamespace + "#" + projectLock.ProjectName
 }
 
 func (projectLock *ProjectLockImpl) LockId() string {
-	return projectLock.RepoOwner + "/" + projectLock.RepoName + "#" + projectLock.ProjectName
+	return projectLock.ProjectNamespace + "#" + projectLock.ProjectName
 }
 
 func GetLock() (Lock, error) {

--- a/pkg/locking/locking_test.go
+++ b/pkg/locking/locking_test.go
@@ -10,11 +10,10 @@ func TestLockingTwiceThrowsError(t *testing.T) {
 	mockDynamoDB := utils.MockLock{make(map[string]int)}
 	mockPrManager := utils.MockGithubPullrequestManager{}
 	pl := ProjectLockImpl{
-		InternalLock: &mockDynamoDB,
-		CIService:    &mockPrManager,
-		ProjectName:  "a",
-		RepoName:     "",
-		RepoOwner:    "",
+		InternalLock:     &mockDynamoDB,
+		CIService:        &mockPrManager,
+		ProjectName:      "a",
+		ProjectNamespace: "",
 	}
 	state1, err1 := pl.Lock(1)
 	assert.True(t, state1)


### PR DESCRIPTION
we don't want to have references to particular git repository providers to have core git repo agnostic. DiggerExecutor won't even know that the code is hosted somewhere