### PR TITLE
Fix terragrunt version syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
     - name: Setup Terragrunt
       uses: autero1/action-terragrunt@v3.0.2
       with:
-        terragrunt_version: ${{ inputs.terragrunt-version }}
+        terragrunt-version: ${{ inputs.terragrunt-version }}
       if: inputs.setup-terragrunt == 'true'
 
     - name: Setup OpenTofu


### PR DESCRIPTION
Correct, terragrunt action has introduced this breaking change in the most recent version https://github.com/autero1/action-terragrunt/pull/345