### PR TITLE
Updated the docs related to storing plans in AWS

### DIFF
--- a/docs/gcp/store-plans-in-a-bucket.mdx
+++ b/docs/gcp/store-plans-in-a-bucket.mdx
@@ -1,9 +1,0 @@
----
-title: "Store plans in a Bucket"
----
-
-By default Digger uses Github Artifacts to store `terraform plan` outputs.
-
-You can configure it to use GCP Buckets instead. This is handy in case you want your plan outputs to stay within your organisation’s network for security or compliance reasons.
-
-To do it, set the `PLAN_UPLOAD_DESTINATION` env var to `gcp in your Actions.`

--- a/docs/howto/store-plans-in-a-bucket.mdx
+++ b/docs/howto/store-plans-in-a-bucket.mdx
@@ -1,0 +1,25 @@
+---
+title: "Store plans in a Bucket"
+--
+
+### Github 
+By default Digger uses Github Artifacts to store `terraform plan` outputs.
+
+### GCP 
+You can also configure plan outputs to be uploaded to GCP Buckets instead. This is handy in case you want your plan outputs to stay within your organisation’s network for security or compliance reasons.
+
+To change change digger to upload the plan to GCP set the follow environment variables in the digger_workflow.yml file
+
+```
+PLAN_UPLOAD_DESTINATION = 'gcp'
+GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET = 'terraform-plan-output-1239123'
+```
+
+### AWS 
+You can also use AWS S3 buckets to store plan outputs.  
+
+To change digger to upload the plan to AWS S3 set the following environment variables in the digger_workflow.yaml
+
+```
+PLAN_UPLOAD_DESTINATION = 'aws'
+AWS_S3_BUCKET = '

--- a/docs/howto/store-plans-in-a-bucket.mdx
+++ b/docs/howto/store-plans-in-a-bucket.mdx
@@ -22,4 +22,5 @@ To change digger to upload the plan to AWS S3 set the following environment vari
 
 ```
 PLAN_UPLOAD_DESTINATION = 'aws'
-AWS_S3_BUCKET = '
+AWS_S3_BUCKET = 'terraform-plan-output-1239123'
+```

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -79,6 +79,7 @@
               "howto/policy-overrides",
               "howto/project-level-roles",
               "howto/segregate-cloud-accounts",
+              "gcp/store-plans-in-a-bucket",
               "howto/trigger-directly",
               "howto/using-checkov",
               "howto/using-infracost",
@@ -128,8 +129,7 @@
             "group": "GCP-specific",
             "pages": [
               "gcp/setting-up-gcp-+-gh-actions",
-              "gcp/federated-oidc-access",
-              "gcp/store-plans-in-a-bucket"
+              "gcp/federated-oidc-access"
             ]
         },
         {


### PR DESCRIPTION
This updates some missing documentation how to use a different place for Upload destination, specifically S3.  I move the article out of GCP since it is no longer GCP specific. 