### PR TITLE
multiarch releases for cli

### DIFF
--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -1,4 +1,4 @@
-name: release
+name: release cli
 on:
   release:
     branches:

--- a/.github/workflows/cli_release_multiarch.yml
+++ b/.github/workflows/cli_release_multiarch.yml
@@ -1,0 +1,44 @@
+name: release
+on:
+  release:
+    branches:
+      - 'go'
+    types: [released]
+jobs:
+  binary:
+    strategy:
+      matrix:
+        arch: [arm, arm64, amd64, 386]
+        os: [linux, darwin, freebsd, windows]
+        exclude:
+          - os: darwin
+            arch: arm
+          - os: darwin
+            arch: 386
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.1
+        id: go
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Build
+        run: |
+          echo "Tag that is going to be used as digger version: ${{ github.event.release.tag_name }}"
+          env GOOS=${{matrix.os}} GOARCH=${{matrix.arch}} CGO_ENABLED=0 go build -ldflags="-X digger/pkg/utils.version=${{ github.event.release.tag_name }}" -o digger ./cli/cmd/digger
+
+      - name: Publish linux-x64 exec to github
+        id: upload-release-asset-linux-x64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: 'digger'
+          asset_name: digger-cli-${{matrix.os}}-${{matrix.arch}}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/cli_release_multiarch.yml
+++ b/.github/workflows/cli_release_multiarch.yml
@@ -1,4 +1,4 @@
-name: release
+name: release cli multi architecture
 on:
   release:
     branches:


### PR DESCRIPTION
Addressing https://github.com/diggerhq/digger/issues/1178

In a separate PR we should probably remove `.github/workflows/cli_release.yml` workflow which is redundant, but we will also have to update the action to use the right architecture which I'm considering a separate piece of work

Tested in https://github.com/diggerhq/digger/releases/tag/vtest-cli-multiarch and seems to work https://github.com/diggerhq/digger/actions/runs/8064256364