### PR TITLE
Add helm release github action

### DIFF
--- a/.github/workflows/helm_release.yml
+++ b/.github/workflows/helm_release.yml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: backend/helmchart
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
There are pre-requisites which I don't have the required permissions to manage, see more here: https://github.com/helm/chart-releaser-action?tab=readme-ov-file#pre-requisites. cc: @motatoes

This PR enables the use of the new helm chart without copying it locally.