### PR TITLE
add e2e test for aws s3 plan storage

### DIFF
--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -2,13 +2,14 @@ package cli_e2e
 
 import (
 	"fmt"
-	"github.com/diggerhq/digger/cli/pkg/gcp"
-	"github.com/diggerhq/digger/cli/pkg/storage"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/diggerhq/digger/cli/pkg/gcp"
+	"github.com/diggerhq/digger/cli/pkg/storage"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -17,7 +18,6 @@ func init() {
 }
 
 func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
-	fmt.Printf("in function")
 	file, err := os.CreateTemp("/tmp", "prefix")
 	fmt.Printf("%v", err)
 	assert.Nil(t, err)
@@ -37,16 +37,52 @@ func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	artefactName := "myartefact"
 	fileName := "myplan.tfplan"
 	err = planStorage.StorePlanFile(contents, artefactName, fileName)
-	fmt.Printf("%v", err)
+	fmt.Printf("error StorePlanFile: %v", err)
 	assert.Nil(t, err)
 	exists, err := planStorage.PlanExists(artefactName, fileName)
-	fmt.Printf("%v", err)
+	fmt.Printf("error PlanExists: %v", err)
 	assert.Nil(t, err)
 	assert.True(t, exists)
 
 	planStorage.RetrievePlan(file.Name(), artefactName, fileName)
 	readContents, err := os.ReadFile(file.Name())
-	fmt.Printf("%v", err)
+	fmt.Printf("error RetrievePlan: %v", err)
+	assert.Nil(t, err)
+	assert.Equal(t, readContents, contents)
+}
+
+func TestAWSPlanStorageStorageAndRetrieval(t *testing.T) {
+	file, err := os.CreateTemp("/tmp", "prefix")
+	fmt.Printf("error creating temp dir: %v", err)
+	assert.Nil(t, err)
+	defer os.Remove(file.Name())
+
+	fmt.Printf("getting AWS S3 client")
+	ctx, client, err := storage.GetAWSStorageClient()
+	if err != nil {
+		t.Errorf("failed to get AWS storage client: %v", err)
+	}
+	bucketName := strings.ToLower(os.Getenv("AWS_S3_BUCKET"))
+	fmt.Printf("using AWS S3 bucket found by env var 'AWS_S3_BUCKET': %s", bucketName)
+	planStorage := &storage.PlanStorageAWS{
+		Client:  client,
+		Bucket:  bucketName,
+		Context: ctx,
+	}
+	contents := []byte{'a'}
+	artefactName := "myartefact"
+	fileName := "myplan.tfplan"
+	err = planStorage.StorePlanFile(contents, artefactName, fileName)
+	fmt.Printf("error StorePlanFile: %v", err)
+	assert.Nil(t, err)
+	exists, err := planStorage.PlanExists(artefactName, fileName)
+	fmt.Printf("error PlanExists: %v", err)
+	assert.Nil(t, err)
+	assert.True(t, exists)
+
+	planStorage.RetrievePlan(file.Name(), artefactName, fileName)
+	readContents, err := os.ReadFile(file.Name())
+	fmt.Printf("error RetrievePlan: %v", err)
 	assert.Nil(t, err)
 	assert.Equal(t, readContents, contents)
 }


### PR DESCRIPTION
fixes https://github.com/diggerhq/digger/issues/1380

This needs AWS credentials configured in the pipeline and a environment variable `AWS_S3_BUCKET` configured for the bucket.
Example:
```yaml
      - name: Configure OIDC AWS credentials
        uses: aws-actions/configure-aws-credentials@v4
        with:
          role-to-assume: arn:aws:iam::xxx:role/digger
```