### PR TITLE
Fix execution when using http backends

### DIFF
--- a/cli/pkg/core/terraform/opentofu.go
+++ b/cli/pkg/core/terraform/opentofu.go
@@ -24,10 +24,12 @@ func (tf OpenTofu) Init(params []string, envs map[string]string) (string, string
 }
 
 func (tf OpenTofu) Apply(params []string, plan *string, envs map[string]string) (string, string, error) {
-	err := tf.switchToWorkspace(envs)
-	if err != nil {
-		log.Printf("Fatal: Error terraform to workspace %v", err)
-		return "", "", err
+	if tf.Workspace != "default" {
+		err := tf.switchToWorkspace(envs)
+		if err != nil {
+			log.Printf("Fatal: Error terraform to workspace %v", err)
+			return "", "", err
+		}
 	}
 	params = append(append(append(params, "-input=false"), "-no-color"), "-auto-approve")
 	if plan != nil {
@@ -38,20 +40,10 @@ func (tf OpenTofu) Apply(params []string, plan *string, envs map[string]string) 
 }
 
 func (tf OpenTofu) Plan(params []string, envs map[string]string) (bool, string, string, error) {
-
-	workspaces, _, _, err := tf.runOpentofuCommand(false, "workspace", envs, "list")
-	if err != nil {
-		return false, "", "", err
-	}
-	workspaces = tf.formatOpentofuWorkspaces(workspaces)
-	if strings.Contains(workspaces, tf.Workspace) {
-		_, _, _, err := tf.runOpentofuCommand(true, "workspace", envs, "select", tf.Workspace)
+	if tf.Workspace != "default" {
+		err := tf.switchToWorkspace(envs)
 		if err != nil {
-			return false, "", "", err
-		}
-	} else {
-		_, _, _, err := tf.runOpentofuCommand(true, "workspace", envs, "new", tf.Workspace)
-		if err != nil {
+			log.Printf("Fatal: Error terraform to workspace %v", err)
 			return false, "", "", err
 		}
 	}
@@ -72,10 +64,12 @@ func (tf OpenTofu) Show(params []string, envs map[string]string) (string, string
 }
 
 func (tf OpenTofu) Destroy(params []string, envs map[string]string) (string, string, error) {
-	err := tf.switchToWorkspace(envs)
-	if err != nil {
-		log.Printf("Fatal: Error terraform to workspace %v", err)
-		return "", "", err
+	if tf.Workspace != "default" {
+		err := tf.switchToWorkspace(envs)
+		if err != nil {
+			log.Printf("Fatal: Error terraform to workspace %v", err)
+			return "", "", err
+		}
 	}
 	params = append(append(append(params, "-input=false"), "-no-color"), "-auto-approve")
 	stdout, stderr, _, err := tf.runOpentofuCommand(true, "destroy", envs, params...)

--- a/cli/pkg/core/terraform/tf.go
+++ b/cli/pkg/core/terraform/tf.go
@@ -32,10 +32,12 @@ func (tf Terraform) Init(params []string, envs map[string]string) (string, strin
 
 	// switch to workspace for next step
 	// TODO: make this an individual and isolated step
-	werr := tf.switchToWorkspace(envs)
-	if werr != nil {
-		log.Printf("Fatal: Error terraform switch to workspace %v", err)
-		return "", "", werr
+	if tf.Workspace != "default" {
+		werr := tf.switchToWorkspace(envs)
+		if werr != nil {
+			log.Printf("Fatal: Error terraform switch to workspace %v", err)
+			return "", "", werr
+		}
 	}
 
 	return stdout, stderr, err


### PR DESCRIPTION
This PR updates the Digger github action so that it doesn't attempt to switch workspaces when it's unnecessary.
(i.e. terraform workspace is already "default", there's no need to attempt to switch to it.)

Reason being is that the [HTTP backend](https://developer.hashicorp.com/terraform/language/settings/backends/http) in Terraform/OpenTofu does not currently support workspaces:

https://github.com/hashicorp/terraform/issues/26797
https://github.com/opentofu/opentofu/issues/317

Attempting to use any workspace commands gives an error:

```
# terraform workspace list
workspaces not supported
```

which in turn was causing Digger to fail:

```
Running command: terraform [workspace list]
Error: exit status 1
Fatal: Error terraform switch to workspace <nil>
Failed to run digger plan command. error running init: exit status 1
Failed to run commands. error while running command: Failed to run digger plan command. error running init: exit status 1
```
