### PR TITLE
Fix for opa regressions

### DIFF
--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -97,9 +97,13 @@ func (p *DiggerHttpPolicyProvider) GetPolicy(organisation string, repo string, p
 		return "", err
 	}
 
+	// project policy found
 	if resp.StatusCode == 200 && content != "" {
 		return content, nil
-	} else if resp.StatusCode == 404 {
+	}
+
+	// check if project policy was empty or not found (retrieve org policy if so)
+	if (resp.StatusCode == 200 && content == "") || resp.StatusCode == 404 {
 		content, resp, err := getPolicyForOrganisation(p)
 		if err != nil {
 			return "", err
@@ -112,7 +116,7 @@ func (p *DiggerHttpPolicyProvider) GetPolicy(organisation string, repo string, p
 			return "", errors.New(fmt.Sprintf("unexpected response while fetching organisation policy: %v, code %v", content, resp.StatusCode))
 		}
 	} else {
-		return "", errors.New(fmt.Sprintf("unexpected response while fetching org policy: %v code %v", content, resp.StatusCode))
+		return "", errors.New(fmt.Sprintf("unexpected response while fetching project policy: %v code %v", content, resp.StatusCode))
 	}
 }
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -53,6 +53,7 @@ func getPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.Respon
 func getPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projectName string) (string, *http.Response, error) {
 	// fetch RBAC policies for project from Digger API
 	req, err := http.NewRequest("GET", p.DiggerHost+"/repos/"+namespace+"/projects/"+projectName+"/access-policy", nil)
+	fmt.Printf(p.DiggerHost + "/repos/" + namespace + "/projects/" + projectName + "/access-policy\n\n\n\n")
 
 	if err != nil {
 		return "", nil, err

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -76,7 +76,10 @@ func getPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projec
 // GetPolicy fetches policy for particular project,  if not found then it will fallback to org level policy
 func (p *DiggerHttpPolicyProvider) GetPolicy(organisation string, repo string, projectName string) (string, error) {
 	namespace := fmt.Sprintf("%v-%v", organisation, repo)
+	fmt.Printf("getting policy for organisation: %v - repo: %v\n", organisation, repo)
 	content, resp, err := getPolicyForNamespace(p, namespace, projectName)
+	fmt.Printf("content: %v\n", content)
+
 	if err != nil {
 		return "", err
 	}
@@ -112,7 +115,7 @@ func (p DiggerPolicyChecker) Check(ciService ci.CIService, SCMOrganisation strin
 	organisation := p.PolicyProvider.GetOrganisation()
 	policy, err := p.PolicyProvider.GetPolicy(organisation, SCMrepository, projectName)
 
-	fmt.Printf("policy was: %v | error was: %v|", policy, err)
+	fmt.Printf("policy was: %v | error was: %v\n", policy, err)
 
 	if err != nil {
 		fmt.Printf("Error while fetching policy: %v", err)

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -112,6 +112,8 @@ func (p DiggerPolicyChecker) Check(ciService ci.CIService, SCMOrganisation strin
 	organisation := p.PolicyProvider.GetOrganisation()
 	policy, err := p.PolicyProvider.GetPolicy(organisation, SCMrepository, projectName)
 
+	fmt.Printf("policy was: %v | error was: %v|", policy, err)
+
 	if err != nil {
 		fmt.Printf("Error while fetching policy: %v", err)
 		return false, err

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"github.com/open-policy-agent/opa/rego"
 	"io"
+	"log"
 	"net/http"
+	"net/url"
 )
 
 type PolicyProvider interface {
@@ -31,7 +33,12 @@ func (p NoOpPolicyChecker) Check(_ ci.CIService, _ string, _ string, _ string, _
 
 func getPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.Response, error) {
 	organisation := p.DiggerOrganisation
-	req, err := http.NewRequest("GET", p.DiggerHost+"/orgs/"+organisation+"/access-policy", nil)
+	u, err := url.Parse(p.DiggerHost)
+	if err != nil {
+		log.Fatalf("Not able to parse digger cloud url: %v", err)
+	}
+	u.Path = "/orgs/" + organisation + "/access-policy"
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -52,8 +59,13 @@ func getPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.Respon
 
 func getPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projectName string) (string, *http.Response, error) {
 	// fetch RBAC policies for project from Digger API
-	req, err := http.NewRequest("GET", p.DiggerHost+"/repos/"+namespace+"/projects/"+projectName+"/access-policy", nil)
-	fmt.Printf(p.DiggerHost + "/repos/" + namespace + "/projects/" + projectName + "/access-policy\n\n\n\n")
+	u, err := url.Parse(p.DiggerHost)
+	if err != nil {
+		log.Fatalf("Not able to parse digger cloud url: %v", err)
+	}
+	u.Path = "/repos/" + namespace + "/projects/" + projectName + "/access-policy"
+	req, err := http.NewRequest("GET", u.String(), nil)
+	fmt.Printf(u.String() + "\n\n\n\n")
 
 	if err != nil {
 		return "", nil, err

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -65,7 +65,6 @@ func getPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projec
 	}
 	u.Path = "/repos/" + namespace + "/projects/" + projectName + "/access-policy"
 	req, err := http.NewRequest("GET", u.String(), nil)
-	fmt.Printf(u.String() + "\n\n\n\n")
 
 	if err != nil {
 		return "", nil, err
@@ -89,10 +88,7 @@ func getPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projec
 // GetPolicy fetches policy for particular project,  if not found then it will fallback to org level policy
 func (p *DiggerHttpPolicyProvider) GetPolicy(organisation string, repo string, projectName string) (string, error) {
 	namespace := fmt.Sprintf("%v-%v", organisation, repo)
-	fmt.Printf("getting policy for organisation: %v - repo: %v\n", organisation, repo)
 	content, resp, err := getPolicyForNamespace(p, namespace, projectName)
-	fmt.Printf("content: %v\n", content)
-
 	if err != nil {
 		return "", err
 	}
@@ -131,8 +127,6 @@ type DiggerPolicyChecker struct {
 func (p DiggerPolicyChecker) Check(ciService ci.CIService, SCMOrganisation string, SCMrepository string, projectName string, command string, requestedBy string) (bool, error) {
 	organisation := p.PolicyProvider.GetOrganisation()
 	policy, err := p.PolicyProvider.GetPolicy(organisation, SCMrepository, projectName)
-
-	fmt.Printf("policy was: %v | error was: %v\n", policy, err)
 
 	if err != nil {
 		fmt.Printf("Error while fetching policy: %v", err)


### PR DESCRIPTION
we were not properly composing urls for the case when user sets url to "https://cloud.uselemon.cloud/" we formed invalid urls with double /

now we use golang url library to compose the urls

also we improve the readability of `getPolicy` function by adding comments and splitting out the if statements to be more clear and readable

validated to be working in new pull request of test repository: https://github.com/digger-tests/digger-demo-opa/pull/8