### PR TITLE
Fix GH comment hyperlink

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -283,7 +283,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-drift-url }}
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
         NO_BACKEND: ${{ inputs.no-backend }}
         DEBUG: 'true'
       run: |
@@ -309,7 +309,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-drift-url }}
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
         NO_BACKEND: ${{ inputs.no-backend }}
       id: digger
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,10 @@ inputs:
     description: 'drift-detection slack drift url'
     required: false
     default: ''
+  id:
+    description: 'DiggerJobID'
+    required: false
+    default: ''
 outputs:
   output:
     value: ${{ steps.digger.outputs.output }}
@@ -279,7 +283,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-drift-url }}
         NO_BACKEND: ${{ inputs.no-backend }}
         DEBUG: 'true'
       run: |
@@ -305,7 +309,7 @@ runs:
         INPUT_DIGGER_PROJECT: ${{ inputs.project }}
         INPUT_DIGGER_MODE: ${{ inputs.mode }}
         INPUT_DIGGER_COMMAND: ${{ inputs.command }}
-        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-notification-url }}
+        INPUT_DRIFT_DETECTION_SLACK_NOTIFICATION_URL: ${{ inputs.drift-detection-slack-drift-url }}
         NO_BACKEND: ${{ inputs.no-backend }}
       id: digger
       shell: bash


### PR DESCRIPTION
I found two bugs with local testing:

1) The `-07:00` UTC offset portion of the timeFilter was throwing off the github query so I got rid of it alltogether since I'm assuming the API is normalized relative to the query time anyways

2) The code is using the comparison`strings.Contains(*step.Name, diggerJobID)` however the id was never set as part of the step name. I believe this is because the actions doesn't take it in as an input, despite the action attempting to use it and echo it.

I'd like to push this to a test release and do further testing since it was hard to write mock tests for.