### PR TITLE
fix: remove unexpected input from cache action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -361,8 +361,6 @@ runs:
       with:
         path: ${{ github.workspace }}/cache
         key: digger-cache-${{ hashFiles('**/cache') }}
-        restore-keys: |
-          digger-cache-
 
 branding:
   icon: globe


### PR DESCRIPTION
the cache/save action does not use a restore-keys input

this was incorectly added by me in #1411 