### PR TITLE
Add helm release github action

### DIFF
--- a/.github/workflows/helm_release.yml
+++ b/.github/workflows/helm_release.yml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: backend/helmchart
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/backend/controllers/github_test.go
+++ b/backend/controllers/github_test.go
@@ -676,7 +676,6 @@ func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 }
 func TestGithubHandleIssueCommentEvent(t *testing.T) {
-	t.Skip("!!TODO: Fix this failing test and unskip it")
 	teardownSuite, _ := setupSuite(t)
 	defer teardownSuite(t)
 

--- a/backend/utils/github.go
+++ b/backend/utils/github.go
@@ -194,14 +194,13 @@ func SetPRStatusForJobs(prService *github2.GithubService, prNumber int, jobs []o
 func GetWorkflowIdAndUrlFromDiggerJobId(client *github.Client, repoOwner string, repoName string, diggerJobID string) (int64, string, error) {
 	timeFilter := time.Now().Add(-5 * time.Minute)
 	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(context.Background(), repoOwner, repoName, &github.ListWorkflowRunsOptions{
-		Created: ">= " + timeFilter.Format(time.RFC3339),
+		Created: ">=" + timeFilter.Format(time.RFC3339),
 	})
 	if err != nil {
 		return 0, "#", fmt.Errorf("error listing workflow runs %v", err)
 	}
 
 	for _, workflowRun := range runs.WorkflowRuns {
-		println(*workflowRun.ID)
 		workflowjobs, _, err := client.Actions.ListWorkflowJobs(context.Background(), repoOwner, repoName, *workflowRun.ID, nil)
 		if err != nil {
 			return 0, "#", fmt.Errorf("error listing workflow jobs for run %v %v", workflowRun.ID, err)


### PR DESCRIPTION
There are pre-requisites which I don't have the required permissions to manage, see more here: https://github.com/helm/chart-releaser-action?tab=readme-ov-file#pre-requisites. cc: @motatoes 

This PR enables the use of the new helm chart without copying it locally.