### PR TITLE
fix(deps): update default chekov version to 2.3.360 in github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
   checkov-version:
     description: Checkov version
     required: false
-    default: '2.3.245'
+    default: '2.3.360'
   disable-locking:
     description: Disable locking
     required: false


### PR DESCRIPTION
Updates default chekov version from 2.3.245 to 2.3.360