### PR TITLE
[Tiny] - Fix image scr in documentation

### DIFF
--- a/docs/features/plan-preview.mdx
+++ b/docs/features/plan-preview.mdx
@@ -4,7 +4,7 @@ title: "Plan preview"
 
 Digger runs `terraform plan` whenever a pull request is raised, and appends output as comment
 
-<img height="200" src="images/digger-plan-preview.png" />
+<img height="200" src="/images/digger-plan-preview.png" />
 
 Digger run report also contains other useful info e.g. results of policy checks.
 


### PR DESCRIPTION
While reading through the docs, I found this link to be broken. This should fix it

![image](https://github.com/diggerhq/digger/assets/3263338/4f66a6b3-a092-4d49-9387-7c06063d6533)
