### PR TITLE
Use filepath.Match() instead of regex in GetFilesWithExtension()

### DIFF
--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/diggerhq/digger/libs/digger_config/terragrunt/atlantis"
@@ -37,7 +36,7 @@ func GetFilesWithExtension(workingDir string, ext string) ([]string, error) {
 	}
 	for _, f := range listOfFiles {
 		if !f.IsDir() {
-			r, err := regexp.MatchString(ext, f.Name())
+			r, err := filepath.Match("*"+ext, f.Name())
 			if err == nil && r {
 				files = append(files, f.Name())
 			}

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -402,6 +402,28 @@ generate_projects:
 	assert.Equal(t, 2, len(dg.Projects))
 }
 
+// A .tfvars file should not be recognised as .tf and break parsing for projects nested deeper
+// Issue: https://github.com/diggerhq/digger/issues/887
+func TestDiggerGenerateProjectsWithTfvars(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	dirsWithTfToCreate := []string{"dev/us-east-1"}
+
+	for _, dir := range dirsWithTfToCreate {
+		err := os.MkdirAll(path.Join(tempDir, dir), os.ModePerm)
+		defer createFile(path.Join(tempDir, dir, "main.tf"), "")()
+		assert.NoError(t, err, "expected error to be nil")
+	}
+
+	defer createFile(path.Join(tempDir, "dev", "blank.tfvars"), "")()
+
+	dg, _, _, err := LoadDiggerConfig(tempDir)
+	assert.NoError(t, err, "expected error to be nil")
+	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
+	assert.Equal(t, 1, len(dg.Projects))
+}
+
 func TestDiggerGenerateProjectsIgnoreSubdirs(t *testing.T) {
 	tempDir, teardown := setUp()
 	defer teardown()


### PR DESCRIPTION
Fixes #887 