### PR TITLE
Fix/fail gracefully if teams fetch failed

### DIFF
--- a/libs/orchestrator/github/github.go
+++ b/libs/orchestrator/github/github.go
@@ -35,7 +35,7 @@ type GithubService struct {
 func (svc *GithubService) GetUserTeams(organisation string, user string) ([]string, error) {
 	teamsResponse, _, err := svc.Client.Teams.ListTeams(context.Background(), organisation, nil)
 	if err != nil {
-		log.Fatalf("Failed to list github teams: %v", err)
+		return nil, fmt.Errorf("failed to list github teams: %v", err)
 	}
 	var teams []string
 	for _, team := range teamsResponse {

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -223,8 +223,8 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			}
 			return msg, fmt.Errorf(msg)
 		} else if planPerformed {
-			reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
 			if isNonEmptyPlan {
+				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
 				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, job.ProjectName, planJsonOutput)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to validate plan. %v", err)
@@ -254,10 +254,13 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					log.Printf(msg)
 					return msg, fmt.Errorf(msg)
 				} else {
-					err := reporter.Report("Terraform plan validation checks succeeded :white_check_mark:", planPolicyFormatter)
-					if err != nil {
-						log.Printf("Failed to report plan. %v", err)
-					}
+					reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan")
+				}
+			} else {
+				msg := "Terraform plan completed with no changes to apply"
+				err := reporter.Report(msg, utils.AsComment(msg))
+				if err != nil {
+					log.Printf("Failed to report plan. %v", err)
 				}
 			}
 			err := prService.SetStatus(*job.PullRequestNumber, "success", job.ProjectName+"/plan")

--- a/pkg/digger/digger.go
+++ b/pkg/digger/digger.go
@@ -258,12 +258,6 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan")
 				}
 			} else {
-				msg := "Terraform plan completed with no changes to apply"
-				err := reporter.Report(msg, utils.AsComment(msg))
-				if err != nil {
-					log.Printf("Failed to report plan. %v", err)
-				}
-			} else {
 				reportTerraformPlanOutput(reporter, projectLock.LockId(), "No changes in terraform plan\n")
 			}
 			err := prService.SetStatus(*job.PullRequestNumber, "success", job.ProjectName+"/plan")

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -275,7 +275,8 @@ func (p DiggerPolicyChecker) CheckAccessPolicy(ciService orchestrator.OrgService
 	teams, err := ciService.GetUserTeams(SCMOrganisation, requestedBy)
 	if err != nil {
 		log.Printf("Error while fetching user teams for CI service: %v", err)
-		return false, err
+		log.Printf("WARNING: teams failed to be fetched, passing an empty list instead for access policy checks\n")
+		teams = []string{}
 	}
 
 	// list of pull request approvals (if applicable)


### PR DESCRIPTION
We will be ignoring failing teams fetch for now since with token flow the only workaround is to place a bot token into the action.  As a result the GH App driven flow is failing and only passes when you pass a bot token

This shouldn't be part of the onboarding for GH app, since the app does have access to fetch user teams
In the future the teams will be passed into the workflow from the backend to avoid this

For now we resort to a warning and passing an empty teams list into the policy if there is no access, while printing a warning.

In future changes we want to:
-  document for actions flow how to create a bot token for proper teams access
- pass the teams list from the backend to the action so that the cli could check it accordingly