### PR TITLE
bring back repo added creation of repo

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -288,23 +288,11 @@ func handleInstallationRepositoriesAddedEvent(ghClientProvider utils.GithubClien
 			return err
 		}
 
-		//_, org, err := createOrGetDiggerRepoForGithubRepo(repoFullName, installationId)
-		//if err != nil {
-		//	log.Printf("createOrGetDiggerRepoForGithubRepo failed, error: %v\n", err)
-		//	return err
-		//}
-
-		//client, _, err := ghClientProvider.Get(int64(appId), installationId)
-		//if err != nil {
-		//	log.Printf("GetGithubClient failed, error: %v\n", err)
-		//	return err
-		//}
-		//
-		//err = CreateDiggerWorkflowWithPullRequest(org, client, repoFullName)
-		//if err != nil {
-		//	log.Printf("CreateDiggerWorkflowWithPullRequest failed, error: %v\n", err)
-		//	return err
-		//}
+		_, _, err = createOrGetDiggerRepoForGithubRepo(repoFullName, installationId)
+		if err != nil {
+			log.Printf("createOrGetDiggerRepoForGithubRepo failed, error: %v\n", err)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
We had accidentally removed a block with the intent of disabled automated PR creation on app installation but instead also removed a part related to adding repo records to the database.

This PR brings back the repo creation block and removes the commented block as a refactor