### PR TITLE
fix #349 terraform workspace logic: list and select / new

### DIFF
--- a/pkg/core/terraform/tf.go
+++ b/pkg/core/terraform/tf.go
@@ -88,13 +88,22 @@ func (tf Terraform) Apply(params []string, plan *string, envs map[string]string)
 	if err != nil {
 		return "", "", err
 	}
-
+	
 	if strings.TrimSpace(workspace) != tf.Workspace {
-		_, _, _, err = tf.runTerraformCommand("workspace", envs, "new", tf.Workspace)
+		_, stderr, _, err := tf.runTerraformCommand("workspace", envs, "select", tf.Workspace)
+
 		if err != nil {
-			return "", "", err
-		}
+			if strings.Contains(stderr, "doesn't exist") {
+				_, _, _, err := tf.runTerraformCommand("workspace", envs, "new", tf.Workspace)
+				if err != nil {
+					return "", "", err
+				}
+			} else {
+				return "", "", err
+			}
+		} 
 	}
+	
 	params = append(append(append(params, "-input=false"), "-no-color"), "-auto-approve")
 	if plan != nil {
 		params = append(params, *plan)
@@ -128,6 +137,8 @@ func (tf Terraform) runTerraformCommand(command string, envs map[string]string, 
 		fmt.Println("Error:", err)
 	}
 
+	// fmt.Println("Debug stdout:", stdout)
+
 	return stdout.String(), stderr.String(), cmd.ProcessState.ExitCode(), err
 }
 
@@ -152,17 +163,27 @@ func (sw *StdWriter) GetString() string {
 }
 
 func (tf Terraform) Plan(params []string, envs map[string]string) (bool, string, string, error) {
-	workspace, _, _, err := tf.runTerraformCommand("workspace", envs, "show")
-
+	workspaces, _, _, err := tf.runTerraformCommand("workspace", envs, "list")
 	if err != nil {
 		return false, "", "", err
 	}
-	if strings.TrimSpace(workspace) != tf.Workspace {
-		_, _, _, err = tf.runTerraformCommand("workspace", envs, "new", tf.Workspace)
+
+	workspaces = strings.Replace(workspaces, "* ", "", -1)
+	workspaces = strings.Replace(workspaces, "\n", ",", -1)
+	workspaces = strings.TrimSpace(workspaces)
+
+	if strings.Contains(workspaces, tf.Workspace) {
+		_, _, _, err := tf.runTerraformCommand("workspace", envs, "select", tf.Workspace)
 		if err != nil {
 			return false, "", "", err
 		}
+	} else {
+		_, _, _, err := tf.runTerraformCommand("workspace", envs, "new", tf.Workspace)
+		if err != nil {
+			return false, "", "", err
+		}		
 	}
+
 	params = append(append(params, "-input=false"), "-no-color")
 	stdout, stderr, statusCode, err := tf.runTerraformCommand("plan", envs, params...)
 	if err != nil {


### PR DESCRIPTION
Hey guys, this should fix #349 
I'm no go expert so that's the warning, however.. I tested it and it seems to for work me.
I got as far as the plan because I wasn't able to run apply because of #362 - if you have something already in place there to test a quick apply that would do, my current setup doesn't allow me to proceed without tfvars.

Note: I added a function to reformat the workspace list, it may be a bit overkill because I'm using 'contains' for the lookup so the spaces, newlines, star, don't really bother it.. I decided to return a space trimmed comma separated string, but it could also be totally ditched, up to you.. it'd work anyway