### PR TITLE
graceful handling of merge_group event in digger

### DIFF
--- a/cli/cmd/digger/main.go
+++ b/cli/cmd/digger/main.go
@@ -303,7 +303,7 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 
 		impactedProjects, requestedProject, prNumber, err := dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 		if err != nil {
-			if errors.Is(err, &dg_github.EventToIgnoreError{}) {
+			if errors.Is(err, dg_github.UnhandledMergeGroupEventError) {
 				reportErrorAndExit(githubActor, fmt.Sprintf("Graceful handling of GitHub event. %s", err), 0)
 			} else {
 				reportErrorAndExit(githubActor, fmt.Sprintf("Failed to process GitHub event. %s", err), 6)

--- a/cli/pkg/github/models/models.go
+++ b/cli/pkg/github/models/models.go
@@ -81,6 +81,12 @@ func (g *GithubAction) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		g.Event = event
+	case "merge_group":
+		var event github.MergeGroupEvent
+		if err := json.Unmarshal(rawEvent, &event); err != nil {
+			return err
+		}
+		g.Event = event
 	case "schedule":
 		// TODO: Find appropriate event for workflow scheduled run
 		var event github.WorkflowDispatchEvent

--- a/libs/orchestrator/github/errors.go
+++ b/libs/orchestrator/github/errors.go
@@ -4,4 +4,4 @@ import (
 	"errors"
 )
 
-var UnhandledMergeGroupEventError = errors.New("vertex not found")
+var UnhandledMergeGroupEventError = errors.New("ignoring event: merge_group")

--- a/libs/orchestrator/github/errors.go
+++ b/libs/orchestrator/github/errors.go
@@ -1,0 +1,11 @@
+package github
+
+import "fmt"
+
+type EventToIgnoreError struct {
+	Message string
+}
+
+func (e *EventToIgnoreError) Error() string {
+	return fmt.Sprintf("Unsupported event: %s", e.Message)
+}

--- a/libs/orchestrator/github/errors.go
+++ b/libs/orchestrator/github/errors.go
@@ -1,11 +1,7 @@
 package github
 
-import "fmt"
+import (
+	"errors"
+)
 
-type EventToIgnoreError struct {
-	Message string
-}
-
-func (e *EventToIgnoreError) Error() string {
-	return fmt.Sprintf("Unsupported event: %s", e.Message)
-}
+var UnhandledMergeGroupEventError = errors.New("vertex not found")

--- a/libs/orchestrator/github/github.go
+++ b/libs/orchestrator/github/github.go
@@ -490,7 +490,8 @@ func ProcessGitHubEvent(ghEvent interface{}, diggerConfig *digger_config.DiggerC
 			}
 		}
 		return nil, nil, 0, fmt.Errorf("requested project not found in modified projects")
-
+	case github.MergeGroupEvent:
+		return nil, nil, 0, &EventToIgnoreError{"ignoring event of type merge_group"}
 	default:
 		return nil, nil, 0, fmt.Errorf("unsupported event type")
 	}

--- a/libs/orchestrator/github/github.go
+++ b/libs/orchestrator/github/github.go
@@ -491,7 +491,7 @@ func ProcessGitHubEvent(ghEvent interface{}, diggerConfig *digger_config.DiggerC
 		}
 		return nil, nil, 0, fmt.Errorf("requested project not found in modified projects")
 	case github.MergeGroupEvent:
-		return nil, nil, 0, &EventToIgnoreError{"ignoring event of type merge_group"}
+		return nil, nil, 0, UnhandledMergeGroupEventError
 	default:
 		return nil, nil, 0, fmt.Errorf("unsupported event type")
 	}


### PR DESCRIPTION
For backendless mode, merge_queue event failure causes blocking of the queue. Handling this event and returning 0 exit status (do nothing basically) is implemented in this PR. fixes #1337