### PR TITLE
fix: Support case insensitive digger commands

### DIFF
--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -450,11 +450,12 @@ func ConvertAzureEventToCommands(parseAzureContext Azure, impactedProjects []con
 		}
 
 		supportedCommands := []string{"digger plan", "digger apply", "digger unlock", "digger lock"}
+		inputCommands := strings.ToLower(diggerCommand)
 		for _, command := range supportedCommands {
-			if strings.Contains(diggerCommand, command) {
+			if strings.Contains(inputCommands, command) {
 				for _, project := range runForProjects {
 					workspace := project.Workspace
-					workspaceOverride, err := utils.ParseWorkspace(diggerCommand)
+					workspaceOverride, err := utils.ParseWorkspace(inputCommands)
 					if err != nil {
 						return []models.ProjectCommand{}, coversAllImpactedProjects, err
 					}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -202,9 +202,9 @@ func ConvertGithubEventToCommands(event models.Event, impactedProjects []configu
 				return commandsPerProject, false, fmt.Errorf("requested project %v is not impacted by this PR", requestedProject.Name)
 			}
 		}
-
+		inputCommands := strings.ToLower(event.Comment.Body)
 		for _, command := range supportedCommands {
-			if strings.Contains(event.Comment.Body, command) {
+			if strings.Contains(inputCommands, command) {
 				for _, project := range runForProjects {
 					workflow, ok := workflows[project.Workflow]
 					if !ok {
@@ -215,7 +215,7 @@ func ConvertGithubEventToCommands(event models.Event, impactedProjects []configu
 					coreApplyStage := workflow.Apply.ToCoreStage()
 					corePlanStage := workflow.Plan.ToCoreStage()
 					workspace := project.Workspace
-					workspaceOverride, err := utils.ParseWorkspace(event.Comment.Body)
+					workspaceOverride, err := utils.ParseWorkspace(inputCommands)
 					if err != nil {
 						return []dg_models.ProjectCommand{}, false, err
 					}
@@ -285,10 +285,11 @@ func ProcessGitHubEvent(ghEvent models.Event, diggerConfig *configuration.Digger
 }
 
 func issueCommentEventContainsComment(event models.Event, comment string) bool {
+	inputCommands := strings.ToLower(event.Comment.Body)
 	switch event.(type) {
 	case models.IssueCommentEvent:
 		event := event.(models.IssueCommentEvent)
-		if strings.Contains(event.Comment.Body, comment) {
+		if strings.Contains(inputCommands, comment) {
 			return true
 		}
 	}

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -320,7 +320,7 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 				return commandsPerProject, false, fmt.Errorf("requested project %v is not impacted by this PR", requestedProject.Name)
 			}
 		}
-        inputCommands := strings.ToLower(gitLabContext.DiggerCommand)
+        	inputCommands := strings.ToLower(gitLabContext.DiggerCommand)
 		for _, command := range supportedCommands {
 			if strings.Contains(inputCommands, command) {
 				for _, project := range runForProjects {

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -320,16 +320,16 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 				return commandsPerProject, false, fmt.Errorf("requested project %v is not impacted by this PR", requestedProject.Name)
 			}
 		}
-
+        inputCommands := strings.ToLower(gitLabContext.DiggerCommand)
 		for _, command := range supportedCommands {
-			if strings.Contains(gitLabContext.DiggerCommand, command) {
+			if strings.Contains(inputCommands, command) {
 				for _, project := range runForProjects {
 					workflow, ok := workflows[project.Workflow]
 					if !ok {
 						workflow = workflows["default"]
 					}
 					workspace := project.Workspace
-					workspaceOverride, err := utils.ParseWorkspace(gitLabContext.DiggerCommand)
+					workspaceOverride, err := utils.ParseWorkspace(inputCommands)
 					if err != nil {
 						return []models.ProjectCommand{}, false, err
 					}


### PR DESCRIPTION
closes #344 

**Issue Description:**

Requested by user:

Digger commentOps currently only work with exact lowercase "digger plan", "digger apply" etc.

Digger should be able to also support case insensitve commands such as "Digger plan" and so on since it is more forgiving.

Proposal: make digger case insensitive by default, allow users to make it case sensitive through some parameter passed into composite action case-sensitve (defaults to false)