### PR TITLE
Add SHA256 checksums to release artifacts

### DIFF
--- a/.github/workflows/backend_build_prod_ecr.yml
+++ b/.github/workflows/backend_build_prod_ecr.yml
@@ -1,7 +1,9 @@
+---
 name: Backend Build&Push to Prod ECR
-on:
+
+"on":
   push:
-    branches: [ 'develop' ]
+    branches: ['develop']
 
 permissions:
   id-token: write

--- a/.github/workflows/backend_docker_release.yml
+++ b/.github/workflows/backend_docker_release.yml
@@ -1,8 +1,10 @@
+---
 name: Backend Publish docker image
 
-on:
+"on":
   release:
-    types: ['released']
+    types:
+      - 'released'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/backend_release.yml
+++ b/.github/workflows/backend_release.yml
@@ -3,7 +3,8 @@ name: Backend release
 
 "on":
   release:
-    types: [released]
+    types:
+      - 'released'
 
 jobs:
   binary:
@@ -16,10 +17,13 @@ jobs:
             arch: arm
           - os: darwin
             arch: "386"
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Build and publish binary artifact to GitHub
         id: build-and-release-binary
         uses: wangyoucao577/go-release-action@8fa1e8368c8465264d64e0198208e10f71474c87  # v1.50

--- a/.github/workflows/backend_release.yml
+++ b/.github/workflows/backend_release.yml
@@ -1,41 +1,38 @@
+---
 name: Backend release
-on:
+
+"on":
   release:
     types: [released]
+
 jobs:
   binary:
     strategy:
       matrix:
-        arch: [arm, arm64, amd64, 386]
+        arch: [arm, arm64, amd64, "386"]
         os: [linux, darwin, freebsd, windows]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
-            arch: 386
-
+            arch: "386"
     runs-on: ubuntu-latest
     steps:
-      - name: Download Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.1
-        id: go
-
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Build
-        run: |
-          echo "Tag that is going to be used as digger version: ${{ github.event.release.tag_name }}"
-          env GOOS=${{matrix.os}} GOARCH=${{matrix.arch}} CGO_ENABLED=0 go build -ldflags="-X digger/pkg/utils.version=${{ github.event.release.tag_name }}" -o digger-api ./backend
-      - name: Publish linux-x64 exec to github
-        id: upload-release-asset-linux-x64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and publish binary artifact to GitHub
+        id: build-and-release-binary
+        uses: wangyoucao577/go-release-action@8fa1e8368c8465264d64e0198208e10f71474c87  # v1.50
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: 'digger-api'
-          asset_name: digger-api-${{matrix.os}}-${{matrix.arch}}
-          asset_content_type: application/octet-stream
-
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.os }}
+          goarch: ${{ matrix.arch }}
+          goversion: 1.21.1
+          project_path: ./backend
+          binary_name: digger-api
+          pre_command: export CGO_ENABLED=0
+          ldflags: ${{ matrix.ldflags }}
+          sha256sum: true
+          md5sum: false
+          asset_name: "digger-api-${{matrix.os}}-${{matrix.arch}}"
+          compress_assets: "OFF"

--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -1,16 +1,17 @@
+---
 name: Backend Go Tests
-on:
+
+"on":
   push:
-    branches: [ develop ]
+    branches: ['develop']
   pull_request:
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
 
+    steps:
       - name: Download Go
         uses: actions/setup-go@v5
         with:
@@ -38,6 +39,3 @@ jobs:
         env:
           GITHUB_PAT_TOKEN: ${{ secrets.TOKEN_GITHUB }}
         working-directory: backend
-
-
-          

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -1,12 +1,17 @@
+---
 name: release cli
-on:
+
+"on":
   release:
     branches:
       - 'go'
-    types: [released]
+    types:
+      - 'released'
+
 jobs:
   binary:
     runs-on: ubuntu-latest
+
     steps:
       - name: Download Go
         uses: actions/setup-go@v5
@@ -16,6 +21,7 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Build
         run: |
           echo "Tag that is going to be used as digger version: ${{ github.event.release.tag_name }}"

--- a/.github/workflows/cli_release_multiarch.yml
+++ b/.github/workflows/cli_release_multiarch.yml
@@ -5,7 +5,8 @@ name: release cli multi architecture
   release:
     branches:
       - 'go'
-    types: [released]
+    types:
+      - 'released'
 
 jobs:
   binary:
@@ -18,10 +19,13 @@ jobs:
             arch: arm
           - os: darwin
             arch: "386"
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Build and publish binary artifact to GitHub
         id: build-and-release-binary
         uses: wangyoucao577/go-release-action@8fa1e8368c8465264d64e0198208e10f71474c87  # v1.50

--- a/.github/workflows/cli_release_multiarch.yml
+++ b/.github/workflows/cli_release_multiarch.yml
@@ -1,44 +1,40 @@
+---
 name: release cli multi architecture
-on:
+
+"on":
   release:
     branches:
       - 'go'
     types: [released]
+
 jobs:
   binary:
     strategy:
       matrix:
-        arch: [arm, arm64, amd64, 386]
+        arch: [arm, arm64, amd64, "386"]
         os: [linux, darwin, freebsd, windows]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
-            arch: 386
-
+            arch: "386"
     runs-on: ubuntu-latest
-
     steps:
-      - name: Download Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.1
-        id: go
-
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Build
-        run: |
-          echo "Tag that is going to be used as digger version: ${{ github.event.release.tag_name }}"
-          env GOOS=${{matrix.os}} GOARCH=${{matrix.arch}} CGO_ENABLED=0 go build -ldflags="-X digger/pkg/utils.version=${{ github.event.release.tag_name }}" -o digger ./cli/cmd/digger
-
-      - name: Publish linux-x64 exec to github
-        id: upload-release-asset-linux-x64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and publish binary artifact to GitHub
+        id: build-and-release-binary
+        uses: wangyoucao577/go-release-action@8fa1e8368c8465264d64e0198208e10f71474c87  # v1.50
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: 'digger'
-          asset_name: digger-cli-${{matrix.os}}-${{matrix.arch}}
-          asset_content_type: application/octet-stream
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.os }}
+          goarch: ${{ matrix.arch }}
+          goversion: 1.21.1
+          project_path: ./cli/cmd/digger
+          binary_name: digger
+          pre_command: export CGO_ENABLED=0
+          ldflags: ${{ matrix.ldflags }}
+          sha256sum: true
+          md5sum: false
+          asset_name: "digger-cli-${{matrix.os}}-${{matrix.arch}}"
+          compress_assets: "OFF"

--- a/.github/workflows/cli_test.yml
+++ b/.github/workflows/cli_test.yml
@@ -1,15 +1,16 @@
+---
 name: Cli tests
-on: 
+
+"on":
   push:
   pull_request:
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
 
+    steps:
       - name: Download Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -1,7 +1,9 @@
+---
 name: Cli e2e tests
-on:
+
+"on":
   push:
-    branches: [ 'develop' ]
+    branches: ['develop']
 
 jobs:
   build:
@@ -11,8 +13,8 @@ jobs:
 
     name: Build
     runs-on: ubuntu-latest
-    steps:
 
+    steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
@@ -51,6 +53,3 @@ jobs:
           GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET: gcp-plan-artefacts
           AWS_S3_BUCKET: digger-tests-bucket
           AWS_REGION: us-east-1
-
-
-

--- a/.github/workflows/dgctl_release.yml
+++ b/.github/workflows/dgctl_release.yml
@@ -1,20 +1,24 @@
+---
 name: release dgctl
-on:
+
+"on":
   release:
     branches:
       - 'go'
-    types: [released]
+    types:
+      - 'released'
+
 jobs:
   binary:
     strategy:
       matrix:
-        arch: [arm, arm64, amd64, 386]
+        arch: [arm, arm64, amd64, "386"]
         os: [linux, darwin, freebsd, windows]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
-            arch: 386
+            arch: "386"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ee_backend_docker_release.yml
+++ b/.github/workflows/ee_backend_docker_release.yml
@@ -1,8 +1,10 @@
+---
 name: EE Backend Publish docker image
 
-on:
+"on":
   release:
-    types: ['released']
+    types:
+      - 'released'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/ee_backend_test.yml
+++ b/.github/workflows/ee_backend_test.yml
@@ -1,16 +1,17 @@
+---
 name: EE Backend Go Tests
-on:
+
+"on":
   push:
-    branches: [ develop ]
+    branches: ['develop']
   pull_request:
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
 
+    steps:
       - name: Download Go
         uses: actions/setup-go@v5
         with:
@@ -38,6 +39,3 @@ jobs:
         env:
           GITHUB_PAT_TOKEN: ${{ secrets.TOKEN_GITHUB }}
         working-directory: ee/backend
-
-
-

--- a/.github/workflows/ee_cli_release.yml
+++ b/.github/workflows/ee_cli_release.yml
@@ -1,12 +1,17 @@
+---
 name: release ee cli
-on:
+
+"on":
   release:
     branches:
       - 'go'
-    types: [released]
+    types:
+      - 'released'
+
 jobs:
   binary:
     runs-on: ubuntu-latest
+
     steps:
       - name: Download Go
         uses: actions/setup-go@v5
@@ -16,6 +21,7 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Build
         run: |
           echo "Tag that is going to be used as digger version: ${{ github.event.release.tag_name }}"

--- a/.github/workflows/ee_cli_release_multiarch.yml
+++ b/.github/workflows/ee_cli_release_multiarch.yml
@@ -1,20 +1,24 @@
+---
 name: EE release cli multi architecture
-on:
+
+"on":
   release:
     branches:
       - 'go'
-    types: [released]
+    types:
+      - 'released'
+
 jobs:
   binary:
     strategy:
       matrix:
-        arch: [arm, arm64, amd64, 386]
+        arch: [arm, arm64, amd64, "386"]
         os: [linux, darwin, freebsd, windows]
         exclude:
           - os: darwin
             arch: arm
           - os: darwin
-            arch: 386
+            arch: "386"
 
     runs-on: ubuntu-latest
 
@@ -27,6 +31,7 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Build
         run: |
           echo "Tag that is going to be used as digger version: ${{ github.event.release.tag_name }}"

--- a/.github/workflows/ee_cli_test.yml
+++ b/.github/workflows/ee_cli_test.yml
@@ -1,15 +1,16 @@
+---
 name: EE Cli tests
-on:
+
+"on":
   push:
   pull_request:
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
 
+    steps:
       - name: Download Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ee_tasks_release.yml
+++ b/.github/workflows/ee_tasks_release.yml
@@ -1,8 +1,10 @@
+---
 name: EE Tasks Publish docker image
 
-on:
+"on":
   release:
-    types: ['released']
+    types:
+      - 'released'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/latest_tag.yml
+++ b/.github/workflows/latest_tag.yml
@@ -1,13 +1,15 @@
+---
 name: Update latest tag for every new latest release
 
-on:
+"on":
   release:
     types:
-      - released
+      - 'released'
 
 jobs:
   update_latest_tag:
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -20,8 +22,8 @@ jobs:
           latest_release=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
           echo "Latest release: $latest_release"
           echo "Current release: ${{ github.ref }}"
-          if [[ "refs/tags/$latest_release" == "${{ github.ref }}" ]]; then            
-            echo "is_latest=true" >> $GITHUB_OUTPUT            
+          if [[ "refs/tags/$latest_release" == "${{ github.ref }}" ]]; then
+            echo "is_latest=true" >> $GITHUB_OUTPUT
           else
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/libs_test.yml
+++ b/.github/workflows/libs_test.yml
@@ -1,14 +1,16 @@
+---
 name: Libs tests
-on:
+
+"on":
   push:
-    branches: [ 'develop' ]
+    branches: ['develop']
   pull_request:
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
+
     steps:
       - name: Download Go
         uses: actions/setup-go@v5

--- a/.github/workflows/misc_top_issues.yml
+++ b/.github/workflows/misc_top_issues.yml
@@ -1,14 +1,16 @@
-
+---
 name: Top issues updater
-on:
+
+"on":
   schedule:
-    - cron: "0 * * * *" # every hour
+    - cron: "0 * * * *"  # every hour
   workflow_dispatch:
 
 jobs:
   get-top-issues:
     if: github.repository_owner == 'diggerhq'
     runs-on: ubuntu-latest
+
     steps:
       - name: update-top-issues
         uses: diggerhq/top-issues@main

--- a/.github/workflows/tasks_release.yml
+++ b/.github/workflows/tasks_release.yml
@@ -1,8 +1,10 @@
+---
 name: Tasks Publish docker image
 
-on:
+"on":
   release:
-    types: ['released']
+    types:
+      - 'released'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/tasks_run_test.yml
+++ b/.github/workflows/tasks_run_test.yml
@@ -1,13 +1,15 @@
+---
 name: Tasks run tests
-on:
+
+"on":
   push:
   pull_request:
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
+
     steps:
       - name: Download Go
         uses: actions/setup-go@v5
@@ -23,7 +25,6 @@ jobs:
           pwd
           go get -v ./...
         working-directory: backend/tasks
-
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
This replaces the action used in release workflows with a Go-specific release action, but the build and release process more or less remains the same as before. We effectively only add an additional checksum generation and publish step with this update.

We also remove `cli_release.yml` because it builds `digger-cli-Linux-X64` which is the same as the `digger-cli-linux-amd64` artifact built by `cli_release_multiarch.yml`. If this isn't desired, we can remove that commit on request.