### PR TITLE
fix Github's GetChangedFiles() to also return previous filenames

### DIFF
--- a/libs/orchestrator/github/github.go
+++ b/libs/orchestrator/github/github.go
@@ -3,11 +3,12 @@ package github
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/diggerhq/digger/libs/digger_config"
 	orchestrator "github.com/diggerhq/digger/libs/orchestrator"
 	"github.com/dominikbraun/graph"
-	"log"
-	"strings"
 
 	"github.com/google/go-github/v55/github"
 )
@@ -61,6 +62,9 @@ func (svc *GithubService) GetChangedFiles(prNumber int) ([]string, error) {
 
 		for _, file := range files {
 			fileNames = append(fileNames, *file.Filename)
+			if file.PreviousFilename != nil {
+				fileNames = append(fileNames, *file.PreviousFilename)
+			}
 		}
 		if resp.NextPage == 0 {
 			break

--- a/libs/orchestrator/github/github_test.go
+++ b/libs/orchestrator/github/github_test.go
@@ -1,9 +1,10 @@
 package github
 
 import (
+	"testing"
+
 	"github.com/diggerhq/digger/libs/digger_config"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestFindAllProjectsDependantOnImpactedProjects(t *testing.T) {
@@ -116,5 +117,6 @@ func TestFindAllProjectsDependantOnImpactedProjects(t *testing.T) {
 func TestFindAllChangedFilesOfPR(t *testing.T) {
 	githubPrService := NewGitHubService("", "digger", "diggerhq")
 	files, _ := githubPrService.GetChangedFiles(98)
-	assert.Equal(t, 45, len(files))
+	// 45 changed files including 1 renamed file so the previous filename is included
+	assert.Equal(t, 46, len(files))
 }


### PR DESCRIPTION
when moving files from one project to another, GetChangedFiles() will now include the previous filepath and new filepath causing plans to run in both projects instead of only the project where the file is getting moved to.

Fixes #630 