### PR TITLE
Add init error output to Digger run reports

### DIFF
--- a/pkg/core/execution/execution.go
+++ b/pkg/core/execution/execution.go
@@ -8,13 +8,14 @@ import (
 	"digger/pkg/core/terraform"
 	"digger/pkg/core/utils"
 	"fmt"
-	configuration "github.com/diggerhq/lib-digger-config"
-	orchestrator "github.com/diggerhq/lib-orchestrator"
 	"log"
 	"os"
 	"path"
 	"regexp"
 	"strings"
+
+	configuration "github.com/diggerhq/lib-digger-config"
+	orchestrator "github.com/diggerhq/lib-orchestrator"
 )
 
 type Executor interface {
@@ -144,8 +145,12 @@ func (d DiggerExecutor) Plan() (bool, bool, string, string, error) {
 	}
 	for _, step := range planSteps {
 		if step.Action == "init" {
-			_, _, err := d.TerraformExecutor.Init(step.ExtraArgs, d.StateEnvVars)
+			_, stderr, err := d.TerraformExecutor.Init(step.ExtraArgs, d.StateEnvVars)
 			if err != nil {
+				commentErr := d.Reporter.Report(stderr, utils.GetTerraformOutputAsCollapsibleComment("Error during init."))
+				if commentErr != nil {
+					fmt.Printf("error publishing comment: %v", err)
+				}
 				return false, false, "", "", fmt.Errorf("error running init: %v", err)
 			}
 		}
@@ -238,8 +243,12 @@ func (d DiggerExecutor) Apply() (bool, string, error) {
 
 	for _, step := range applySteps {
 		if step.Action == "init" {
-			stdout, _, err := d.TerraformExecutor.Init(step.ExtraArgs, d.StateEnvVars)
+			stdout, stderr, err := d.TerraformExecutor.Init(step.ExtraArgs, d.StateEnvVars)
 			if err != nil {
+				commentErr := d.Reporter.Report(stderr, utils.GetTerraformOutputAsCollapsibleComment("Error during init."))
+				if commentErr != nil {
+					fmt.Printf("error publishing comment: %v", err)
+				}
 				return false, stdout, fmt.Errorf("error running init: %v", err)
 			}
 		}
@@ -291,8 +300,12 @@ func (d DiggerExecutor) Destroy() (bool, error) {
 
 	for _, step := range destroySteps {
 		if step.Action == "init" {
-			_, _, err := d.TerraformExecutor.Init(step.ExtraArgs, d.StateEnvVars)
+			_, stderr, err := d.TerraformExecutor.Init(step.ExtraArgs, d.StateEnvVars)
 			if err != nil {
+				commentErr := d.Reporter.Report(stderr, utils.GetTerraformOutputAsCollapsibleComment("Error during init."))
+				if commentErr != nil {
+					fmt.Printf("error publishing comment: %v", err)
+				}
 				return false, fmt.Errorf("error running init: %v", err)
 			}
 		}


### PR DESCRIPTION
Closes #468

This will include terraform init stderr in a comment when an error occurs. Here is an example run report from my testing repo:  

<img width="842" alt="Screenshot 2023-08-28 at 10 39 06 PM" src="https://github.com/diggerhq/digger/assets/122894610/d721a850-0fa6-409c-8106-da3c57acf98b">
