### PR TITLE
Make specifying both assume roles optional

### DIFF
--- a/docs/howto/project-level-roles.mdx
+++ b/docs/howto/project-level-roles.mdx
@@ -8,7 +8,9 @@ them directly in terraform you can use this as an [example repository](https://g
 
 You can also use digger.yml to specify which roles should be used for which repository. In this case you specify a main
 role in the workflow file using `aws-role-to-assume` (or using keys) and inside the repo if you wish to assume
-a differnt role for a specific project you specify an `aws_role_to_assume` under that project. Example digger.yml:
+a differnt role for a specific project you specify an `aws_role_to_assume` under that project. 
+If you only specify one role (either `state` or `command`) it is assumed that both options are the same role.
+Example digger.yml:
 
 ```
 projects:

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -26,6 +26,13 @@ func copyProjects(projects []*ProjectYaml) []Project {
 
 		var roleToAssume *AssumeRoleForProject = nil
 		if p.AwsRoleToAssume != nil {
+			if p.AwsRoleToAssume.State == "" {
+				p.AwsRoleToAssume.State = p.AwsRoleToAssume.Command
+			}
+			if p.AwsRoleToAssume.Command == "" {
+				p.AwsRoleToAssume.Command = p.AwsRoleToAssume.State
+			}
+
 			roleToAssume = &AssumeRoleForProject{
 				State:   p.AwsRoleToAssume.State,
 				Command: p.AwsRoleToAssume.Command,

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -168,11 +168,8 @@ func TestDiggerConfigOneRole(t *testing.T) {
 projects:
 - name: prod
   branch: /main/
-  dir: path/to/module/test
   aws_role_to_assume:
     command: "arn://abc:xyz:cmd"
-  workspace: default
-  workflow_file: "test.yml"
 `
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
@@ -181,29 +178,8 @@ projects:
 	fmt.Printf("%v", err)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
-	assert.Equal(t, 1, len(dg.Projects))
-	assert.Equal(t, false, dg.AutoMerge)
-	assert.Equal(t, true, dg.Telemetry)
-	assert.Equal(t, false, dg.TraverseToNestedProjects)
-	assert.Equal(t, 1, len(dg.Workflows))
-
-	assert.Equal(t, "prod", dg.Projects[0].Name)
-	assert.Equal(t, "test.yml", dg.Projects[0].WorkflowFile)
-	assert.Equal(t, "path/to/module/test", dg.Projects[0].Dir)
 	assert.Equal(t, "arn://abc:xyz:cmd", dg.Projects[0].AwsRoleToAssume.Command)
 	assert.Equal(t, "arn://abc:xyz:cmd", dg.Projects[0].AwsRoleToAssume.State)
-
-	workflow := dg.Workflows["default"]
-	assert.NotNil(t, workflow, "expected workflow to be not nil")
-	assert.NotNil(t, workflow.Plan)
-	assert.NotNil(t, workflow.Plan.Steps)
-
-	assert.NotNil(t, workflow.Apply)
-	assert.NotNil(t, workflow.Apply.Steps)
-	assert.NotNil(t, workflow.EnvVars)
-	assert.NotNil(t, workflow.Configuration)
-
-	assert.Equal(t, "path/to/module/test", dg.GetDirectory("prod"))
 }
 
 func TestDiggerConfigDefaultWorkflow(t *testing.T) {


### PR DESCRIPTION
My use-case here is that both the `state` and `command` roles are equivalent and therefore duplicates code so this introduces a cleaner approach.