### PR TITLE
automate latest version of digger in docs

### DIFF
--- a/docs/azure-specific/azure.mdx
+++ b/docs/azure-specific/azure.mdx
@@ -2,6 +2,8 @@
 title: "Setting up Azure + GH Actions"
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 ## Prerequisites
 
 * Azure Cloud account
@@ -64,7 +66,7 @@ projects:
 
 In your repository, create a file at `.github/workflows/infra.yml`
 
-```
+<BlockCode version={latestversion} code={`
 name: CI
 
 on:
@@ -85,27 +87,27 @@ jobs:
 
       - name: Checkout Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
         run: |
-          PR_URL="${{ github.event.issue.pull_request.url }}"
-          PR_NUM=${PR_URL##*/}
+          PR_URL="$\{\{ github.event.issue.pull_request.url \}\}"
+          PR_NUM=$\{PR_URL##*/\}
           echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
           hub pr checkout $PR_NUM
         if: github.event_name == 'issue_comment'
     
       - name: digger
-        uses: diggerhq/digger@main
+        uses: diggerhq/digger@latest
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
           LOCK_PROVIDER: azure
           DIGGER_AZURE_AUTH_METHOD: CONNECTION_STRING
-          DIGGER_AZURE_CONNECTION_STRING: ${{ secrets.DIGGER_AZURE_CONNECTION_STRING }}
-          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}          
-```
+          DIGGER_AZURE_CONNECTION_STRING: $\{\{ secrets.DIGGER_AZURE_CONNECTION_STRING \}\}
+          ARM_CLIENT_ID: $\{\{ secrets.ARM_CLIENT_ID \}\}
+          ARM_CLIENT_SECRET: $\{\{ secrets.ARM_CLIENT_SECRET \}\}
+          ARM_TENANT_ID: $\{\{ secrets.ARM_TENANT_ID \}\}
+          ARM_SUBSCRIPTION_ID: $\{\{ secrets.ARM_SUBSCRIPTION_ID \}\}          
+`}></BlockCode>
 
 ## 6\. Create a PR to verify that it works
 

--- a/docs/digger-api/rbac-via-opa-guide.mdx
+++ b/docs/digger-api/rbac-via-opa-guide.mdx
@@ -2,6 +2,8 @@
 title: "RBAC via OPA guide"
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 Welcome to the Digger API. This guide aims to help you understand how to manage and use Digger's RBAC OPA policy rules and tokens.
 
 ### Authorization
@@ -63,7 +65,7 @@ Once you have an access token, you can use it in your GitHub Action `digger/digg
 
 Here is an example of how to use these parameters in a GitHub Actions workflow:
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger Action
 on: [push]
 jobs:
@@ -71,11 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Run Digger
-      uses: digger/digger@
+      uses: digger/digger@latest
       with:
-        digger-token: ${{ secrets.DIGGER_TOKEN }}
+        digger-token: $\{\{ secrets.DIGGER_TOKEN \}\}
         digger-host: 'https://cloud.uselemon.cloud'
-```
+`}></BlockCode>
 
 In this example, `secrets.DIGGER_TOKEN` is a GitHub secret where your Digger access token is stored.
 

--- a/docs/gcp/federated-oidc-access.mdx
+++ b/docs/gcp/federated-oidc-access.mdx
@@ -3,6 +3,8 @@ title: "Federated OIDC access"
 description: "You can configure Digger to use OIDC instead of key-value pairs."
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 If you already have configured GCP for that, skip to step 5.
 
 ## 1\. Create a Workload Identity Pool
@@ -10,7 +12,7 @@ If you already have configured GCP for that, skip to step 5.
 A Workload Identity Pool is an umbrella entity for managing access in GCP. The best practice is to have a dedicated pool for each non-GCP environment.
 
 ```
-gcloud iam workload-identity-pools create github-wif-pool --location="global" --project 
+gcloud iam workload-identity-pools create github-wif-pool --location="global" --project
 ```
 
 ## 2\. Create a Workload Identity Provider
@@ -22,7 +24,7 @@ gcloud iam workload-identity-pools providers create-oidc githubwif \
 --location="global" --workload-identity-pool="github-wif-pool"  \
 --issuer-uri="https://token.actions.githubusercontent.com" \
 --attribute-mapping="attribute.actor=assertion.actor,google.subject=assertion.sub,attribute.repository=assertion.repository" \
---project 
+--project
 ```
 
 ## 3\. Create a Service Account and bind policies
@@ -32,7 +34,7 @@ A service account with relevant permissions will be impersonated by WIF. This al
 ```
 gcloud iam service-accounts create test-wif \
 --display-name="Service account used by WIF POC" \
---project 
+--project
 
 gcloud projects add-iam-policy-binding  \
 --member='serviceAccount:test-wif@.iam.gserviceaccount.com' \
@@ -47,21 +49,21 @@ gcloud iam service-accounts add-iam-policy-binding test-wif@.iam.gserviceaccount
 
 Create 2 secrets in your Action Secrets with the following names:
 
-* GCP\_WORKLOAD\_IDENTITY\_PROVIDER
+- GCP_WORKLOAD_IDENTITY_PROVIDER
 
-* GCP\_SERVICE\_ACCOUNT
+- GCP_SERVICE_ACCOUNT
 
 ## 5\. Configure Digger workflow to use federated access
 
 Set `EXT` env var intead of the usual key pair. See [oidc-gcp-example](https://github.com/diggerhq/digger-gcp-ocid-demo) repo for more detail. Sample config below:
 
-```
+<BlockCode version={latestversion} code={`
 - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
           token_format: access_token
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: $\{\{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER \}\}
+          service_account: $\{\{ env.GCP_SERVICE_ACCOUNT \}\}
           audience: google-wif
 
       - name: 'Set up Cloud SDK'
@@ -70,16 +72,21 @@ Set `EXT` env var intead of the usual key pair. See [oidc-gcp-example](https://g
       - name: 'Use gcloud CLI'
         run: |
           gcloud info
-          gsutil ls gs://${{ env.GOOGLE_STORAGE_BUCKET }}
+          gsutil ls gs://$\{\{ env.GOOGLE_STORAGE_BUCKET \}\}
       - name: digger
-        uses: diggerhq/digger@main
+        uses: diggerhq/digger@latest
         env:
           LOCK_PROVIDER: gcp
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
           GOOGLE_STORAGE_BUCKET: digger-lock2
-```
 
-## 
+`}></BlockCode>
 
-<Note>This article is based on [this post](https://medium.com/google-cloud/how-does-the-gcp-workload-identity-federation-work-with-github-provider-a9397efd7158) by Pradeep Kumar Singh</Note>
+##
+
+<Note>
+  This article is based on [this
+  post](https://medium.com/google-cloud/how-does-the-gcp-workload-identity-federation-work-with-github-provider-a9397efd7158)
+  by Pradeep Kumar Singh
+</Note>

--- a/docs/getting-started/github-actions-+-aws.mdx
+++ b/docs/getting-started/github-actions-+-aws.mdx
@@ -2,9 +2,12 @@
 title: "Github Actions + AWS"
 ---
 
-In this tutorial, you will set up Digger to automate terraform pull requests using Github Actions and AWS 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
+In this tutorial, you will set up Digger to automate terraform pull requests using Github Actions and AWS
 
 # Prerequisites
+
 - A GitHub repository with valid terraform code. Here's a [demo repo](https://github.com/diggerhq/quickstart-actions-aws)
 - Your AWS credentials. See [Hashicorp's AWS tutorial](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build)
 - Digger token from [cloud.digger.dev](https://cloud.digger.dev)
@@ -14,15 +17,20 @@ In this tutorial, you will set up Digger to automate terraform pull requests usi
 cloud.digger.dev does not need access to your cloud account, it just starts jobs in your CI.
 
 You can also [self-host Digger orchestrator](/self-host/deploy-docker) with a private GiHub app and issue your own token
+
 </Note>
 
 # Create Action Secrets
+
 In GitHub repository settings, go to Secrets and Variables - Actions. Create the following secrets:
+
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (you can also [use OIDC](https://docs.digger.dev/cloud-providers/authenticating-with-oidc-on-aws))
 - `DIGGER_TOKEN` - your Digger token (cloud or self-hosted)
 
 # Create digger.yml
+
 This file contains Digger configuration and needs to be placed at the root level of your repository. Assuming your terraform code is in the `prod` directory:
+
 ```
 projects:
 - name: production
@@ -30,9 +38,11 @@ projects:
 ```
 
 # Create Github Actions workflow file
+
+
 Place it at `.github/workflows/digger_workflow.yml` (name is important!)
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger Workflow
 
 on:
@@ -48,7 +58,7 @@ on:
 jobs:
   digger-job:
     runs-on: ubuntu-latest
-    permissions:    
+    permissions:
       contents: write      # required to merge PRs
       actions: write       # required for plan persistence
       id-token: write      # required for workload-identity-federation
@@ -60,28 +70,31 @@ jobs:
       - uses: diggerhq/digger@latest
         with:
           setup-aws: true
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: $\{\{ secrets.AWS_ACCESS_KEY_ID \}\}
+          aws-secret-access-key: $\{\{ secrets.AWS_SECRET_ACCESS_KEY \}\}
           disable-locking: true
           digger-hostname: 'https://cloud.digger.dev'
           digger-organisation: 'digger'
-          digger-token: ${{ secrets.DIGGER_TOKEN }}
+          digger-token: $\{\{ secrets.DIGGER_TOKEN \}\}
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         
-```
+          GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
+`}></BlockCode>
+
 
 This file defines a simple workflow that
+
 - Checks out repository using Github's official [Checkout action](https://github.com/actions/checkout)
 - Runs Digger. Note that `DIGGER_TOKEN` needs to be set as a secret in Actions (either repository secret, or environment secret), you also need to set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY parameter. OIDC is also supported if you prefer that route
 
 # Create a PR to verify that it works
 
-Terraform  will run an existing plan against your code. 
+Terraform will run an existing plan against your code.
 
-Make any change to your terraform code e.g. add a blank line. An action run should start (you can see log output in Actions). After some time you should see output of Terraform Plan added as a comment to your PR. 
+Make any change to your terraform code e.g. add a blank line. An action run should start (you can see log output in Actions). After some time you should see output of Terraform Plan added as a comment to your PR.
 
 Then you can add a comment like `digger apply` and shortly after apply output will be added as comment too.
 
+```
 
+```

--- a/docs/getting-started/github-actions-and-gcp.mdx
+++ b/docs/getting-started/github-actions-and-gcp.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Github Actions + GCP"
 ---
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
 
 In this tutorial, you will set up Digger to automate terraform pull requests using Github Actions and GCP.
 
@@ -32,7 +33,7 @@ projects:
 # Create Github Actions workflow file
 Place it at `.github/workflows/digger_workflow.yml` (name is important!)
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger
 
 on:
@@ -60,7 +61,7 @@ jobs:
     - id: 'auth'
       uses: 'google-github-actions/auth@v1'
       with:
-        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+        credentials_json: '$\{\{ secrets.GCP_CREDENTIALS \}\}'
         create_credentials_file: true
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
@@ -73,11 +74,11 @@ jobs:
           disable-locking: true
           digger-hostname: 'https://cloud.digger.dev'
           digger-organisation: 'digger'
-          digger-token: ${{ secrets.DIGGER_TOKEN }}
+          digger-token: $\{\{ secrets.DIGGER_TOKEN \}\}
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+          GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
+`}></BlockCode>
 
 This file defines a workflow with 5 steps:
 - Checkout repository using Github's official [Checkout action](https://github.com/actions/checkout)

--- a/docs/howto/destroy-manual.mdx
+++ b/docs/howto/destroy-manual.mdx
@@ -2,11 +2,15 @@
 title: "Destroy via manual workflow"
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 Normally Digger workflow is not supposed to be triggered manually. It is triggered ether by the orchestrator backend, or directly by an event from GitHub (in the "backendless" mode with `no-backend: true` option set). The Destroy operation is a special case, by design: the only way to run `terraform destroy` in Digger is by triggering a workflow manually. This way unwanted destroys are guaranteed to never happen.
 
 You can create a dedicated workflow accepting project name and action:
 
-```
+<BlockCode
+  version={latestversion}
+  code={`
 on:
   workflow_dispatch:
     inputs:
@@ -18,23 +22,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: digger destroy
-      uses: diggerhq/digger@develop
+      uses: diggerhq/digger@latest
       with:
         mode: manual
         command: "digger destroy"
-        project: "${{ inputs.project }}"
+        project: "$\{\{ inputs.project \}\}"
         setup-aws: true
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: $\{\{ secrets.AWS_ACCESS_KEY_ID \}\}
+        aws-secret-access-key: $\{\{ secrets.AWS_SECRET_ACCESS_KEY \}\}
         aws-region: us-east-2
-        # digger-token: ${{ secrets.DIGGER_TOKEN }}
+        # digger-token: $\{\{ secrets.DIGGER_TOKEN \}\}
         # digger-organisation: digger
         # digger-hostname: https://cloud.digger.dev/
       env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+        GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+        GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
+`}
+></BlockCode>
 
-<Note>Note the arguments “mode: manual” and “command: digger destroy” above are different from the default workflow</Note>
-
-
+<Note>
+  Note the arguments “mode: manual” and “command: digger destroy” above are
+  different from the default workflow
+</Note>

--- a/docs/howto/drift-detection.mdx
+++ b/docs/howto/drift-detection.mdx
@@ -2,13 +2,15 @@
 title: 'Drift Detection'
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 Digger supports drift detection alerting via Slack. To configure drift detection:
 
 ## Create a separate workflow file for drift
 
 To run digger in drift detection mode, pass `mode: drift-detection` in the workflow file and configure the relevant crontab to run it with the frequency you want:
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger Drift Detection
 
 on:  
@@ -25,17 +27,17 @@ jobs:
       with:
         mode: drift-detection
         setup-aws: true
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: $\{\{ secrets.AWS_ACCESS_KEY_ID \}\}
+        aws-secret-access-key: $\{\{ secrets.AWS_SECRET_ACCESS_KEY \}\}
         aws-region: us-east-1
-        digger-token: ${{ secrets.DIGGER_TOKEN }}
+        digger-token: $\{\{ secrets.DIGGER_TOKEN \}\}
         digger-organisation: digger
         digger-hostname: https://cloud.digger.dev/
-        drift-detection-slack-notification-url: ${{ secrets.DRIFT_DETECTION_SLACK_NOTIFICATION }}
+        drift-detection-slack-notification-url: $\{\{ secrets.DRIFT_DETECTION_SLACK_NOTIFICATION \}\}
       env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+        GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+        GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
+`}></BlockCode>
 
 ## Configure Slack notification URL
 

--- a/docs/howto/multiacc-aws.mdx
+++ b/docs/howto/multiacc-aws.mdx
@@ -2,6 +2,8 @@
 title: "Multiple AWS accounts"
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 In this guide you will set up Digger to use completely segregated AWS accounts for Dev and Prod environments
 
 ## Prerequisites
@@ -39,7 +41,7 @@ In each environment, create 2 secrets corresponding to your AWS accounts:
 
 Don't forget to change `environment` and the Rename step from Dev to Prod
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger Dev
 
 on:
@@ -69,13 +71,13 @@ jobs:
         uses: diggerhq/digger@latest
         with:
           setup-aws: true
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: $\{\{ secrets.AWS_ACCESS_KEY_ID \}\}
+          aws-secret-access-key: $\{\{ secrets.AWS_SECRET_ACCESS_KEY \}\}
           aws-region: us-east-1
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+          GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
+`}></BlockCode>
 
 ## Verify that it works
 That's it! Now you can use Digger to automate your Terraform PRs.

--- a/docs/howto/trigger-directly.mdx
+++ b/docs/howto/trigger-directly.mdx
@@ -2,11 +2,13 @@
 title: "Trigger workflow directly"
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 By default Digger workflows are triggered by an orchestrator backend (Digger Cloud or self-hosted) that listens to events from GitHub and triggers jobs in Actions. Without an orchestrator backend it is not possible to start jobs in parallel, so all plans and applies have to run sequentially in one action job, which can be slow. Also without an orchestrator backend the action needs to start on every commit and every comment, even if there were no terraform changes; large monorepos this can get expensive.
 
 But in some scenarios e.g. small projects that have no need for concurrency, it might be easier to just use a standalone action triggered directly from GitHub events. You can achieve that by specifying triggers at the top of the workflow:
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger Pull Request Workflow
 
 on:
@@ -23,15 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: digger run
-      uses: diggerhq/digger@v0.3.4
+      uses: diggerhq/digger@latest
       with:
         disable-locking: true
         setup-terraform: true
         digger-hostname: 'https://cloud.digger.dev'
         digger-organisation: 'digger-playground'
-        digger-token: ${{ secrets.DIGGER_TOKEN }}        
+        digger-token: $\{\{ secrets.DIGGER_TOKEN \}\}
       env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
+        GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
+        GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
+`}></BlockCode>

--- a/docs/howto/using-terragrunt.mdx
+++ b/docs/howto/using-terragrunt.mdx
@@ -2,6 +2,8 @@
 title: "Using Terragrunt"
 ---
 
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
+
 There are 2 ways of using Digger with Terragrunt:
 - individual projects
 - dynamically generated projects
@@ -45,7 +47,7 @@ workflows:
 
 And the workflow for this needs to use `setup-terragrunt: true` as follows:
 
-```
+<BlockCode version={latestversion} code={`
 name: Digger
 
 on:
@@ -68,13 +70,13 @@ jobs:
         uses: diggerhq/digger@latest
         with:
           setup-google-cloud: true # FOR aws use setup-aws instead
-          google-auth-credentials: '${{ secrets.DIGGER_GCP_CREDENTIALS }}'
+          google-auth-credentials: '$\'{\'{ secrets.DIGGER_GCP_CREDENTIALS \}\}'
           setup-terragrunt: true
           terragrunt-version: 0.44.1
         env:
           LOCK_PROVIDER: gcp
           GOOGLE_STORAGE_BUCKET: please-create-me-for-storing-locks
-          GOOGLE_ENCRYPTION_KEY: ${{ secrets.GOOGLE_ENCRYPTION_KEY }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+          GOOGLE_ENCRYPTION_KEY: $\'{\'{ secrets.GOOGLE_ENCRYPTION_KEY \}\}
+          GITHUB_CONTEXT: $\'{\'{ toJson(github) \}\}
+          GITHUB_TOKEN: $\'{\'{ secrets.GITHUB_TOKEN \}\}
+`}></BlockCode>

--- a/docs/howto/versioning.mdx
+++ b/docs/howto/versioning.mdx
@@ -2,6 +2,7 @@
 title: "Specifying version"
 description: "For serious usecases always use a pinned version which is of the form @vX.Y.Z since this will download compiled binary. Addition to being faster to run, it is also more secure than using a commit from a branch"
 ---
+import { latestversion, BlockCode } from "/snippets/versioncode.mdx";
 
 <Warning>For serious usecases always use a pinned version which is of the form @vX.Y.Z since this will download compiled binary. Addition to being faster to run, it is also more secure than using a commit from a branch</Warning>
 
@@ -9,12 +10,12 @@ description: "For serious usecases always use a pinned version which is of the f
 
 To pin a specific release of Digger, you can use `@vX.Y.Z` tag in your workflow file:
 
-```
+<BlockCode version={latestversion} code={`
 - name: digger
-  uses: diggerhq/digger@v0.1.10
+  uses: diggerhq/digger@latest
   env:
     ...
-```
+`}></BlockCode>
 
 ## Use latest commit from a branch
 
@@ -24,9 +25,9 @@ Only use this at your own risk in non-production scenarios. This can break thing
 
 <Warning>Only use this at your own risk in non-production scenarios. This can break things!</Warning>
 
-```
+<BlockCode version={latestversion} code={`
 - name: digger
   uses: diggerhq/digger@yolo-lets-do-it
   env:
     ...
-```
+`}></BlockCode>

--- a/docs/snippets/versioncode.mdx
+++ b/docs/snippets/versioncode.mdx
@@ -1,0 +1,11 @@
+export const latestversion = "v0.4.13";
+
+export const BlockCode = ({ version, code }) => {
+    return (
+        <pre>
+            {code.replace("@latest", "@" + version)}
+        </pre>
+
+    )
+
+};


### PR DESCRIPTION
created a quick snipped in docs to automate the latest version accross all pages. Its not perfect but it works we will replace the triple tics block with a component called BlockCode:
import { latestversion, BlockCode } from "/snippets/versioncode.mdx";

```
<BlockCode version={latestversion} code={`
      - name: digger
        uses: diggerhq/digger@latest
        env:
          GITHUB_CONTEXT: $\{\{ toJson(github) \}\}
          GITHUB_TOKEN: $\{\{ secrets.GITHUB_TOKEN \}\}
          DIGGER_AZURE_CONNECTION_STRING: $\{\{ secrets.DIGGER_AZURE_CONNECTION_STRING \}\}
`}></BlockCode>
```

The annoying part is all ‘{’ and ‘}’ need to be escaped with backslash throughout the code string.
But it works. And to updated to new version we need to update the value of latestversion variable in docs/snippets/versioncode.mdx once (can be automated)

Can also be automated to be updated on every release later