### PR TITLE
do not autogenerate projects in set-status

### DIFF
--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -482,13 +482,18 @@ func CreateRunForProject(c *gin.Context) {
 
 func AutomergePRforBatchIfEnabled(gh utils.GithubClientProvider, batch *models.DiggerBatch) error {
 	diggerYmlString := batch.DiggerConfig
-	diggerConfig, _, _, err := digger_config.LoadDiggerConfigFromString(diggerYmlString, "./")
+	diggerConfigYml, err := digger_config.LoadDiggerConfigYamlFromString(diggerYmlString)
 	if err != nil {
 		log.Printf("Error loading digger config from batch: %v", err)
 		return fmt.Errorf("error loading digger config from batch: %v", err)
-
 	}
-	if batch.Status == orchestrator_scheduler.BatchJobSucceeded && batch.BatchType == orchestrator_scheduler.BatchTypeApply && diggerConfig.AutoMerge == true {
+	var automerge bool
+	if diggerConfigYml.AutoMerge != nil {
+		automerge = *diggerConfigYml.AutoMerge
+	} else {
+		automerge = false
+	}
+	if batch.Status == orchestrator_scheduler.BatchJobSucceeded && batch.BatchType == orchestrator_scheduler.BatchTypeApply && automerge == true {
 		ghService, _, err := utils.GetGithubService(
 			gh,
 			batch.GithubInstallationId,


### PR DESCRIPTION
fixing issue that in the backend /set-status endpoint for project it tried to laod diggerConfig from string and traverse directory structure which is not present. Instead now we will call the lowlevel version of the loader and check for the exact flag we need