### PR TITLE
update env variables to only use inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,11 @@ inputs:
       description: "'audience' parameter configured in Google's Workload Identity Provider (if specified). To be used when the 'google-workload-identity-provider' input is specified"
       required: false
   google-service-account:
-      description: Service account to be used when the 'google-workload-identity-provider' input is specified)
-      required: false
+    description: Service account to be used when the 'google-workload-identity-provider' input is specified)
+    required: false
+  google-lock-bucket:
+    description: The GCP bucket to use for locks
+    required: false
   setup-azure:
     description: Setup Azure
     required: false
@@ -292,7 +295,8 @@ runs:
       shell: bash
       env:
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
-        GOOGLE_STORAGE_BUCKET: ${{ inputs.upload-plan-destination-gcp-bucket }}
+        GOOGLE_STORAGE_LOCK_BUCKET: ${{ inputs.google-lock-bucket }}
+        GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET: ${{ inputs.upload-plan-destination-gcp-bucket }}
         AWS_S3_BUCKET: ${{ inputs.upload-plan-destination-s3-bucket }}
         ACTIVATE_VENV: ${{ inputs.setup-checkov == 'true' }}
         DISABLE_LOCKING: ${{ inputs.disable-locking == 'true' }}
@@ -323,7 +327,8 @@ runs:
       env:
         actionref: ${{ github.action_ref }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
-        GOOGLE_STORAGE_BUCKET: ${{ inputs.upload-plan-destination-gcp-bucket }}
+        GOOGLE_STORAGE_LOCK_BUCKET: ${{ inputs.google-lock-bucket }}
+        GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET: ${{ inputs.upload-plan-destination-gcp-bucket }}
         AWS_S3_BUCKET: ${{ inputs.upload-plan-destination-s3-bucket }}
         ACTIVATE_VENV: ${{ inputs.setup-checkov == 'true' }}
         DISABLE_LOCKING: ${{ inputs.disable-locking == 'true' }}

--- a/cli/cmd/digger/main.go
+++ b/cli/cmd/digger/main.go
@@ -918,9 +918,9 @@ func newPlanStorage(ghToken string, ghRepoOwner string, ghRepositoryName string,
 		}
 	case uploadDestination == "gcp":
 		ctx, client := gcp.GetGoogleStorageClient()
-		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
+		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET"))
 		if bucketName == "" {
-			reportErrorAndExit(requestedBy, "GOOGLE_STORAGE_BUCKET is not defined", 9)
+			reportErrorAndExit(requestedBy, "GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET is not defined", 9)
 		}
 		bucket := client.Bucket(bucketName)
 		planStorage = &storage.PlanStorageGcp{

--- a/cli/pkg/locking/locking.go
+++ b/cli/pkg/locking/locking.go
@@ -294,9 +294,9 @@ func GetLock() (locking.Lock, error) {
 			}
 		}(client)
 
-		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
+		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_LOCK_BUCKET"))
 		if bucketName == "" {
-			return nil, errors.New("GOOGLE_STORAGE_BUCKET is not set")
+			return nil, errors.New("GOOGLE_STORAGE_LOCK_BUCKET is not set")
 		}
 		bucket := client.Bucket(bucketName)
 		lock := gcp.GoogleStorageLock{Client: client, Bucket: bucket, Context: ctx}

--- a/cli_e2e/plan_storage_test.go
+++ b/cli_e2e/plan_storage_test.go
@@ -26,7 +26,7 @@ func TestGCPPlanStorageStorageAndRetrieval(t *testing.T) {
 	fmt.Printf("getting cp client")
 	ctx, client := gcp.GetGoogleStorageClient()
 	fmt.Printf("getting bucket")
-	bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
+	bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET"))
 	bucket := client.Bucket(bucketName)
 	planStorage := &storage.PlanStorageGcp{
 		Client:  client,

--- a/docs/features/plan-persistence.mdx
+++ b/docs/features/plan-persistence.mdx
@@ -8,9 +8,10 @@ Use the following workflow option to use Artifacts plan storage:
 ```
 upload-plan-destination: github
 ```
-Or to use a GCP bucket (set environment variable: GOOGLE_STORAGE_BUCKET):
+Or to use a GCP bucket:
 ```
 upload-plan-destination: gcp
+upload-plan-destination-gcp-bucket: "my-bucket"
 ```
 
 Similarly you can use an aws bucket (set environment variable: AWS_S3_BUCKET):

--- a/docs/howto/using-terragrunt.mdx
+++ b/docs/howto/using-terragrunt.mdx
@@ -73,9 +73,10 @@ jobs:
           google-auth-credentials: '$\'{\'{ secrets.DIGGER_GCP_CREDENTIALS \}\}'
           setup-terragrunt: true
           terragrunt-version: 0.44.1
+          google-lock-bucket: please-create-me-for-storing-locks
         env:
           LOCK_PROVIDER: gcp
-          GOOGLE_STORAGE_BUCKET: please-create-me-for-storing-locks
+          GOOGLE_STORAGE_LOCK_BUCKET: please-create-me-for-storing-locks
           GOOGLE_ENCRYPTION_KEY: $\'{\'{ secrets.GOOGLE_ENCRYPTION_KEY \}\}
           GITHUB_CONTEXT: $\'{\'{ toJson(github) \}\}
           GITHUB_TOKEN: $\'{\'{ secrets.GITHUB_TOKEN \}\}

--- a/ee/cli/cmd/digger/main.go
+++ b/ee/cli/cmd/digger/main.go
@@ -887,9 +887,9 @@ func newPlanStorage(ghToken string, ghRepoOwner string, ghRepositoryName string,
 		}
 	} else if uploadDestination == "gcp" {
 		ctx, client := gcp.GetGoogleStorageClient()
-		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_BUCKET"))
+		bucketName := strings.ToLower(os.Getenv("GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET"))
 		if bucketName == "" {
-			reportErrorAndExit(requestedBy, fmt.Sprintf("GOOGLE_STORAGE_BUCKET is not defined"), 9)
+			reportErrorAndExit(requestedBy, fmt.Sprintf("GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET is not defined"), 9)
 		}
 		bucket := client.Bucket(bucketName)
 		planStorage = &storage.PlanStorageGcp{


### PR DESCRIPTION
In case of GCP we had been accepting env variables as raw inputs to the digger action, we want to change it to action arguments since they are validated by GH. Another issue was we had a naming clash of GOOGLE_STORAGE_BUCKET for both plan storage and locking bucket. We switch to more explicit naming to avoid this clash. Changes:

- For plan artefacts storage we use upload-plan-destination-gcp-bucket and underlying env variable will be GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET
- For locking we use google-lock-bucket and env variable will be GOOGLE_STORAGE_LOCK_BUCKET

fixes #1409 