### PR TITLE
handle case when plan did not run due to locking gracefully

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -482,7 +482,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		msg := fmt.Sprintf("Command '%s' is not supported", command)
 		return nil, msg, fmt.Errorf(msg)
 	}
-	return nil, "", nil
+	return &execution.DiggerExecutorResult{}, "", nil
 }
 
 func retrievePlanBeforeApply(planStorage storage.PlanStorage, planPathProvider execution.PlanPathProvider, diggerExecutor execution.LockingExecutorWrapper) (string, error) {


### PR DESCRIPTION
fixes #1139 

After introducing DiggerExecutorResult we missed a return at the end which occured when there is a locking error. A plan attempt of a locked project in digger is not considered as an error, so we don't return any errors, but we should return an empty ExecutorResult in order to avoid nilpointer exception in the accessor