### PR TITLE
Fix: ensure that variables used for slack match the input variable name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -279,7 +279,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-drift-url }}
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}.
         NO_BACKEND: ${{ inputs.no-backend }}
         DEBUG: 'true'
       run: |
@@ -305,7 +305,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-drift-url }}
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
         NO_BACKEND: ${{ inputs.no-backend }}
       id: digger
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -279,7 +279,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}.
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
         NO_BACKEND: ${{ inputs.no-backend }}
         DEBUG: 'true'
       run: |


### PR DESCRIPTION
Why do we need this change?
=======================
Introduced in #1239 a change went into the action to change the inputs for the digger portion of the action but didn't update the inputs to match. So this change ensures that inputs and usage are consistent. This prevents the slack_url from being a NULL always and causing drift detection to always fail out.

What effects does this change have?
=======================
* ensure that slack url variables are consistent.
* Fixes #1295 