### PR TITLE
Added bool that was missing for LoadDiggerConfig

### DIFF
--- a/dgctl/cmd/validate.go
+++ b/dgctl/cmd/validate.go
@@ -6,10 +6,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/diggerhq/digger/libs/digger_config"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
+
+	"github.com/diggerhq/digger/libs/digger_config"
+	"github.com/spf13/cobra"
 )
 
 // validateCmd represents the validate command
@@ -18,7 +19,7 @@ var validateCmd = &cobra.Command{
 	Short: "Validate a digger.yml file",
 	Long:  `Validate a digger.yml file`,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, configYaml, _, err := digger_config.LoadDiggerConfig("./", false)
+		_, configYaml, _, err := digger_config.LoadDiggerConfig("./", true)
 		if err != nil {
 			log.Printf("Invalid digger config file: %v. Exiting.", err)
 			os.Exit(1)

--- a/dgctl/cmd/validate.go
+++ b/dgctl/cmd/validate.go
@@ -18,7 +18,7 @@ var validateCmd = &cobra.Command{
 	Short: "Validate a digger.yml file",
 	Long:  `Validate a digger.yml file`,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, configYaml, _, err := digger_config.LoadDiggerConfig("./")
+		_, configYaml, _, err := digger_config.LoadDiggerConfig("./", false)
 		if err != nil {
 			log.Printf("Invalid digger config file: %v. Exiting.", err)
 			os.Exit(1)


### PR DESCRIPTION
I was getting the following error when trying to build dgctl to test the new cli

```sh
cmd/validate.go:21:59: not enough arguments in call to digger_config.LoadDiggerConfig
	have (string)
	want (string, bool)
```

It looks like the arg is to generate projects, so made the assumption this should be false for validation of config. 