### PR TITLE
fix issues with port loading from config

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"github.com/spf13/cast"
+	"os"
 	"strings"
 	"time"
 
@@ -24,6 +26,14 @@ func New() *Config {
 	v.SetDefault("max_concurrency_per_batch", "0")
 	v.BindEnv()
 	return v
+}
+
+func GetPort() int {
+	port := cast.ToInt(os.Getenv("PORT"))
+	if port == 0 {
+		port = 3000
+	}
+	return port
 }
 
 func init() {

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/diggerhq/digger/backend/segment"
 	"github.com/diggerhq/digger/backend/config"
+	"github.com/diggerhq/digger/backend/segment"
 	"html/template"
 	"io/fs"
 	"log"
@@ -186,7 +186,9 @@ func main() {
 	runsApiGroup.POST("/:run_id/approve", controllers.ApproveRun)
 
 	fronteggWebhookProcessor.POST("/create-org-from-frontegg", controllers.CreateFronteggOrgFromWebhook)
-	r.Run(fmt.Sprintf(":%d", cfg.GetInt("port")))
+
+	port := config.GetPort()
+	r.Run(fmt.Sprintf(":%d", port))
 }
 
 func initLogging() {


### PR DESCRIPTION
Hotfix: v0.4.25, v0.4.26

An issue with viper is preventing port from loading correctly in some k8s instances reported (#1456). Fixes by loading directly from env variable while the viper issue is sorted