### PR TITLE
Hotfix-Disable logging of full Terraform Plan output in CheckPlanPolicy

### DIFF
--- a/cli/pkg/policy/policy.go
+++ b/cli/pkg/policy/policy.go
@@ -352,7 +352,7 @@ func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisati
 	}
 
 	ctx := context.Background()
-	log.Printf("DEBUG: passing the following input policy: %v ||| text: %v", input, policy)
+	log.Printf("DEBUG: passing the following input policy: %v", policy)
 	query, err := rego.New(
 		rego.Query("data.digger.deny"),
 		rego.Module("digger", policy),


### PR DESCRIPTION
This is a hotfix for my issue https://github.com/diggerhq/digger/issues/1261

The "input" variable that is removed from logs in this PR contained full output of terraform plan. The output from TF plan can be sensitive (as it can contain secrets if those are managed by Terraform) and logging it has caused it to be public in the output of  Github Action (those are public to all users with read access to the repository)

Proper fix would be implementing a better logging in the Digger CLI application, with log levels.
Currently, the log message is marked as DEBUG, but there is no notion of log levels implemented in Digger CLI application and those "DEBUG" logs are contained in standard output for every run. 

But due to the high impact of this issue on security I would be glad if you could implement this in nearest release.
