### PR TITLE
feat: create text file in project root repository when plan returned changes

### DIFF
--- a/pkg/core/execution/execution.go
+++ b/pkg/core/execution/execution.go
@@ -138,6 +138,15 @@ func (d DiggerExecutor) Plan() (bool, bool, string, string, error) {
 			planArgs = append(planArgs, step.ExtraArgs...)
 			nonEmptyPlan, stdout, stderr, err := d.TerraformExecutor.Plan(planArgs, d.CommandEnvVars)
 			isNonEmptyPlan = nonEmptyPlan
+			if isNonEmptyPlan {
+				nonEmptyPlanFilepath := strings.Replace(d.PlanPathProvider.LocalPlanFilePath(), d.PlanPathProvider.PlanFileName(), "isNonEmptyPlan.txt", 1)
+				file, err := os.Create(nonEmptyPlanFilepath)
+				if err != nil {
+					return false, false, "", "", fmt.Errorf("unable to create file: %v", err)
+				}
+				defer file.Close()
+			}
+
 			if err != nil {
 				return false, false, "", "", fmt.Errorf("error executing plan: %v", err)
 			}


### PR DESCRIPTION
This allows to add logic in the digger workflow based on if the plan returned changes or not.

For instance, to run `checkov` only when the plan returned changes:

```
workflows:
  default:
    plan:
      steps:
        - init
        - plan
        - run: if [ -f "isNonEmptyPlan.txt" ]; then checkov --directory .; fi
```

The `-no-color` plan default argument was also added in this PR to fix a bug in `cleanupTerraformOutput()` function when `nonEmptyOutput` is false. The following logic would not work because of color characters around the `No changes` substring:

```
	} else if nonEmptyOutput {
		start = "Terraform will perform the following actions:"
	} else {
		start = "No changes. Your infrastructure matches the configuration."
	}

```