### PR TITLE
do not automerge rennovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":automergeMinor"
+    "config:base"
   ],
   "labels": ["dependencies"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
in many cases we need to review minor version updates, for example when there was an issue with azure/login we had to downgrade to v1.5 and then renovate last night automerged an updated again which could have gone unnoticed