### PR TITLE
Add helm chart lint/test job on KinD

### DIFF
--- a/.github/workflows/helm_release.yml
+++ b/.github/workflows/helm_release.yml
@@ -6,7 +6,50 @@ on:
       - develop
 
 jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.8.0
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+
   release:
+    needs: lint-test
+    if: needs.lint-test.result == 'success'
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/backend/helmchart/Chart.yaml
+++ b/backend/helmchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/backend/helmchart/README.md
+++ b/backend/helmchart/README.md
@@ -31,5 +31,6 @@ To configure the Digger backend deployment with the Helm chart, you'll need to s
 Remember to replace placeholders and default values with your specific, sensitive information before deploying the chart. For example, it's essential to generate a strong `bearerAuthToken` and `postgresPassword` rather than using the defaults for security reasons.
 
 You can also deploy a PostgreSQL database ONLY FOR TEST PURPOSES configuring the `postgres.*` section:
+
 - `postgres.enabled`: Set to `true` if you want to deploy a postgres database
 - `postgres.secret.*`: As for the digger secret, you can pass the `postgres` user password directly or through an existing secret


### PR DESCRIPTION
Grabbed the helm chart lint/test action from [Helm documentation](https://helm.sh/docs/howto/chart_releaser_action/) and made the release conditional on its success. Also tweaked the `default` branch since the actions assume `master` but we use `develop` here.

@motatoes for the release to fully work we need to setup a Github page for this repo (described in more [detail here](https://github.com/helm/chart-releaser-action?tab=readme-ov-file#pre-requisites)). Could you set that up, I don't have the required permissions on this repo :) 