### PR TITLE
feat: extend drift detection notification url types

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,10 +105,14 @@ inputs:
     description: 'project name for digger to run in case of manual mode'
     required: false
     default: ''
-  drift-detection-slack-notification-url:
-    description: 'drift-detection slack notification url'
+  drift-detection-notification-url:
+    description: 'drift-detection notification url'
     required: false
     default: ''
+  drift-detection-notification-url-type:
+    description: 'slack, or other. "other" type will not include any emoji in the notification message'
+    required: false
+    default: 'other'
 
 outputs:
   output:
@@ -215,7 +219,8 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
+        INPUT_DRIFT_DETECTION_NOTIFICATION_URL: ${{ inputs.drift-detection-notification-url }}
+        INPUT_DRIFT_DETECTION_NOTIFICATION_URL_TYPE: ${{ inputs.drift-detection-notification-url-type }}
       run: |
           cd ${{ github.action_path }}
           go build -o digger ./cmd/digger
@@ -238,7 +243,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
+        INPUT_DRIFT_DETECTION_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
       id: digger
       shell: bash
       run: |


### PR DESCRIPTION
Tested the new drift detection feature with a Teams webhook (instead of Slack) and it worked perfectly fine (great feature!)

The only different is how to specify the bangbang emoji prefix included in the notification message so I suggest to remove the `slack` reference to all variables and adding a `drift-detection-notification-url-type` input variable tu support to multiple channel types.

I wasn't able to easily include the "bangbang" emoji using text for teams so I didn't add the "teams" as part of `drift-detection-notification-url-type` supported values.