### PR TITLE
do not handle PR closed event

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -407,6 +407,10 @@ func handlePushEvent(gh utils.GithubClientProvider, payload *github.PushEvent) e
 }
 
 func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullRequestEvent) error {
+	if *payload.Action != "opened" && *payload.Action != "reopened" {
+		return nil
+	}
+
 	installationId := *payload.Installation.ID
 	repoName := *payload.Repo.Name
 	repoOwner := *payload.Repo.Owner.Login

--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -407,7 +407,8 @@ func handlePushEvent(gh utils.GithubClientProvider, payload *github.PushEvent) e
 }
 
 func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullRequestEvent) error {
-	if *payload.Action != "opened" && *payload.Action != "reopened" {
+
+	if *payload.Action == "closed" && *payload.PullRequest.Merged == false {
 		return nil
 	}
 


### PR DESCRIPTION
Current orchestrator behaviour attempts to handle PR closed, this should be ignored