### PR TITLE
fix(deps): update default terragrunt to 0.48.6 in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
   terragrunt-version:
     description: Terragrunt version
     required: false
-    default: v0.45.4
+    default: v0.48.6
   setup-terraform:
     description: Setup terraform
     required: false


### PR DESCRIPTION
Updates default terragrunt version from v0.45.4 to v0.48.6