### PR TITLE
use dynamodb consistent read to ensure we check against latest lock

### DIFF
--- a/cli/pkg/aws/dynamo_locking.go
+++ b/cli/pkg/aws/dynamo_locking.go
@@ -205,6 +205,7 @@ func (dynamoDbLock *DynamoDbLock) GetLock(lockId string) (*int, error) {
 			"PK": &types.AttributeValueMemberS{Value: "LOCK"},
 			"SK": &types.AttributeValueMemberS{Value: "RES#" + lockId},
 		},
+		ConsistentRead: aws.Bool(true),
 	}
 
 	result, err := dynamoDbLock.DynamoDb.GetItem(ctx, input)


### PR DESCRIPTION
I am not super familiar with ConsistentRead, but it seems like a good option to use when utilizing dynamodb as a lock provider. Ref https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html
