### PR TITLE
chore: Use ldflags to automatically set the version to the Git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         run: |
-          env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o digger ./cmd/digger
+          env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+            go build \
+              -ldflags="-s -w -X github.com/diggerhq/digger/pkg/utils.version=${{ github.event.release.tag_name }}" \
+              -o digger ./cmd/digger
       - name: Publish linux-x64 exec to github
         id: upload-release-asset-linux-x64
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
https://docs.github.com/en/webhooks/webhook-events-and-payloads#release