### PR TITLE
Fix plan upload to GitHub Artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -315,10 +315,10 @@ runs:
             echo "artifact=plans-${{ github.event.number }}" >> $GITHUB_OUTPUT
           fi
     - name: upload plan
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: ${{ steps.artifact.outputs.artifact }}
-          path: '${{ env.GITHUB_WORKSPACE }}/**/*.tfplan'
+          path: '${{ github.workspace }}/**/*.tfplan'
           retention-days: 14
       if: ${{ inputs.upload-plan-destination == 'github' }}
 

--- a/action.yml
+++ b/action.yml
@@ -315,10 +315,10 @@ runs:
             echo "artifact=plans-${{ github.event.number }}" >> $GITHUB_OUTPUT
           fi
     - name: upload plan
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
           name: ${{ steps.artifact.outputs.artifact }}
-          path: '$GITHUB_WORKSPACE/**/*.tfplan'
+          path: '${{ env.GITHUB_WORKSPACE }}/**/*.tfplan'
           retention-days: 14
       if: ${{ inputs.upload-plan-destination == 'github' }}
 

--- a/action.yml
+++ b/action.yml
@@ -318,7 +318,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
           name: ${{ steps.artifact.outputs.artifact }}
-          path: '${{ env.GITHUB_WORKSPACE }}/**/*.tfplan'
+          path: '$GITHUB_WORKSPACE/**/*.tfplan'
           retention-days: 14
       if: ${{ inputs.upload-plan-destination == 'github' }}
 


### PR DESCRIPTION
Wrong syntax for github.workspace was used, resulting in EACCESS error when glob in upload-artifact tried to scan everything from root dir