### PR TITLE
only fetch oidc keys once both apply and plan phases

### DIFF
--- a/libs/orchestrator/aws.go
+++ b/libs/orchestrator/aws.go
@@ -17,10 +17,10 @@ import (
 
 func populateretrieveBackendConfigArgs(provider stscreds.WebIdentityRoleProvider) ([]string, error) {
 	creds, err := provider.Retrieve()
+	var args []string
 	if err != nil {
 		return args, fmt.Errorf("populateKeys: Could not retrieve keys from provider %v", err)
 	}
-	var args []string
 	accessKey := fmt.Sprintf("-backend-config=access_key=%v", creds.AccessKeyID)
 	secretKey := fmt.Sprintf("-backend-config=secret_key=%v", creds.SecretAccessKey)
 	token := fmt.Sprintf("-backend-config=token=%v", creds.SessionToken)


### PR DESCRIPTION
follow up from #991 since we were retrieving the keys twice and it was causing a terraform init error since we are passing different keys if we perform plan and subsequent apply in the same job