### PR TITLE
Fix/npe on update status comment

### DIFF
--- a/backend/models/storage.go
+++ b/backend/models/storage.go
@@ -633,8 +633,9 @@ func (db *Database) CreateDiggerJob(batchId uuid.UUID, serializedJob []byte) (*D
 		return nil, result.Error
 	}
 
+	workflowUrl := "#"
 	job := &DiggerJob{DiggerJobID: jobId, Status: scheduler.DiggerJobCreated,
-		BatchID: &batchIdStr, SerializedJobSpec: serializedJob, DiggerJobSummary: *summary}
+		BatchID: &batchIdStr, SerializedJobSpec: serializedJob, DiggerJobSummary: *summary, WorkflowRunUrl: &workflowUrl}
 	result = db.GormDB.Save(job)
 	if result.Error != nil {
 		return nil, result.Error

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -3,7 +3,6 @@ package digger
 import (
 	"errors"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"log"
 	"os"
 	"path"
@@ -170,10 +169,6 @@ func UpdateStatusComment(jobs []scheduler.SerializedJob, prNumber int, prService
 			log.Printf("Failed to convert unmarshall Serialized job")
 		}
 		isPlan := jobSpec.IsPlan()
-
-		spew.Dump(job)
-		println("!!-------!!")
-		spew.Dump(jobSpec)
 
 		message = message + fmt.Sprintf("<!-- PROJECTHOLDER %v -->\n", job.ProjectName)
 		message = message + fmt.Sprintf("%v **%v** <a href='%v'>%v</a>%v\n", job.Status.ToEmoji(), jobSpec.ProjectName, *job.WorkflowRunUrl, job.Status.ToString(), job.ResourcesSummaryString(isPlan))

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -3,6 +3,7 @@ package digger
 import (
 	"errors"
 	"fmt"
+	"github.com/davecgh/go-spew/spew"
 	"log"
 	"os"
 	"path"
@@ -169,6 +170,10 @@ func UpdateStatusComment(jobs []scheduler.SerializedJob, prNumber int, prService
 			log.Printf("Failed to convert unmarshall Serialized job")
 		}
 		isPlan := jobSpec.IsPlan()
+
+		spew.Dump(job)
+		println("!!-------!!")
+		spew.Dump(jobSpec)
 
 		message = message + fmt.Sprintf("<!-- PROJECTHOLDER %v -->\n", job.ProjectName)
 		message = message + fmt.Sprintf("%v **%v** <a href='%v'>%v</a>%v\n", job.Status.ToEmoji(), jobSpec.ProjectName, *job.WorkflowRunUrl, job.Status.ToString(), job.ResourcesSummaryString(isPlan))


### PR DESCRIPTION
If for whatever reason workflow url was not able to be determined we need to ensure that the backend should still return a non nil default value for the cli to use while updating status comment. When we create a batch we set a default value of '#' to acheive this