### PR TITLE
fix swallowing of errors

### DIFF
--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -115,7 +115,7 @@ func RunJobs(
 				if reportErr != nil {
 					fmt.Printf("error reporting project run err: %v.\n", reportErr)
 				}
-				return false, false, fmt.Errorf("error checking policy: %v", err)
+				return false, false, fmt.Errorf("error while running command: %v", err)
 			}
 			err = backendApi.ReportProjectRun(SCMOrganisation+"-"+SCMrepository, job.ProjectName, runStartedAt, time.Now(), "SUCCESS", command, output)
 			if err != nil {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -111,7 +111,10 @@ func RunJobs(
 			output, err := run(command, job, policyChecker, orgService, SCMOrganisation, SCMrepository, job.RequestedBy, reporter, lock, prService, job.Namespace, workingDir, planStorage, appliesPerProject)
 
 			if err != nil {
-				err := backendApi.ReportProjectRun(SCMOrganisation+"-"+SCMrepository, job.ProjectName, runStartedAt, time.Now(), "FAILED", command, output)
+				reportErr := backendApi.ReportProjectRun(SCMOrganisation+"-"+SCMrepository, job.ProjectName, runStartedAt, time.Now(), "FAILED", command, output)
+				if reportErr != nil {
+					fmt.Printf("error reporting project run err: %v.\n", reportErr)
+				}
 				return false, false, fmt.Errorf("error checking policy: %v", err)
 			}
 			err = backendApi.ReportProjectRun(SCMOrganisation+"-"+SCMrepository, job.ProjectName, runStartedAt, time.Now(), "SUCCESS", command, output)


### PR DESCRIPTION
Digger was not reporting the right error on run failure it was overwriting the `err` variable and outputing the wrong error. Fixed in this PR