### PR TITLE
Fix plan artefact storage with gcp buckets

### DIFF
--- a/.github/workflows/cli_test.yml
+++ b/.github/workflows/cli_test.yml
@@ -27,13 +27,11 @@ jobs:
 
       - name: Deps
         run: |
-          pwd
           go get -v ./...
         working-directory: cli
 
       - name: Build
         run: |
-          pwd
           go build -v ./cmd/digger
         working-directory: cli
 

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Download Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -34,12 +34,6 @@ jobs:
           go get -v ./...
         working-directory: cli_e2e
 
-      - name: Build
-        run: |
-          pwd
-          go build -v ./cmd/digger
-        working-directory: cli_2e2
-
       - name: Test
         run: go test -v ./...
         working-directory: cli_e2e

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -40,11 +40,6 @@ jobs:
           go get -v ./...
         working-directory: cli
 
-      - name: Build cli
-        run: |
-          go build -v ./cmd/digger
-        working-directory: cli
-
       - name: Deps e2e
         run: |
           go get -v ./...

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -30,6 +30,9 @@ jobs:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: true
 
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -1,8 +1,6 @@
 name: Cli e2e tests
 on:
   push:
-    branches:
-      - "feat/plan-artefacts-gcp-implementation"
   pull_request:
     types: [opened, reopened]
 
@@ -23,7 +21,7 @@ jobs:
       - name: Download Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.1
+          go-version: 1.22.0
         id: go
 
       - id: 'gcp_auth'

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: 1.21.1
         id: go
 
-      - id: 'gcp auth'
+      - id: 'gcp_auth'
         uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -35,9 +35,18 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Deps
+      - name: Deps cli
         run: |
-          pwd
+          go get -v ./...
+        working-directory: cli
+
+      - name: Build cli
+        run: |
+          go build -v ./cmd/digger
+        working-directory: cli
+
+      - name: Deps e2e
+        run: |
           go get -v ./...
         working-directory: cli_e2e
 

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -1,6 +1,8 @@
 name: Cli e2e tests
 on:
   push:
+    branches:
+      - "feat/plan-artefacts-gcp-implementation"
   pull_request:
     types: [opened, reopened]
 

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -25,7 +25,7 @@ jobs:
         id: go
 
       - id: 'gcp_auth'
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
           create_credentials_file: true

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -44,7 +44,7 @@ jobs:
         run: go test -v ./...
         working-directory: cli_e2e
         env:
-          GOOGLE_STORAGE_BUCKET:
+          GOOGLE_STORAGE_BUCKET: gcp-plan-artefacts
 
 
 

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -9,6 +9,10 @@ on:
 jobs:
 
   build:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -24,15 +24,6 @@ jobs:
           go-version: 1.22.0
         id: go
 
-      - id: 'gcp_auth'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
-          create_credentials_file: true
-
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
@@ -47,9 +38,12 @@ jobs:
         working-directory: cli_e2e
 
       - name: Test
-        run: go test -v ./...
+        run: |
+          echo '${{ secrets.GCP_CREDENTIALS }}' > /tmp/gcp.json
+          go test -v ./...
         working-directory: cli_e2e
         env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp.json
           GOOGLE_STORAGE_BUCKET: gcp-plan-artefacts
 
 

--- a/.github/workflows/cli_test_e2e.yml
+++ b/.github/workflows/cli_test_e2e.yml
@@ -1,0 +1,48 @@
+name: Cli e2e tests
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.1
+        id: go
+
+      - id: 'gcp auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+          create_credentials_file: true
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Deps
+        run: |
+          pwd
+          go get -v ./...
+        working-directory: cli_e2e
+
+      - name: Build
+        run: |
+          pwd
+          go build -v ./cmd/digger
+        working-directory: cli_2e2
+
+      - name: Test
+        run: go test -v ./...
+        working-directory: cli_e2e
+        env:
+          GOOGLE_STORAGE_BUCKET:
+
+
+

--- a/cli/pkg/core/execution/execution.go
+++ b/cli/pkg/core/execution/execution.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/diggerhq/digger/cli/pkg/core/locking"
@@ -122,7 +123,7 @@ type PlanPathProvider interface {
 }
 
 type ProjectPathProvider struct {
-	PRNumber         string
+	PRNumber         *int
 	ProjectPath      string
 	ProjectNamespace string
 	ProjectName      string
@@ -133,8 +134,9 @@ func (d ProjectPathProvider) ArtifactName() string {
 }
 
 func (d ProjectPathProvider) PlanFileName() string {
-	if d.PRNumber != "" {
-		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + d.PRNumber + "-" + d.ProjectName + ".tfplan"
+	if d.PRNumber != nil {
+		prNumber := strconv.Itoa(*d.PRNumber)
+		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + prNumber + "-" + d.ProjectName + ".tfplan"
 	} else {
 		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + d.ProjectName + ".tfplan"
 	}

--- a/cli/pkg/core/execution/execution.go
+++ b/cli/pkg/core/execution/execution.go
@@ -161,7 +161,7 @@ func (d DiggerExecutor) RetrievePlanJson() (string, error) {
 	}
 	if storedPlanExists {
 		log.Printf("Pre-apply plan retrieval: stored plan exists in artefact, retrieving")
-		storedPlanPath, err := planStorage.RetrievePlan(planPathProvider.LocalPlanFilePath(), planPathProvider.ArtifactName())
+		storedPlanPath, err := planStorage.RetrievePlan(planPathProvider.LocalPlanFilePath(), planPathProvider.ArtifactName(), planPathProvider.PlanFileName())
 		if err != nil {
 			return "", fmt.Errorf("failed to retrieve stored plan path. %v", err)
 		}
@@ -292,7 +292,7 @@ func (d DiggerExecutor) Apply() (bool, string, error) {
 	var plansFilename *string
 	if d.PlanStorage != nil {
 		var err error
-		plansFilename, err = d.PlanStorage.RetrievePlan(d.PlanPathProvider.LocalPlanFilePath(), d.PlanPathProvider.ArtifactName())
+		plansFilename, err = d.PlanStorage.RetrievePlan(d.PlanPathProvider.LocalPlanFilePath(), d.PlanPathProvider.ArtifactName(), d.PlanPathProvider.PlanFileName())
 		if err != nil {
 			return false, "", fmt.Errorf("error retrieving plan: %v", err)
 		}

--- a/cli/pkg/core/execution/execution.go
+++ b/cli/pkg/core/execution/execution.go
@@ -122,6 +122,7 @@ type PlanPathProvider interface {
 }
 
 type ProjectPathProvider struct {
+	PRNumber         string
 	ProjectPath      string
 	ProjectNamespace string
 	ProjectName      string
@@ -132,7 +133,12 @@ func (d ProjectPathProvider) ArtifactName() string {
 }
 
 func (d ProjectPathProvider) PlanFileName() string {
-	return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + d.ProjectName + ".tfplan"
+	if d.PRNumber != "" {
+		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + d.PRNumber + "-" + d.ProjectName + ".tfplan"
+	} else {
+		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + d.ProjectName + ".tfplan"
+	}
+
 }
 
 func (d ProjectPathProvider) LocalPlanFilePath() string {

--- a/cli/pkg/core/execution/execution.go
+++ b/cli/pkg/core/execution/execution.go
@@ -155,7 +155,7 @@ func (d DiggerExecutor) RetrievePlanJson() (string, error) {
 	executor := d
 	planStorage := executor.PlanStorage
 	planPathProvider := executor.PlanPathProvider
-	storedPlanExists, err := planStorage.PlanExists(planPathProvider.ArtifactName())
+	storedPlanExists, err := planStorage.PlanExists(planPathProvider.ArtifactName(), planPathProvider.PlanFileName())
 	if err != nil {
 		return "", fmt.Errorf("failed to check if stored plan exists. %v", err)
 	}

--- a/cli/pkg/core/storage/plan_storage.go
+++ b/cli/pkg/core/storage/plan_storage.go
@@ -3,7 +3,7 @@ package storage
 type PlanStorage interface {
 	StorePlan(localPlanFilePath string, storedPlanFilePath string) error
 	StorePlanFile(fileContents []byte, artifactName string, storedPlanFilePath string) error
-	RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error)
-	DeleteStoredPlan(storedPlanFilePath string) error
+	RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error)
+	DeleteStoredPlan(artifactName string, storedPlanFilePath string) error
 	PlanExists(artifactName string, storedPlanFilePath string) (bool, error)
 }

--- a/cli/pkg/core/storage/plan_storage.go
+++ b/cli/pkg/core/storage/plan_storage.go
@@ -2,8 +2,8 @@ package storage
 
 type PlanStorage interface {
 	StorePlan(localPlanFilePath string, storedPlanFilePath string) error
-	StorePlanFile(fileContents []byte, artifactName string, fileName string) error
+	StorePlanFile(fileContents []byte, artifactName string, storedPlanFilePath string) error
 	RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error)
 	DeleteStoredPlan(storedPlanFilePath string) error
-	PlanExists(storedPlanFilePath string) (bool, error)
+	PlanExists(artifactName string, storedPlanFilePath string) (bool, error)
 }

--- a/cli/pkg/core/storage/plan_storage.go
+++ b/cli/pkg/core/storage/plan_storage.go
@@ -1,7 +1,6 @@
 package storage
 
 type PlanStorage interface {
-	StorePlan(localPlanFilePath string, storedPlanFilePath string) error
 	StorePlanFile(fileContents []byte, artifactName string, storedPlanFilePath string) error
 	RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error)
 	DeleteStoredPlan(artifactName string, storedPlanFilePath string) error

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -443,7 +443,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		}
 
 		if planStorage != nil {
-			err = planStorage.DeleteStoredPlan(planPathProvider.StoredPlanFilePath())
+			err = planStorage.DeleteStoredPlan(planPathProvider.ArtifactName(), planPathProvider.PlanFileName())
 			if err != nil {
 				log.Printf("failed to delete stored plan file '%v':  %v", planPathProvider.StoredPlanFilePath(), err)
 			}

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -106,7 +106,7 @@ func RunJobs(
 				continue
 			}
 
-			executorResult, output, err := run(command, job, policyChecker, orgService, SCMOrganisation, SCMrepository, *job.PullRequestNumber, job.RequestedBy, reporter, lock, prService, job.Namespace, workingDir, planStorage, appliesPerProject)
+			executorResult, output, err := run(command, job, policyChecker, orgService, SCMOrganisation, SCMrepository, job.PullRequestNumber, job.RequestedBy, reporter, lock, prService, job.Namespace, workingDir, planStorage, appliesPerProject)
 			if err != nil {
 				reportErr := backendApi.ReportProjectRun(SCMOrganisation+"-"+SCMrepository, job.ProjectName, runStartedAt, time.Now(), "FAILED", command, output)
 				if reportErr != nil {

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -106,7 +106,7 @@ func RunJobs(
 				continue
 			}
 
-			executorResult, output, err := run(command, job, policyChecker, orgService, SCMOrganisation, SCMrepository, string(*job.PullRequestNumber), job.RequestedBy, reporter, lock, prService, job.Namespace, workingDir, planStorage, appliesPerProject)
+			executorResult, output, err := run(command, job, policyChecker, orgService, SCMOrganisation, SCMrepository, *job.PullRequestNumber, job.RequestedBy, reporter, lock, prService, job.Namespace, workingDir, planStorage, appliesPerProject)
 			if err != nil {
 				reportErr := backendApi.ReportProjectRun(SCMOrganisation+"-"+SCMrepository, job.ProjectName, runStartedAt, time.Now(), "FAILED", command, output)
 				if reportErr != nil {
@@ -181,7 +181,7 @@ func reportPolicyError(projectName string, command string, requestedBy string, r
 	return msg
 }
 
-func run(command string, job orchestrator.Job, policyChecker policy.Checker, orgService orchestrator.OrgService, SCMOrganisation string, SCMrepository string, PRNumber string, requestedBy string, reporter core_reporting.Reporter, lock core_locking.Lock, prService orchestrator.PullRequestService, projectNamespace string, workingDir string, planStorage storage.PlanStorage, appliesPerProject map[string]bool) (*execution.DiggerExecutorResult, string, error) {
+func run(command string, job orchestrator.Job, policyChecker policy.Checker, orgService orchestrator.OrgService, SCMOrganisation string, SCMrepository string, PRNumber *int, requestedBy string, reporter core_reporting.Reporter, lock core_locking.Lock, prService orchestrator.PullRequestService, projectNamespace string, workingDir string, planStorage storage.PlanStorage, appliesPerProject map[string]bool) (*execution.DiggerExecutorResult, string, error) {
 	log.Printf("Running '%s' for project '%s' (workflow: %s)\n", command, job.ProjectName, job.ProjectWorkflow)
 
 	allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(orgService, &prService, SCMOrganisation, SCMrepository, job.ProjectName, command, job.PullRequestNumber, requestedBy, []string{})
@@ -557,18 +557,11 @@ func RunJob(
 
 		commandRunner := runners.CommandRunner{}
 
-		var prNumber string
-		if job.PullRequestNumber != nil {
-			prNumber = string(*job.PullRequestNumber)
-		} else {
-			prNumber = ""
-		}
-
 		planPathProvider := execution.ProjectPathProvider{
 			ProjectPath:      projectPath,
 			ProjectNamespace: repo,
 			ProjectName:      job.ProjectName,
-			PRNumber:         prNumber,
+			PRNumber:         job.PullRequestNumber,
 		}
 
 		diggerExecutor := execution.DiggerExecutor{

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -445,7 +445,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		if planStorage != nil {
 			err = planStorage.DeleteStoredPlan(planPathProvider.ArtifactName(), planPathProvider.PlanFileName())
 			if err != nil {
-				log.Printf("failed to delete stored plan file '%v':  %v", planPathProvider.StoredPlanFilePath(), err)
+				log.Printf("failed to delete stored plan file '%v':  %v", planPathProvider.PlanFileName(), err)
 			}
 		}
 	case "digger lock":

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -443,9 +443,9 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		}
 
 		if planStorage != nil {
-			err = planStorage.DeleteStoredPlan(planPathProvider.ArtifactName(), planPathProvider.PlanFileName())
+			err = planStorage.DeleteStoredPlan(planPathProvider.ArtifactName(), planPathProvider.StoredPlanFilePath())
 			if err != nil {
-				log.Printf("failed to delete stored plan file '%v':  %v", planPathProvider.PlanFileName(), err)
+				log.Printf("failed to delete stored plan file '%v':  %v", planPathProvider.StoredPlanFilePath(), err)
 			}
 		}
 	case "digger lock":

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -211,7 +211,7 @@ func (m *MockPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
 	return nil
 }
 
-func (m *MockPlanStorage) PlanExists(storedPlanFilePath string) (bool, error) {
+func (m *MockPlanStorage) PlanExists(artifactName string, storedPlanFilePath string) (bool, error) {
 	m.Commands = append(m.Commands, RunInfo{"PlanExists", storedPlanFilePath, time.Now()})
 	return false, nil
 }

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -201,12 +201,12 @@ func (m *MockPlanStorage) StorePlanFile(fileContents []byte, artifactName string
 	return nil
 }
 
-func (m *MockPlanStorage) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
+func (m *MockPlanStorage) RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error) {
 	m.Commands = append(m.Commands, RunInfo{"RetrievePlan", localPlanFilePath, time.Now()})
 	return nil, nil
 }
 
-func (m *MockPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
+func (m *MockPlanStorage) DeleteStoredPlan(artifactName string, storedPlanFilePath string) error {
 	m.Commands = append(m.Commands, RunInfo{"DeleteStoredPlan", storedPlanFilePath, time.Now()})
 	return nil
 }

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -191,11 +191,6 @@ type MockPlanStorage struct {
 	Commands []RunInfo
 }
 
-func (m *MockPlanStorage) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
-	m.Commands = append(m.Commands, RunInfo{"StorePlan", localPlanFilePath, time.Now()})
-	return nil
-}
-
 func (m *MockPlanStorage) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
 	m.Commands = append(m.Commands, RunInfo{"StorePlanFile", artifactName, time.Now()})
 	return nil

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -220,18 +220,13 @@ func (m MockPlanPathProvider) ArtifactName() string {
 	return "plan"
 }
 
-func (m MockPlanPathProvider) PlanFileName() string {
-	m.Commands = append(m.Commands, RunInfo{"PlanFileName", "", time.Now()})
+func (m MockPlanPathProvider) StoredPlanFilePath() string {
+	m.Commands = append(m.Commands, RunInfo{"StoredPlanFilePath", "", time.Now()})
 	return "plan"
 }
 
 func (m MockPlanPathProvider) LocalPlanFilePath() string {
 	m.Commands = append(m.Commands, RunInfo{"LocalPlanFilePath", "", time.Now()})
-	return "plan"
-}
-
-func (m MockPlanPathProvider) StoredPlanFilePath() string {
-	m.Commands = append(m.Commands, RunInfo{"StoredPlanFilePath", "", time.Now()})
 	return "plan"
 }
 

--- a/cli/pkg/storage/plan_storage.go
+++ b/cli/pkg/storage/plan_storage.go
@@ -79,7 +79,7 @@ func (psg *PlanStorageGcp) StorePlanFile(fileContents []byte, artifactName strin
 	return nil
 }
 
-func (psg *PlanStorageGcp) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
+func (psg *PlanStorageGcp) RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error) {
 	obj := psg.Bucket.Object(storedPlanFilePath)
 	rc, err := obj.NewReader(psg.Context)
 	if err != nil {
@@ -103,7 +103,7 @@ func (psg *PlanStorageGcp) RetrievePlan(localPlanFilePath string, storedPlanFile
 	return &fileName, nil
 }
 
-func (psg *PlanStorageGcp) DeleteStoredPlan(storedPlanFilePath string) error {
+func (psg *PlanStorageGcp) DeleteStoredPlan(artifactName string, storedPlanFilePath string) error {
 	obj := psg.Bucket.Object(storedPlanFilePath)
 	err := obj.Delete(psg.Context)
 
@@ -199,8 +199,8 @@ func doRequest(method, url string, headers map[string]string, body []byte) (*htt
 	return resp, nil
 }
 
-func (gps *GithubPlanStorage) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
-	plansFilename, err := gps.DownloadLatestPlans(storedPlanFilePath)
+func (gps *GithubPlanStorage) RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error) {
+	plansFilename, err := gps.DownloadLatestPlans(artifactName)
 
 	if err != nil {
 		return nil, fmt.Errorf("error downloading plan: %v", err)
@@ -235,7 +235,7 @@ func (gps *GithubPlanStorage) PlanExists(artifactName string, storedPlanFilePath
 	return true, nil
 }
 
-func (gps *GithubPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
+func (gps *GithubPlanStorage) DeleteStoredPlan(artifactName string, storedPlanFilePath string) error {
 	return nil
 }
 

--- a/cli/pkg/storage/plan_storage.go
+++ b/cli/pkg/storage/plan_storage.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 
 	"cloud.google.com/go/storage"
@@ -67,7 +68,15 @@ func (psg *PlanStorageGcp) StorePlan(localPlanFilePath string, storedPlanFilePat
 }
 
 func (psg *PlanStorageGcp) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
-	// TODO: implement me
+	fullPath := path.Join(artifactName, fileName)
+	obj := psg.Bucket.Object(fullPath)
+	writer := obj.NewWriter(context.Background())
+	defer writer.Close()
+
+	if _, err := writer.Write(fileContents); err != nil {
+		log.Printf("Failed to write file to bucket: %v", err)
+		return err
+	}
 	return nil
 }
 

--- a/cli/pkg/storage/plan_storage.go
+++ b/cli/pkg/storage/plan_storage.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 
 	"cloud.google.com/go/storage"
@@ -68,7 +67,7 @@ func (psg *PlanStorageGcp) StorePlan(localPlanFilePath string, storedPlanFilePat
 }
 
 func (psg *PlanStorageGcp) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
-	fullPath := path.Join(artifactName, fileName)
+	fullPath := artifactName
 	obj := psg.Bucket.Object(fullPath)
 	writer := obj.NewWriter(context.Background())
 	defer writer.Close()

--- a/cli/pkg/storage/plan_storage.go
+++ b/cli/pkg/storage/plan_storage.go
@@ -67,7 +67,7 @@ func (psg *PlanStorageGcp) StorePlan(localPlanFilePath string, storedPlanFilePat
 }
 
 func (psg *PlanStorageGcp) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
-	fullPath := artifactName
+	fullPath := fileName
 	obj := psg.Bucket.Object(fullPath)
 	writer := obj.NewWriter(context.Background())
 	defer writer.Close()

--- a/cli/pkg/storage/plan_storage.go
+++ b/cli/pkg/storage/plan_storage.go
@@ -44,28 +44,6 @@ func (psg *PlanStorageGcp) PlanExists(artifactName string, storedPlanFilePath st
 	return true, nil
 }
 
-func (psg *PlanStorageGcp) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
-	file, err := os.Open(localPlanFilePath)
-	if err != nil {
-		return fmt.Errorf("unable to open file: %v", err)
-	}
-	defer file.Close()
-
-	obj := psg.Bucket.Object(storedPlanFilePath)
-	wc := obj.NewWriter(psg.Context)
-
-	if _, err = io.Copy(wc, file); err != nil {
-		wc.Close()
-		return fmt.Errorf("unable to write data to bucket: %v", err)
-	}
-
-	if err := wc.Close(); err != nil {
-		return fmt.Errorf("unable to close writer: %v", err)
-	}
-
-	return nil
-}
-
 func (psg *PlanStorageGcp) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
 	fullPath := fileName
 	obj := psg.Bucket.Object(fullPath)
@@ -110,11 +88,6 @@ func (psg *PlanStorageGcp) DeleteStoredPlan(artifactName string, storedPlanFileP
 	if err != nil {
 		return fmt.Errorf("unable to delete file '%v' from bucket: %v", storedPlanFilePath, err)
 	}
-	return nil
-}
-
-func (gps *GithubPlanStorage) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
-	_ = fmt.Sprintf("Skipping storing plan %s. It should be achieved using actions/upload-artifact@v3", localPlanFilePath)
 	return nil
 }
 

--- a/cli/pkg/utils/mocks.go
+++ b/cli/pkg/utils/mocks.go
@@ -146,11 +146,11 @@ func (t *MockPlanStorage) StorePlanFile(fileContents []byte, artifactName string
 	return nil
 }
 
-func (t MockPlanStorage) RetrievePlan(localPlanFilePath string, storedPlanFilePath string) (*string, error) {
+func (t MockPlanStorage) RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error) {
 	return nil, nil
 }
 
-func (t MockPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
+func (t MockPlanStorage) DeleteStoredPlan(artifactName string, storedPlanFilePath string) error {
 	return nil
 }
 

--- a/cli/pkg/utils/mocks.go
+++ b/cli/pkg/utils/mocks.go
@@ -138,10 +138,6 @@ func (t MockPullRequestManager) SetOutput(prNumber int, key string, value string
 type MockPlanStorage struct {
 }
 
-func (t MockPlanStorage) StorePlan(localPlanFilePath string, storedPlanFilePath string) error {
-	return nil
-}
-
 func (t *MockPlanStorage) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
 	return nil
 }

--- a/cli/pkg/utils/mocks.go
+++ b/cli/pkg/utils/mocks.go
@@ -154,7 +154,7 @@ func (t MockPlanStorage) DeleteStoredPlan(storedPlanFilePath string) error {
 	return nil
 }
 
-func (t MockPlanStorage) PlanExists(storedPlanFilePath string) (bool, error) {
+func (t MockPlanStorage) PlanExists(artifactName string, storedPlanFilePath string) (bool, error) {
 	return false, nil
 }
 

--- a/cli_e2e/go.mod
+++ b/cli_e2e/go.mod
@@ -1,0 +1,3 @@
+module github.com/diggerhq/digger/cli_e2e
+
+go 1.22.0

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -18,7 +18,7 @@ func init() {
 
 func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	fmt.Printf("in function")
-	file, err := os.CreateTemp(os.Getenv("RUNNER_TEMP"), "prefix")
+	file, err := os.CreateTemp("/tmp", "prefix")
 	fmt.Printf("%v", err)
 	assert.Nil(t, err)
 	defer os.Remove(file.Name())

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -5,10 +5,16 @@ import (
 	"github.com/diggerhq/digger/cli/pkg/gcp"
 	"github.com/diggerhq/digger/cli/pkg/storage"
 	"github.com/stretchr/testify/assert"
+	"log"
 	"os"
 	"strings"
 	"testing"
 )
+
+func init() {
+	log.SetOutput(os.Stdout)
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+}
 
 func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	fmt.Printf("in function")

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -28,7 +28,9 @@ func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	contents := []byte{'a'}
 	artefactName := "myartefact"
 	fileName := "myplan.tfplan"
-	planStorage.StorePlanFile(contents, artefactName, fileName)
+	err = planStorage.StorePlanFile(contents, artefactName, fileName)
+	fmt.Printf("%v", err)
+	assert.Nil(t, err)
 	exists, err := planStorage.PlanExists(artefactName, fileName)
 	fmt.Printf("%v", err)
 	assert.Nil(t, err)

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -1,6 +1,7 @@
 package cli_e2e
 
 import (
+	"fmt"
 	"github.com/diggerhq/digger/cli/pkg/gcp"
 	"github.com/diggerhq/digger/cli/pkg/storage"
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,9 @@ import (
 )
 
 func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
+	fmt.Printf("in function")
 	file, err := os.CreateTemp("/tmp", "prefix")
+	fmt.Printf("%v", err)
 	assert.Nil(t, err)
 	defer os.Remove(file.Name())
 
@@ -27,11 +30,13 @@ func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	fileName := "myplan.tfplan"
 	planStorage.StorePlanFile(contents, artefactName, fileName)
 	exists, err := planStorage.PlanExists(artefactName, fileName)
+	fmt.Printf("%v", err)
 	assert.Nil(t, err)
 	assert.True(t, exists)
 
 	planStorage.RetrievePlan(file.Name(), artefactName, fileName)
 	readContents, err := os.ReadFile(file.Name())
+	fmt.Printf("%v", err)
 	assert.Nil(t, err)
 	assert.Equal(t, readContents, contents)
 }

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -12,12 +12,14 @@ import (
 
 func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	fmt.Printf("in function")
-	file, err := os.CreateTemp("/tmp", "prefix")
+	file, err := os.CreateTemp(os.Getenv("RUNNER_TEMP"), "prefix")
 	fmt.Printf("%v", err)
 	assert.Nil(t, err)
 	defer os.Remove(file.Name())
 
+	fmt.Printf("getting cp client")
 	ctx, client := gcp.GetGoogleStorageClient()
+	fmt.Printf("getting bucket")
 	bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
 	bucket := client.Bucket(bucketName)
 	planStorage := &storage.PlanStorageGcp{

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -1,0 +1,37 @@
+package cli_e2e
+
+import (
+	"github.com/diggerhq/digger/cli/pkg/gcp"
+	"github.com/diggerhq/digger/cli/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
+	file, err := os.CreateTemp("/tmp", "prefix")
+	assert.Nil(t, err)
+	defer os.Remove(file.Name())
+
+	ctx, client := gcp.GetGoogleStorageClient()
+	bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
+	bucket := client.Bucket(bucketName)
+	planStorage := &storage.PlanStorageGcp{
+		Client:  client,
+		Bucket:  bucket,
+		Context: ctx,
+	}
+	contents := []byte{'a'}
+	artefactName := "myartefact"
+	fileName := "myplan.tfplan"
+	planStorage.StorePlanFile(contents, artefactName, fileName)
+	exists, err := planStorage.PlanExists(artefactName, fileName)
+	assert.Nil(t, err)
+	assert.True(t, exists)
+
+	planStorage.RetrievePlan(file.Name(), artefactName, fileName)
+	readContents, err := os.ReadFile(file.Name())
+	assert.Nil(t, err)
+	assert.Equal(t, readContents, contents)
+}

--- a/go.work
+++ b/go.work
@@ -1,11 +1,12 @@
-go 1.21.7
+go 1.22.0
 
 use (
 	./backend
 	./cli
-	./libs
+	./cli_e2e
+	./ee/backend
 
 	./ee/cli
-	./ee/backend
+	./libs
 
 )


### PR DESCRIPTION
All methods in the storage interface now accept two arguments: artefactName and storedPlanFileName

include PRNumber in the stored plan file name to ensure that it is unique per PR per project

artefactName is mainly used with githubPlanStorage for storing and retrieval by name

for buckets we will mainly used storedplanfilename in order to fetch and retrive the terraform plan

