### PR TITLE
Add behavior for BitBucket CI detection.

### DIFF
--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -377,6 +377,7 @@ func main() {
 	case digger.Azure:
 		azureCI(lock, policyChecker, reportStrategy)
 	case digger.BitBucket:
+		fallthrough
 	case digger.None:
 		print("No CI detected.")
 		os.Exit(10)

--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -377,7 +377,7 @@ func main() {
 	case digger.Azure:
 		azureCI(lock, policyChecker, reportStrategy)
 	case digger.BitBucket:
-		fallthrough
+		print("Bitbucket support is currently in progress. If you would like to prioritise it, give this issue a bump: https://github.com/diggerhq/digger/issues/81")
 	case digger.None:
 		print("No CI detected.")
 		os.Exit(10)


### PR DESCRIPTION
The current code 

```
case digger.BitBucket:
case digger.None:
            print("No CI detected.")
            os.Exit(10)
```

actually does nothing as described in [issue 433.](https://github.com/diggerhq/digger/issues/433) In other languages. My fix is to make it fallthrough and display the "No CI detected" message. This behavior is consistent with switch statements in other languages and given no code under the BitBucket case, that would seem to have been the intended behavior.

Alternatively, I can edit this to show a message specifically stating that BitBucket is not supported.