### PR TITLE
get all changed files

### DIFF
--- a/libs/orchestrator/github/github.go
+++ b/libs/orchestrator/github/github.go
@@ -13,7 +13,11 @@ import (
 )
 
 func NewGitHubService(ghToken string, repoName string, owner string) GithubService {
-	client := github.NewTokenClient(context.Background(), ghToken)
+	client := github.NewClient(nil)
+	if ghToken != "" {
+		client = client.WithAuthToken(ghToken)
+	}
+
 	return GithubService{
 		Client:   client,
 		RepoName: repoName,

--- a/libs/orchestrator/github/github_test.go
+++ b/libs/orchestrator/github/github_test.go
@@ -112,3 +112,9 @@ func TestFindAllProjectsDependantOnImpactedProjects(t *testing.T) {
 	assert.NotContains(t, projectNames, "k")
 	assert.NotContains(t, projectNames, "b")
 }
+
+func TestFindAllChangedFilesOfPR(t *testing.T) {
+	githubPrService := NewGitHubService("", "digger", "diggerhq")
+	files, _ := githubPrService.GetChangedFiles(98)
+	assert.Equal(t, 45, len(files))
+}


### PR DESCRIPTION
There was a bug that digger only fetches 30 files changed in a pull request

In this PR we are fetching all of the changed files through looping over paginated results.

Also replace deprecated `NewTokenClient` with `NewClient` and support unauthenticated client to add a test for this case