### PR TITLE
fix: fail workflow when a project lock is acquired by another PR

### DIFF
--- a/pkg/locking/locking.go
+++ b/pkg/locking/locking.go
@@ -120,9 +120,9 @@ func (projectLock *PullRequestLock) verifyNoHangingLocks() (bool, error) {
 				return true, nil
 			}
 			transactionIdStr := strconv.Itoa(*transactionId)
-			comment := "Project " + projectLock.projectId() + " locked by another PR #" + transactionIdStr + "(failed to acquire lock " + projectLock.ProjectName + "). The locking plan must be applied or discarded before future plans can execute"
-			err = projectLock.Reporter.Report(comment, utils.AsCollapsibleComment("Locking failed"))
-			return false, nil
+			comment := "Project " + projectLock.projectId() + " locked by another PR #" + transactionIdStr + " (failed to acquire lock " + projectLock.ProjectName + "). The locking plan must be applied or discarded before future plans can execute"
+			_ = projectLock.Reporter.Report(comment, utils.AsCollapsibleComment("Locking failed"))
+			return false, errors.New(comment)
 		}
 		return true, nil
 	}

--- a/pkg/locking/locking_test.go
+++ b/pkg/locking/locking_test.go
@@ -2,8 +2,10 @@ package locking
 
 import (
 	"digger/pkg/utils"
-	"github.com/stretchr/testify/assert"
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLockingTwiceThrowsError(t *testing.T) {
@@ -32,6 +34,5 @@ func TestLockingTwiceThrowsError(t *testing.T) {
 	}
 	state2, err2 := pl2.Lock()
 	assert.False(t, state2)
-	// No error because the lock was not aquired
-	assert.NoError(t, err2)
+	assert.Equal(t, err2, errors.New("Project #a locked by another PR #1 (failed to acquire lock a). The locking plan must be applied or discarded before future plans can execute"))
 }


### PR DESCRIPTION
In a mono-repo with 10 projects, when a lock cannot be acquired for 1 particular project, the workflow would still post the other 9 plan results in a comment and end successfully as if all was good, which is very misleading.

Therefore making a change to fail the workflow when a project lock cannot be acquired.
