### PR TITLE
feat: add show-projects command to commentOps

### DIFF
--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -20,17 +20,18 @@ import (
 	"digger/pkg/utils"
 	"encoding/json"
 	"fmt"
-	configuration "github.com/diggerhq/lib-digger-config"
-	orchestrator "github.com/diggerhq/lib-orchestrator"
-	dg_github "github.com/diggerhq/lib-orchestrator/github"
-	"gopkg.in/yaml.v3"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v53/github"
+	configuration "github.com/diggerhq/lib-digger-config"
+	orchestrator "github.com/diggerhq/lib-orchestrator"
+	dg_github "github.com/diggerhq/lib-orchestrator/github"
+	"gopkg.in/yaml.v3"
+
+	"github.com/google/go-github/v54/github"
 )
 
 func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backendApi core_backend.Api, reportingStrategy reporting.ReportStrategy) {

--- a/cmd/digger/main_test.go
+++ b/cmd/digger/main_test.go
@@ -7,12 +7,14 @@ import (
 	"digger/pkg/reporting"
 	"digger/pkg/utils"
 	"fmt"
+
 	dggithub "github.com/diggerhq/lib-orchestrator/github"
 	dggithubmodels "github.com/diggerhq/lib-orchestrator/github/models"
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v54/github"
+
+	"testing"
 
 	configuration "github.com/diggerhq/lib-digger-config"
-	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 
 require (
 	github.com/diggerhq/lib-digger-config v0.0.0-20230824142939-83044a6a36df
-	github.com/diggerhq/lib-orchestrator v0.0.0-20230829160318-c3cce42f5f35
+	github.com/diggerhq/lib-orchestrator v0.0.0-20230905165200-c04caa57bbfd
 	github.com/dominikbraun/graph v0.23.0
 	github.com/google/go-github/v54 v54.0.0
 	github.com/gruntwork-io/terragrunt v0.36.6
@@ -57,7 +57,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/go-github/v53 v53.2.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/diggerhq/lib-orchestrator v0.0.0-20230829160318-c3cce42f5f35
 	github.com/dominikbraun/graph v0.23.0
 	github.com/google/go-github/v54 v54.0.0
-	github.com/google/go-github/v54 v54.0.0
 	github.com/gruntwork-io/terragrunt v0.36.6
 	github.com/hashicorp/go-getter v1.7.2
 	github.com/hashicorp/hcl/v2 v2.18.0
@@ -58,6 +57,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-github/v53 v53.2.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf // indirect
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/diggerhq/lib-digger-config v0.0.0-20230824142939-83044a6a36df h1:qgAQe6glZKywACL1qVLDXVpfNUEHzpqFxkWpyqap1xE=
 github.com/diggerhq/lib-digger-config v0.0.0-20230824142939-83044a6a36df/go.mod h1:AdWua640lLPJJwWe7kZmKP6rk1+ycxxPjd1M4cQJDbs=
-github.com/diggerhq/lib-orchestrator v0.0.0-20230829160318-c3cce42f5f35 h1:vy9Xi+7z6Qr192CKGri8MG+5N9ONg6N2LwrMLrKdH/8=
-github.com/diggerhq/lib-orchestrator v0.0.0-20230829160318-c3cce42f5f35/go.mod h1:JBjRXAr8bJQjIIhwmJwbLSSt8xziGFcWVcvAQArYfzs=
+github.com/diggerhq/lib-orchestrator v0.0.0-20230905165200-c04caa57bbfd h1:RfYxTPSjfImuMDtCLoowaCvTN02TCJpx6MVkfKIRndQ=
+github.com/diggerhq/lib-orchestrator v0.0.0-20230905165200-c04caa57bbfd/go.mod h1:c3WzTUDIwb+H7t6ZrmX28qoR3DNaRttTbPTzG/gYQP0=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
@@ -644,8 +644,6 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.0.0-20200110202235-f4fb41bf00a3/go.mod h1:2wIuQute9+hhWqvL3vEI7YB0EKluF4WcPzI1eAliazk=
-github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
-github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-github/v54 v54.0.0 h1:OZdXwow4EAD5jEo5qg+dGFH2DpkyZvVsAehjvJuUL/c=
 github.com/google/go-github/v54 v54.0.0/go.mod h1:Sw1LXWHhXRZtzJ9LI5fyJg9wbQzYvFhW8W5P2yaAQ7s=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,6 @@ github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zK
 github.com/aws/aws-sdk-go v1.37.18/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.41.7/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.45.0 h1:qoVOQHuLacxJMO71T49KeE70zm+Tk3vtrl7XO4VUPZc=
-github.com/aws/aws-sdk-go v1.45.0/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go v1.45.2 h1:hTong9YUklQKqzrGk3WnKABReb5R8GjbG4Y6dEQfjnk=
 github.com/aws/aws-sdk-go v1.45.2/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
@@ -648,6 +646,7 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-containerregistry v0.0.0-20200110202235-f4fb41bf00a3/go.mod h1:2wIuQute9+hhWqvL3vEI7YB0EKluF4WcPzI1eAliazk=
 github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
+github.com/google/go-github/v54 v54.0.0 h1:OZdXwow4EAD5jEo5qg+dGFH2DpkyZvVsAehjvJuUL/c=
 github.com/google/go-github/v54 v54.0.0/go.mod h1:Sw1LXWHhXRZtzJ9LI5fyJg9wbQzYvFhW8W5P2yaAQ7s=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	configuration "github.com/diggerhq/lib-digger-config"
 	orchestrator "github.com/diggerhq/lib-orchestrator"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
-	"strings"
 )
 
 const (
@@ -328,6 +329,11 @@ func (a *AzureReposService) EditComment(id interface{}, comment string) error {
 		},
 	})
 	return err
+}
+
+func (a *AzureReposService) GetBranchName(prNumber int) (string, error) {
+	//TODO implement me
+	return "", nil
 }
 
 func (a *AzureReposService) GetComments(prNumber int) ([]orchestrator.Comment, error) {

--- a/pkg/digger/digger_test.go
+++ b/pkg/digger/digger_test.go
@@ -4,14 +4,15 @@ import (
 	"digger/pkg/core/execution"
 	"digger/pkg/reporting"
 	"digger/pkg/utils"
-	orchestrator "github.com/diggerhq/lib-orchestrator"
-	"github.com/dominikbraun/graph"
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	orchestrator "github.com/diggerhq/lib-orchestrator"
+	"github.com/dominikbraun/graph"
+	"github.com/stretchr/testify/assert"
 )
 
 type RunInfo struct {
@@ -122,6 +123,11 @@ func (m *MockPRManager) GetComments(prNumber int) ([]orchestrator.Comment, error
 func (m *MockPRManager) EditComment(id interface{}, comment string) error {
 	m.Commands = append(m.Commands, RunInfo{"EditComment", strconv.Itoa(id.(int)) + " " + comment, time.Now()})
 	return nil
+}
+
+func (m *MockPRManager) GetBranchName(prNumber int) (string, error) {
+	m.Commands = append(m.Commands, RunInfo{"GetBranchName", strconv.Itoa(prNumber), time.Now()})
+	return "", nil
 }
 
 type MockProjectLock struct {

--- a/pkg/github/models/models.go
+++ b/pkg/github/models/models.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/diggerhq/lib-orchestrator/github/models"
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v54/github"
 )
 
 type GithubAction struct {

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -3,10 +3,11 @@ package gitlab
 import (
 	"digger/pkg/utils"
 	"fmt"
-	configuration "github.com/diggerhq/lib-digger-config"
-	orchestrator "github.com/diggerhq/lib-orchestrator"
 	"log"
 	"strings"
+
+	configuration "github.com/diggerhq/lib-digger-config"
+	orchestrator "github.com/diggerhq/lib-orchestrator"
 
 	"github.com/caarlos0/env/v8"
 	go_gitlab "github.com/xanzy/go-gitlab"
@@ -236,6 +237,11 @@ func (gitlabService GitLabService) EditComment(id interface{}, comment string) e
 func (gitlabService GitLabService) GetComments(prNumber int) ([]orchestrator.Comment, error) {
 	//TODO implement me
 	return nil, nil
+}
+
+func (gitlabService GitLabService) GetBranchName(prNumber int) (string, error) {
+	//TODO implement me
+	return "", nil
 }
 
 func getMergeRequest(gitlabService GitLabService) *go_gitlab.MergeRequest {

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -10,18 +10,19 @@ import (
 	"digger/pkg/reporting"
 	"digger/pkg/storage"
 	"digger/pkg/utils"
-	configuration "github.com/diggerhq/lib-digger-config"
-	dg_github "github.com/diggerhq/lib-orchestrator/github"
 	"log"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
 
+	configuration "github.com/diggerhq/lib-digger-config"
+	dg_github "github.com/diggerhq/lib-orchestrator/github"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v54/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -2,10 +2,11 @@ package reporting
 
 import (
 	"digger/pkg/core/utils"
-	orchestrator "github.com/diggerhq/lib-orchestrator"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	orchestrator "github.com/diggerhq/lib-orchestrator"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCommentPerRunStrategyReport(t *testing.T) {
@@ -226,4 +227,8 @@ func (t MockCiService) EditComment(commentId interface{}, comment string) error 
 		}
 	}
 	return nil
+}
+
+func (t MockCiService) GetBranchName(prNumber int) (string, error) {
+	return "", nil
 }

--- a/pkg/storage/plan_storage.go
+++ b/pkg/storage/plan_storage.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 
 	"cloud.google.com/go/storage"
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v54/github"
 )
 
 type PlanStorageGcp struct {

--- a/pkg/utils/commands.go
+++ b/pkg/utils/commands.go
@@ -16,6 +16,7 @@ var availableCommands = []Commad{
 	{"digger version", "Display version information"},
 	{"digger apply", "Apply the Terraform  configuration"},
 	{"digger plan", "Plan the Terraform  configuration"},
+	{"digger show-projects", "Show the impacted projects"},
 	{"digger lock", "Lock Terraform project"},
 	{"digger unlock", "Unlock the Terraform project"},
 }

--- a/pkg/utils/mocks.go
+++ b/pkg/utils/mocks.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	orchestrator "github.com/diggerhq/lib-orchestrator"
 	"time"
+
+	orchestrator "github.com/diggerhq/lib-orchestrator"
 )
 
 type MockTerraform struct {
@@ -109,6 +110,10 @@ func (t MockPullRequestManager) GetComments(prNumber int) ([]orchestrator.Commen
 
 func (t MockPullRequestManager) EditComment(commentId interface{}, comment string) error {
 	return nil
+}
+
+func (t MockPullRequestManager) GetBranchName(prNumber int) (string, error) {
+	return "", nil
 }
 
 type MockPlanStorage struct {

--- a/pkg/utils/pullrequestmanager_mock.go
+++ b/pkg/utils/pullrequestmanager_mock.go
@@ -73,3 +73,8 @@ func (mockGithubPullrequestManager *MockGithubPullrequestManager) EditComment(co
 	mockGithubPullrequestManager.commands = append(mockGithubPullrequestManager.commands, "EditComment")
 	return nil
 }
+
+func (mockGithubPullrequestManager *MockGithubPullrequestManager) GetBranchName(prNumber int) (string, error) {
+	mockGithubPullrequestManager.commands = append(mockGithubPullrequestManager.commands, "GetBranchName")
+	return "", nil
+}


### PR DESCRIPTION
Fixes: #547 

This PR implements new command `digger show-projects` to show all the impacted projects by the PR on the comment. 

- Address library bump issue introduced by https://github.com/diggerhq/digger/pull/544
- Add interim implementation of GetBranchName method (See https://github.com/diggerhq/lib-orchestrator/commit/65be3864de9d21f05bece8ead9826169186c7a6e)