### PR TITLE
fix for redirect to subdomain

### DIFF
--- a/backend/controllers/web.go
+++ b/backend/controllers/web.go
@@ -293,7 +293,7 @@ func (web *WebController) PolicyDetailsUpdatePage(c *gin.Context) {
 	c.HTML(http.StatusOK, "policy_details.tmpl", pageContext)
 }
 
-func (web *WebController) RedirectToLoginSubdomain(context *gin.Context) {
+func (web *WebController) RedirectToLoginSubdomainIfDiggerDevOtherwiseToProjects(context *gin.Context) {
 	host := context.Request.Host
 	if strings.Contains(host, "digger.dev") || strings.Contains(host, "uselemon.cloud") {
 		hostParts := strings.Split(host, ".")

--- a/backend/controllers/web.go
+++ b/backend/controllers/web.go
@@ -295,16 +295,17 @@ func (web *WebController) PolicyDetailsUpdatePage(c *gin.Context) {
 
 func (web *WebController) RedirectToLoginSubdomain(context *gin.Context) {
 	host := context.Request.Host
-	hostParts := strings.Split(host, ".")
-	if len(hostParts) > 2 {
-		hostParts[0] = "login"
-		host = strings.Join(hostParts, ".")
-	}
-	context.Redirect(http.StatusMovedPermanently, fmt.Sprintf("https://%s", host))
-}
+	if strings.Contains(host, "digger.dev") || strings.Contains(host, "uselemon.cloud") {
+		hostParts := strings.Split(host, ".")
+		if len(hostParts) > 2 {
+			hostParts[0] = "login"
+			host = strings.Join(hostParts, ".")
+		}
+		context.Redirect(http.StatusMovedPermanently, fmt.Sprintf("https://%s", host))
 
-func (web *WebController) RedirectToProjectsPage(context *gin.Context) {
-	context.Redirect(http.StatusMovedPermanently, "/projects")
+	} else {
+		context.Redirect(http.StatusMovedPermanently, "/projects")
+	}
 }
 
 func (web *WebController) UpdateRepoPage(c *gin.Context) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -71,7 +71,7 @@ func main() {
 	})
 
 	r.LoadHTMLGlob("templates/*.tmpl")
-	r.GET("/", web.RedirectToLoginSubdomain)
+	r.GET("/", web.RedirectToLoginSubdomainIfDiggerDevOtherwiseToProjects)
 
 	r.POST("/github-app-webhook", controllers.GithubAppWebHook)
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -71,7 +71,7 @@ func main() {
 	})
 
 	r.LoadHTMLGlob("templates/*.tmpl")
-	r.GET("/", web.RedirectToProjectsPage)
+	r.GET("/", web.RedirectToLoginSubdomain)
 
 	r.POST("/github-app-webhook", controllers.GithubAppWebHook)
 


### PR DESCRIPTION
We had a blank redirect to `/project` since release of selfhosted. However for cloud.digger.dev we are relying on frontegg that needs redirecting to login.digger.dev on initial visit to cloud.digger.dev/ . In this PR we make a check on hostname and redirect to login.digger.dev if it matches *.digger.dev, otherwise we redirect to /projects.