### PR TITLE
chore: Backend include a step in the backend tests to ensure that the dcoker image still builds

### DIFF
--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Test that the docker image still builds successfully
+        run: |
+          export COMMIT_SHA=$(git rev-parse --short HEAD)
+          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
+
       - name: Download Go
         uses: actions/setup-go@v5
         with:
@@ -34,9 +39,5 @@ jobs:
           GITHUB_PAT_TOKEN: ${{ secrets.TOKEN_GITHUB }}
         working-directory: backend
 
-      - name: Test that the docker image still builds successfully
-        run: |
-          export COMMIT_SHA=$(git rev-parse --short HEAD)
-          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
 
           

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -33,3 +33,10 @@ jobs:
         env:
           GITHUB_PAT_TOKEN: ${{ secrets.TOKEN_GITHUB }}
         working-directory: backend
+
+      - name: Test that the docker image still builds successfully
+        run: |
+          export COMMIT_SHA=$(git rev-parse --short HEAD)
+          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
+
+          

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Test that the docker image still builds successfully
-        run: |
-          export COMMIT_SHA=$(git rev-parse --short HEAD)
-          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
-
       - name: Download Go
         uses: actions/setup-go@v5
         with:
@@ -24,6 +19,11 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+
+      - name: Test that the docker image still builds successfully
+        run: |
+          export COMMIT_SHA=$(git rev-parse --short HEAD)
+          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
 
       - name: Deps
         run: go get -v ./...

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21.5
+go 1.21.6
 
 use (
 	./backend


### PR DESCRIPTION
Rennovate automerges minor updates by default when it creates a PR and it passes: 

In this PR it has updated golang version and all tests passed so it merged it. However it for some reason has broken our docker builds for backend and upon merge the jobs that https://github.com/diggerhq/digger/pull/1018

we ensure they will not be automerged by adding an additional docker build that will fail if anything breaks