### PR TITLE
do not regenerate projects on the cli side

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -531,7 +531,7 @@ func getDiggerConfigForBranch(gh utils.GithubClientProvider, installationId int6
 	err = utils.CloneGitRepoAndDoAction(cloneUrl, branch, *token, func(dir string) error {
 		diggerYmlBytes, err := os.ReadFile(path.Join(dir, "digger.yml"))
 		diggerYmlStr = string(diggerYmlBytes)
-		config, _, dependencyGraph, err = dg_configuration.LoadDiggerConfig(dir)
+		config, _, dependencyGraph, err = dg_configuration.LoadDiggerConfig(dir, true)
 		if err != nil {
 			log.Printf("Error loading digger config: %v", err)
 			return err

--- a/cli/cmd/digger/main.go
+++ b/cli/cmd/digger/main.go
@@ -178,7 +178,7 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 			reportErrorAndExit(githubActor, fmt.Sprintf("Failed to run commands. %s", err), 5)
 		}
 
-		diggerConfig, _, _, err := digger_config.LoadDiggerConfig("./")
+		diggerConfig, _, _, err := digger_config.LoadDiggerConfig("./", false)
 		if err != nil {
 			reportErrorAndExit(githubActor, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 		}
@@ -205,7 +205,7 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 		reportErrorAndExit(githubActor, "Digger finished successfully", 0)
 	}
 
-	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig("./")
+	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig("./", true)
 	if err != nil {
 		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -432,7 +432,7 @@ func gitLabCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 	}
 	log.Printf("main: working dir: %s \n", currentDir)
 
-	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir)
+	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir, true)
 	if err != nil {
 		reportErrorAndExit(projectNamespace, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -536,7 +536,7 @@ func azureCI(lock core_locking.Lock, policyChecker core_policy.Checker, backendA
 	}
 	log.Printf("main: working dir: %s \n", currentDir)
 
-	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir)
+	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir, true)
 	if err != nil {
 		reportErrorAndExit(parsedAzureContext.BaseUrl, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -628,7 +628,7 @@ func bitbucketCI(lock core_locking.Lock, policyChecker core_policy.Checker, back
 		reportErrorAndExit(actor, fmt.Sprintf("Failed to get current dir. %s", err), 4)
 	}
 
-	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./")
+	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./", true)
 	if err != nil {
 		reportErrorAndExit(actor, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -863,7 +863,7 @@ func exec(actor string, projectName string, repoNamespace string, command string
 
 	planStorage := newPlanStorage("", "", "", actor, nil)
 
-	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./")
+	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./", true)
 	if err != nil {
 		reportErrorAndExit(actor, fmt.Sprintf("Failed to load digger config. %s", err), 4)
 	}

--- a/cli/pkg/integration/integration_test.go
+++ b/cli/pkg/integration/integration_test.go
@@ -358,7 +358,7 @@ func TestHappyPath(t *testing.T) {
 	terraform.CreateValidTerraformTestFile(dir)
 	terraform.CreateSingleEnvDiggerYmlFile(dir)
 
-	diggerConfig, _, _, err := configuration.LoadDiggerConfig(dir)
+	diggerConfig, _, _, err := configuration.LoadDiggerConfig(dir, true)
 	assert.NoError(t, err)
 
 	lock, err := locking.GetLock()
@@ -511,7 +511,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	terraform.CreateValidTerraformTestFile(dir)
 	terraform.CreateMultiEnvDiggerYmlFile(dir)
 
-	diggerConfig, _, _, err := configuration.LoadDiggerConfig(dir)
+	diggerConfig, _, _, err := configuration.LoadDiggerConfig(dir, true)
 	assert.NoError(t, err)
 
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
@@ -730,7 +730,7 @@ workflows:
 	terraform.CreateValidTerraformTestFile(dir)
 	terraform.CreateCustomDiggerYmlFile(dir, diggerCfg)
 
-	diggerConfig, _, _, err := configuration.LoadDiggerConfig(dir)
+	diggerConfig, _, _, err := configuration.LoadDiggerConfig(dir, true)
 	assert.NoError(t, err)
 
 	assert.NotNil(t, diggerConfig.Workflows)

--- a/cli/pkg/usage/usage.go
+++ b/cli/pkg/usage/usage.go
@@ -95,7 +95,7 @@ func init() {
 		source = "azure"
 	}
 
-	config, _, _, err := configuration.LoadDiggerConfig(currentDir)
+	config, _, _, err := configuration.LoadDiggerConfig(currentDir, false)
 	if err != nil {
 		return
 	}

--- a/ee/cli/cmd/digger/main.go
+++ b/ee/cli/cmd/digger/main.go
@@ -183,7 +183,7 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 		reportErrorAndExit(githubActor, "Digger finished successfully", 0)
 	}
 
-	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig("./")
+	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig("./", true)
 	if err != nil {
 		reportErrorAndExit(githubActor, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -406,7 +406,7 @@ func gitLabCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 	}
 	log.Printf("main: working dir: %s \n", currentDir)
 
-	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir)
+	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir, true)
 	if err != nil {
 		reportErrorAndExit(projectNamespace, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -510,7 +510,7 @@ func azureCI(lock core_locking.Lock, policyChecker core_policy.Checker, backendA
 	}
 	log.Printf("main: working dir: %s \n", currentDir)
 
-	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir)
+	diggerConfig, diggerConfigYaml, dependencyGraph, err := digger_config.LoadDiggerConfig(currentDir, true)
 	if err != nil {
 		reportErrorAndExit(parsedAzureContext.BaseUrl, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -602,7 +602,7 @@ func bitbucketCI(lock core_locking.Lock, policyChecker core_policy.Checker, back
 		reportErrorAndExit(actor, fmt.Sprintf("Failed to get current dir. %s", err), 4)
 	}
 
-	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./")
+	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./", true)
 	if err != nil {
 		reportErrorAndExit(actor, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}
@@ -833,7 +833,7 @@ func exec(actor string, projectName string, repoNamespace string, command string
 
 	planStorage := newPlanStorage("", "", "", actor, nil)
 
-	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./")
+	diggerConfig, _, dependencyGraph, err := digger_config.LoadDiggerConfig("./", true)
 	if err != nil {
 		reportErrorAndExit(actor, fmt.Sprintf("Failed to load digger config. %s", err), 4)
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -117,6 +117,7 @@ cloud.google.com/go/grafeas v0.3.4 h1:D4x32R/cHX3MTofKwirz015uEdVk4uAxvZkZCZkOrF
 cloud.google.com/go/grafeas v0.3.4/go.mod h1:A5m316hcG+AulafjAbPKXBO/+I5itU4LOdKO2R/uDIc=
 cloud.google.com/go/gsuiteaddons v1.6.5 h1:CZEbaBwmbYdhFw21Fwbo+C35HMe36fTE0FBSR4KSfWg=
 cloud.google.com/go/gsuiteaddons v1.6.5/go.mod h1:Lo4P2IvO8uZ9W+RaC6s1JVxo42vgy+TX5a6hfBZ0ubs=
+cloud.google.com/go/iam v1.1.6/go.mod h1:O0zxdPeGBoFdWW3HWmBxJsk0pfvNM/p/qa82rWOGTwI=
 cloud.google.com/go/iap v1.9.4 h1:94zirc2r4t6KzhAMW0R6Dme005eTP6yf7g6vN4IhRrA=
 cloud.google.com/go/iap v1.9.4/go.mod h1:vO4mSq0xNf/Pu6E5paORLASBwEmphXEjgCFg7aeNu1w=
 cloud.google.com/go/ids v1.4.5 h1:xd4U7pgl3GHV+MABnv1BF4/Vy/zBF7CYC8XngkOLzag=
@@ -338,7 +339,6 @@ github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
-github.com/caarlos0/env/v11 v11.0.0 h1:ZIlkOjuL3xoZS0kmUJlF74j2Qj8GMOq3CDLX/Viak8Q=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/charmbracelet/bubbles v0.16.1 h1:6uzpAAaT9ZqKssntbvZMlksWHruQLNxg49H5WdeuYSY=
@@ -363,6 +363,8 @@ github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJ
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe h1:QQ3GSy+MqSHxm/d8nCtnAiZdYFd45cYZPs8vOOIYKfk=
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20231109132714-523115ebc101/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa h1:jQCWAUqqlij9Pgj2i/PB79y4KOPYVyFYdROxgaCwdTQ=
+github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa/go.mod h1:x/1Gn8zydmfq8dk6e9PdstVsDgu9RuyIIJqAaF//0IM=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
@@ -403,6 +405,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633 h1:H2pdYOb3KQ1
 github.com/envoyproxy/go-control-plane v0.12.0 h1:4X+VP1GHd1Mhj6IB5mMeGbLCleqxjletLK6K0rbxyZI=
 github.com/envoyproxy/go-control-plane v0.12.0/go.mod h1:ZBTaoJ23lqITozF0M6G4/IragXCQKCnYbmlmtHvwRG0=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
+github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU4zdyUgIUNhlgg0A=
+github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=
 github.com/flosch/pongo2/v4 v4.0.2 h1:gv+5Pe3vaSVmiJvh/BZa82b7/00YUGm0PIyVVLop0Hw=
@@ -456,6 +460,7 @@ github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/googleapis/gax-go/v2 v2.12.1/go.mod h1:61M8vcyyXR2kqKFxKrfA22jaA8JGF7Dc8App1U3H6jc=
+github.com/googleapis/gax-go/v2 v2.12.2/go.mod h1:61M8vcyyXR2kqKFxKrfA22jaA8JGF7Dc8App1U3H6jc=
 github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
@@ -640,6 +645,7 @@ github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Q
 github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d h1:PinQItctnaL2LtkaSM678+ZLLy5TajwOeXzWvYC7tII=
 github.com/pquerna/otp v1.2.1-0.20191009055518-468c2dd2b58d/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
+github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
 github.com/pterm/pterm v0.12.41 h1:e2BRfFo1H9nL8GY0S3ImbZqfZ/YimOk9XtkhoobKJVs=
 github.com/pterm/pterm v0.12.41/go.mod h1:LW/G4J2A42XlTaPTAGRPvbBfF4UXvHWhC6SN7ueU4jU=
 github.com/quasoft/memstore v0.0.0-20191010062613-2bce066d2b0b h1:aUNXCGgukb4gtY99imuIeoh8Vr0GSwAlYxPAhqZrpFc=
@@ -732,11 +738,16 @@ go.etcd.io/etcd/client/v3 v3.5.10/go.mod h1:RVeBnDz2PUEZqTpgqwAtUd8nAPf5kjyFyND7
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0/go.mod h1:r9vWsPS/3AQItv3OSlEJ/E4mbrhUbbw18meOjArPtKQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0/go.mod h1:tIKj3DbO8N9Y2xo52og3irLsPI4GW02DSMtrVgNMgxg=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.47.0/go.mod h1:SK2UL73Zy1quvRPonmOmRDiWk1KBV3LyIeeIxcEApWw=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0/go.mod h1:rdENBZMT2OE6Ne/KLwpiXudnAsbdrdBaqBvTN8M8BgA=
 go.opentelemetry.io/otel v1.22.0/go.mod h1:eoV4iAi3Ea8LkAEI9+GFT44O6T/D0GWAVFyZVCC6pMI=
+go.opentelemetry.io/otel v1.23.0/go.mod h1:YCycw9ZeKhcJFrb34iVSkyT0iczq/zYDtZYFufObyB0=
 go.opentelemetry.io/otel/metric v1.22.0/go.mod h1:evJGjVpZv0mQ5QBRJoBF64yMuOf4xCWdXjK8pzFvliY=
+go.opentelemetry.io/otel/metric v1.23.0/go.mod h1:MqUW2X2a6Q8RN96E2/nqNoT+z9BSms20Jb7Bbp+HiTo=
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
 go.opentelemetry.io/otel/trace v1.22.0/go.mod h1:RbbHXVqKES9QhzZq/fE5UnOSILqRt40a21sPw2He1xo=
+go.opentelemetry.io/otel/trace v1.23.0/go.mod h1:GSGTbIClEsuZrGIzoEHqsVfxgn5UkggkflQwDScNUsk=
 go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
 go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
@@ -746,18 +757,22 @@ golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
+golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.14.0/go.mod h1:lAtNWgaWfL4cm7j2OV8TxGi9Qb7ECORx8DktCY74OwM=
 golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
 golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
+golang.org/x/oauth2 v0.17.0/go.mod h1:OzPDGQiuQMguemayvdylqddI7qcD9lnSDb+1FiwQ5HA=
 golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2 h1:IRJeR9r1pYWsHKTRe/IInb7lYvbBVIqOgsX/u0mbOWY=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
 google.golang.org/api v0.152.0/go.mod h1:3qNJX5eOmhiWYc67jRA/3GsDw97UFb5ivv7Y2PrriAY=
@@ -770,6 +785,7 @@ google.golang.org/genproto v0.0.0-20240116215550-a9fa1716bcac/go.mod h1:+Rvu7ElI
 google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80/go.mod h1:cc8bqMqtv9gMOr0zHg2Vzff5ULhhL2IXP4sbcn32Dro=
 google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:cc8bqMqtv9gMOr0zHg2Vzff5ULhhL2IXP4sbcn32Dro=
 google.golang.org/genproto v0.0.0-20240205150955-31a09d347014/go.mod h1:xEgQu1e4stdSSsxPDK8Azkrk/ECl5HvdPf6nbZrTS5M=
+google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9/go.mod h1:mqHbVIp48Muh7Ywss/AD6I5kNVKZMmAa/QEW58Gxp2s=
 google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d/go.mod h1:KjSP20unUpOx5kyQUFa7k4OJg0qeJ7DEZflGDu2p6Bk=
 google.golang.org/genproto/googleapis/api v0.0.0-20240123012728-ef4313101c80/go.mod h1:4jWUdICTdgc3Ibxmr8nAJiiLHwQBY0UI0XZcEMaFKaA=
 google.golang.org/genproto/googleapis/api v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:4jWUdICTdgc3Ibxmr8nAJiiLHwQBY0UI0XZcEMaFKaA=
@@ -794,6 +810,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240304161311-37d4d3c04a78/go.
 google.golang.org/grpc v1.61.0/go.mod h1:VUbo7IFqmF1QtCAstipjG0GIoq49KvMe9+h1jFLBNJs=
 google.golang.org/grpc v1.61.1/go.mod h1:VUbo7IFqmF1QtCAstipjG0GIoq49KvMe9+h1jFLBNJs=
 google.golang.org/grpc v1.62.0/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
+google.golang.org/grpc v1.62.1/go.mod h1:IWTG0VlJLCh1SkC58F7np9ka9mx/WNkjl4PGJaiq+QE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -131,9 +131,9 @@ func (walker *FileSystemTerragruntDirWalker) GetDirs(workingDir string, configYa
 
 var ErrDiggerConfigConflict = errors.New("more than one digger digger_config file detected, please keep either 'digger.yml' or 'digger.yaml'")
 
-func LoadDiggerConfig(workingDir string) (*DiggerConfig, *DiggerConfigYaml, graph.Graph[string, Project], error) {
+func LoadDiggerConfig(workingDir string, generateProjects bool) (*DiggerConfig, *DiggerConfigYaml, graph.Graph[string, Project], error) {
 	config := &DiggerConfig{}
-	configYaml, err := LoadDiggerConfigYaml(workingDir)
+	configYaml, err := LoadDiggerConfigYaml(workingDir, generateProjects)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -243,7 +243,7 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string) 
 	return nil
 }
 
-func LoadDiggerConfigYaml(workingDir string) (*DiggerConfigYaml, error) {
+func LoadDiggerConfigYaml(workingDir string, generateProjects bool) (*DiggerConfigYaml, error) {
 	configYaml := &DiggerConfigYaml{}
 	fileName, err := retrieveConfigFile(workingDir)
 	if err != nil {
@@ -279,9 +279,11 @@ func LoadDiggerConfigYaml(workingDir string) (*DiggerConfigYaml, error) {
 		return configYaml, err
 	}
 
-	err = HandleYamlProjectGeneration(configYaml, workingDir)
-	if err != nil {
-		return configYaml, err
+	if generateProjects == true {
+		err = HandleYamlProjectGeneration(configYaml, workingDir)
+		if err != nil {
+			return configYaml, err
+		}
 	}
 
 	return configYaml, nil

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -34,7 +34,7 @@ func TestDiggerConfigWhenMultipleConfigExist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.Error(t, err, "expected error to be returned")
 	assert.ErrorContains(t, err, ErrDiggerConfigConflict.Error(), "expected error to match target error")
 	assert.Nil(t, dg, "expected diggerConfig to be nil")
@@ -75,7 +75,7 @@ projects:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "path/to/module/test", dg.GetDirectory("prod"))
@@ -90,7 +90,7 @@ func TestNoDiggerYaml(t *testing.T) {
 	defer deleteFile()
 
 	os.Chdir(tempDir)
-	dg, _, _, err := LoadDiggerConfig("./")
+	dg, _, _, err := LoadDiggerConfig("./", true)
 
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
@@ -131,7 +131,7 @@ projects:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	fmt.Printf("%v", err)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
@@ -174,7 +174,7 @@ projects:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	fmt.Printf("%v", err)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
@@ -195,7 +195,7 @@ projects:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "default", dg.Projects[0].Workflow)
@@ -217,7 +217,7 @@ projects:
 	deleteFile := createFile(path.Join(tempDir, "digger.yml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "path/to/module", dg.GetDirectory("dev"))
@@ -242,7 +242,7 @@ workflows:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.Equal(t, Step{Action: "run", Value: "echo \"hello\"", Shell: ""}, dg.Workflows["myworkflow"].Plan.Steps[0], "parsed struct does not match expected struct")
 }
@@ -287,7 +287,7 @@ workflows:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.Equal(t, []EnvVar{
 		{Name: "TF_VAR_state", Value: "s3://mybucket/terraform.tfstate"},
@@ -327,7 +327,7 @@ workflows:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.Equal(t, Step{Action: "run", Value: "rm -rf .terraform", Shell: ""}, dg.Workflows["dev"].Plan.Steps[0], "parsed struct does not match expected struct")
 	assert.Equal(t, Step{Action: "init", ExtraArgs: nil, Shell: ""}, dg.Workflows["dev"].Plan.Steps[1], "parsed struct does not match expected struct")
@@ -357,7 +357,7 @@ generate_projects:
 		assert.NoError(t, err, "expected error to be nil")
 	}
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "dev_test1", dg.Projects[0].Name)
@@ -385,7 +385,7 @@ func TestGenerateProjectsWithoutDiggerConfig(t *testing.T) {
 		assert.NoError(t, err, "expected error to be nil")
 	}
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "dev_project", dg.Projects[0].Name)
@@ -421,7 +421,7 @@ generate_projects:
 		assert.NoError(t, err, "expected error to be nil")
 	}
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "dev_test1_utils", dg.Projects[0].Name)
@@ -447,7 +447,7 @@ func TestDiggerGenerateProjectsWithTfvars(t *testing.T) {
 
 	defer createFile(path.Join(tempDir, "dev", "blank.tfvars"), "")()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, 1, len(dg.Projects))
@@ -476,7 +476,7 @@ generate_projects:
 		defer createFile(path.Join(tempDir, dir, "main.tf"), "")()
 		assert.NoError(t, err, "expected error to be nil")
 	}
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "dev", dg.Projects[0].Name)
@@ -491,7 +491,7 @@ func TestMissingProjectsReturnsError(t *testing.T) {
 `
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
-	_, _, _, err := LoadDiggerConfig(tempDir)
+	_, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.ErrorContains(t, err, "no projects digger_config found")
 }
 
@@ -514,7 +514,7 @@ workflows:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "my_custom_workflow", dg.Projects[0].Workflow)
@@ -536,7 +536,7 @@ projects:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	_, _, _, err := LoadDiggerConfig(tempDir)
+	_, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.Error(t, err, "failed to find workflow digger_config 'my_custom_workflow' for project 'my-first-app'")
 
 	// steps block is missing for workflows
@@ -551,7 +551,7 @@ workflows:
 	deleteFile = createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	diggerConfig, _, _, err := LoadDiggerConfig(tempDir)
+	diggerConfig, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.Equal(t, "my_custom_workflow", diggerConfig.Projects[0].Workflow)
 	workflow, ok := diggerConfig.Workflows["my_custom_workflow"]
 	assert.True(t, ok)
@@ -580,7 +580,7 @@ workflows:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	_, _, _, err := LoadDiggerConfig(tempDir)
+	_, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.Equal(t, "failed to find workflow digger_config 'my_custom_workflow' for project 'my-first-app'", err.Error())
 
 }
@@ -605,7 +605,7 @@ workflows:
 	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
 	defer deleteFile()
 
-	_, _, _, err := LoadDiggerConfig(tempDir)
+	_, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.Nil(t, err)
 }
 
@@ -845,7 +845,7 @@ workflows:
 		t.Run(tt.name, func(t *testing.T) {
 			deleteFile := createFile(path.Join(tempDir, "digger.yaml"), tt.diggerCfg)
 			defer deleteFile()
-			_, _, _, err := LoadDiggerConfig(tempDir)
+			_, _, _, err := LoadDiggerConfig(tempDir, true)
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
@@ -941,7 +941,7 @@ workflows:
 		assert.NoError(t, err, "expected error to be nil")
 	}
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, "dev_test1", dg.Projects[0].Name)
@@ -1005,7 +1005,7 @@ projects:
 	defer createFile(path.Join(tempDir, "main.tf"), "resource \"null_resource\" \"test4\" {}")()
 	defer createFile(path.Join(tempDir, "terragrunt.hcl"), "terraform {}")()
 
-	_, config, _, err := LoadDiggerConfig(tempDir)
+	_, config, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err)
 
 	print(config)
@@ -1038,7 +1038,7 @@ generate_projects:
 
 	err = createAndCloseFile(path.Join(projectDir, "digger.yml"), diggerCfg)
 	assert.NoError(t, err)
-	_, _, _, err = LoadDiggerConfig(projectDir)
+	_, _, _, err = LoadDiggerConfig(projectDir, true)
 	assert.NoError(t, err)
 }
 
@@ -1069,7 +1069,7 @@ inputs = {
 	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
 	defer createFile(path.Join(tempDir, "terragrunt.hcl"), hclFile)()
 
-	_, config, _, err := LoadDiggerConfig(tempDir)
+	_, config, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err)
 
 	print(config)
@@ -1098,7 +1098,7 @@ generate_projects:
 
 	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
 
-	_, config, _, err := LoadDiggerConfig(tempDir)
+	_, config, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 
@@ -1121,7 +1121,7 @@ func TestDiggerGenerateProjectsMultipleBlocksDemo(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, config, _, err := LoadDiggerConfig(tempDir)
+	_, config, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 	assert.Equal(t, "projects_dev_test1", config.Projects[0].Name)
@@ -1164,7 +1164,7 @@ generate_projects:
 		assert.NoError(t, err, "expected error to be nil")
 	}
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err, "expected error to be nil")
 	assert.NotNil(t, dg, "expected digger digger_config to be not nil")
 	assert.Equal(t, true, dg.TraverseToNestedProjects)
@@ -1195,7 +1195,7 @@ projects:
 	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
 	defer createFile(path.Join(tempDir, "main.tf"), "resource \"null_resource\" \"test4\" {}")()
 
-	dg, _, _, err := LoadDiggerConfig(tempDir)
+	dg, _, _, err := LoadDiggerConfig(tempDir, true)
 	assert.NoError(t, err)
 	assert.Equal(t, false, dg.AllowDraftPRs)
 }


### PR DESCRIPTION
Avoid regenerating projects on the cli side if we are in the workflow_dispatch side since we have already performed the project generation on the orchestrator side. Also avoid generation of projects in the `usage.go` part, since we only need to pick up one boolean from it

