### PR TITLE
Report no-changes plans correctly

### DIFF
--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -138,10 +138,9 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 		planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, githubActor, job.PullRequestNumber)
 
 		reporter := &reporting.CiReporter{
-			CiService:         &githubPrService,
-			PrNumber:          *job.PullRequestNumber,
-			ReportStrategy:    reportingStrategy,
-			IsSupportMarkdown: true,
+			CiService:      &githubPrService,
+			PrNumber:       *job.PullRequestNumber,
+			ReportStrategy: reportingStrategy,
 		}
 
 		jobs := []orchestrator.Job{orchestrator.JsonToJob(job)}
@@ -305,9 +304,10 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 		planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, githubActor, &prNumber)
 
 		reporter := &reporting.CiReporter{
-			CiService:      &githubPrService,
-			PrNumber:       prNumber,
-			ReportStrategy: reportingStrategy,
+			CiService:         &githubPrService,
+			PrNumber:          prNumber,
+			ReportStrategy:    reportingStrategy,
+			IsSupportMarkdown: true,
 		}
 
 		jobs = digger.SortedCommandsByDependency(jobs, &dependencyGraph)

--- a/cmd/digger/main.go
+++ b/cmd/digger/main.go
@@ -138,9 +138,10 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 		planStorage := newPlanStorage(ghToken, repoOwner, repositoryName, githubActor, job.PullRequestNumber)
 
 		reporter := &reporting.CiReporter{
-			CiService:      &githubPrService,
-			PrNumber:       *job.PullRequestNumber,
-			ReportStrategy: reportingStrategy,
+			CiService:         &githubPrService,
+			PrNumber:          *job.PullRequestNumber,
+			ReportStrategy:    reportingStrategy,
+			IsSupportMarkdown: true,
 		}
 
 		jobs := []orchestrator.Job{orchestrator.JsonToJob(job)}

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -223,8 +223,8 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			}
 			return msg, fmt.Errorf(msg)
 		} else if planPerformed {
-			reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
 			if isNonEmptyPlan {
+				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
 				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, job.ProjectName, planJsonOutput)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to validate plan. %v", err)
@@ -254,10 +254,13 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					log.Printf(msg)
 					return msg, fmt.Errorf(msg)
 				} else {
-					err := reporter.Report("Terraform plan validation checks succeeded :white_check_mark:", planPolicyFormatter)
-					if err != nil {
-						log.Printf("Failed to report plan. %v", err)
-					}
+					reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan")
+				}
+			} else {
+				msg := "Terraform plan completed with no changes to apply"
+				err := reporter.Report(msg, utils.AsComment(msg))
+				if err != nil {
+					log.Printf("Failed to report plan. %v", err)
 				}
 			}
 			err := prService.SetStatus(*job.PullRequestNumber, "success", job.ProjectName+"/plan")

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -3,6 +3,7 @@ package digger
 import (
 	"errors"
 	"fmt"
+	"github.com/davecgh/go-spew/spew"
 	config "github.com/diggerhq/digger/libs/digger_config"
 	orchestrator "github.com/diggerhq/digger/libs/orchestrator"
 	"github.com/diggerhq/digger/pkg/core/backend"
@@ -382,6 +383,9 @@ func reportApplyMergeabilityError(reporter core_reporting.Reporter) string {
 func reportTerraformPlanOutput(reporter core_reporting.Reporter, projectId string, plan string) {
 	var formatter func(string) string
 
+	fmt.Printf("reporting terraform plan output for: %v \n\n\n plaN: %v\n", projectId, plan)
+	fmt.Printf("is support markdown:: %v \n", reporter.SupportsMarkdown())
+	spew.Dump(reporter)
 	if reporter.SupportsMarkdown() {
 		formatter = utils.GetTerraformOutputAsCollapsibleComment("Plan for <b>" + projectId + "</b>")
 	} else {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -3,7 +3,6 @@ package digger
 import (
 	"errors"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	config "github.com/diggerhq/digger/libs/digger_config"
 	orchestrator "github.com/diggerhq/digger/libs/orchestrator"
 	"github.com/diggerhq/digger/pkg/core/backend"
@@ -383,9 +382,6 @@ func reportApplyMergeabilityError(reporter core_reporting.Reporter) string {
 func reportTerraformPlanOutput(reporter core_reporting.Reporter, projectId string, plan string) {
 	var formatter func(string) string
 
-	fmt.Printf("reporting terraform plan output for: %v \n\n\n plaN: %v\n", projectId, plan)
-	fmt.Printf("is support markdown:: %v \n", reporter.SupportsMarkdown())
-	spew.Dump(reporter)
 	if reporter.SupportsMarkdown() {
 		formatter = utils.GetTerraformOutputAsCollapsibleComment("Plan for <b>" + projectId + "</b>")
 	} else {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -254,14 +254,13 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					log.Printf(msg)
 					return msg, fmt.Errorf(msg)
 				} else {
-					reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan")
+					err := reporter.Report("Terraform plan validation checks succeeded :white_check_mark:", planPolicyFormatter)
+					if err != nil {
+						log.Printf("Failed to report plan. %v", err)
+					}
 				}
 			} else {
-				msg := "Terraform plan completed with no changes to apply"
-				err := reporter.Report(msg, utils.AsComment(msg))
-				if err != nil {
-					log.Printf("Failed to report plan. %v", err)
-				}
+				reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan")
 			}
 			err := prService.SetStatus(*job.PullRequestNumber, "success", job.ProjectName+"/plan")
 			if err != nil {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -260,7 +260,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					}
 				}
 			} else {
-				reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan")
+				reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan\n")
 			}
 			err := prService.SetStatus(*job.PullRequestNumber, "success", job.ProjectName+"/plan")
 			if err != nil {


### PR DESCRIPTION
NOTE for future: I think there is still a bug in the case where CI does not support markdown since we are stripping first and last lines here it seems like the closing of the codeblcok is getting stripped out as well https://github.com/diggerhq/digger/blob/d8c97bac74d1549721d3656e994a0b531d972276/pkg/reporting/reporting.go#L82

However this fixes it for the case of github