### PR TITLE
support jobtype in report title

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -500,7 +500,7 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 	}
 
 	batchType := getBatchType(jobsForImpactedProjects)
-	batchId, _, err := utils.ConvertJobsToDiggerJobs("", organisationId, impactedJobsMap, impactedProjectsMap, impactedProjectsSourceMapping, projectsGraph, installationId, *branch, prNumber, repoOwner, repoName, repoFullName, commentReporter.CommentId, diggerYmlStr, batchType)
+	batchId, _, err := utils.ConvertJobsToDiggerJobs(orchestrator.DiggerCommandPlan, organisationId, impactedJobsMap, impactedProjectsMap, impactedProjectsSourceMapping, projectsGraph, installationId, *branch, prNumber, repoOwner, repoName, repoFullName, commentReporter.CommentId, diggerYmlStr, batchType)
 	if err != nil {
 		log.Printf("ConvertJobsToDiggerJobs error: %v", err)
 		utils.InitCommentReporter(ghService, prNumber, fmt.Sprintf(":x: ConvertJobsToDiggerJobs error: %v", err))

--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -500,7 +500,7 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 	}
 
 	batchType := getBatchType(jobsForImpactedProjects)
-	batchId, _, err := utils.ConvertJobsToDiggerJobs(organisationId, impactedJobsMap, impactedProjectsMap, impactedProjectsSourceMapping, projectsGraph, installationId, *branch, prNumber, repoOwner, repoName, repoFullName, commentReporter.CommentId, diggerYmlStr, batchType)
+	batchId, _, err := utils.ConvertJobsToDiggerJobs("", organisationId, impactedJobsMap, impactedProjectsMap, impactedProjectsSourceMapping, projectsGraph, installationId, *branch, prNumber, repoOwner, repoName, repoFullName, commentReporter.CommentId, diggerYmlStr, batchType)
 	if err != nil {
 		log.Printf("ConvertJobsToDiggerJobs error: %v", err)
 		utils.InitCommentReporter(ghService, prNumber, fmt.Sprintf(":x: ConvertJobsToDiggerJobs error: %v", err))
@@ -642,6 +642,13 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		return fmt.Errorf("error initializing comment reporter")
 	}
 
+	diggerCommand, err := orchestrator.GetCommandFromComment(*payload.Comment.Body)
+	if err != nil {
+		log.Printf("unkown digger command in comment: %v", *payload.Comment.Body)
+		utils.InitCommentReporter(ghService, issueNumber, fmt.Sprintf(":x: Could not recognise comment, error: %v", err))
+		return fmt.Errorf("unkown digger command in comment %v", err)
+	}
+
 	prBranchName, err := ghService.GetBranchName(issueNumber)
 	if err != nil {
 		log.Printf("GetBranchName error: %v", err)
@@ -702,7 +709,7 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 	}
 
 	batchType := getBatchType(jobs)
-	batchId, _, err := utils.ConvertJobsToDiggerJobs(orgId, impactedProjectsJobMap, impactedProjectsMap, impactedProjectsSourceMapping, projectsGraph, installationId, *branch, issueNumber, repoOwner, repoName, repoFullName, commentReporter.CommentId, diggerYmlStr, batchType)
+	batchId, _, err := utils.ConvertJobsToDiggerJobs(*diggerCommand, orgId, impactedProjectsJobMap, impactedProjectsMap, impactedProjectsSourceMapping, projectsGraph, installationId, *branch, issueNumber, repoOwner, repoName, repoFullName, commentReporter.CommentId, diggerYmlStr, batchType)
 	if err != nil {
 		log.Printf("ConvertJobsToDiggerJobs error: %v", err)
 		utils.InitCommentReporter(ghService, issueNumber, fmt.Sprintf(":x: ConvertJobsToDiggerJobs error: %v", err))

--- a/backend/controllers/github_after_merge.go
+++ b/backend/controllers/github_after_merge.go
@@ -217,7 +217,7 @@ func handlePushEventApplyAfterMerge(gh utils.GithubClientProvider, payload *gith
 				return fmt.Errorf("error creating job token")
 			}
 
-			planJobSpec, err := json.Marshal(orchestrator.JobToJson(planJob, orgName, planJobToken.Value, backendHostName, impactedProjects[i], impactedProjectsSourceMapping))
+			planJobSpec, err := json.Marshal(orchestrator.JobToJson(planJob, orchestrator.DiggerCommandPlan, orgName, planJobToken.Value, backendHostName, impactedProjects[i], impactedProjectsSourceMapping))
 			if err != nil {
 				log.Printf("Error creating jobspec: %v %v", projectName, err)
 				return fmt.Errorf("error creating jobspec")
@@ -230,7 +230,7 @@ func handlePushEventApplyAfterMerge(gh utils.GithubClientProvider, payload *gith
 				return fmt.Errorf("error creating job token")
 			}
 
-			applyJobSpec, err := json.Marshal(orchestrator.JobToJson(applyJob, orgName, applyJobToken.Value, backendHostName, impactedProjects[i], impactedProjectsSourceMapping))
+			applyJobSpec, err := json.Marshal(orchestrator.JobToJson(applyJob, orchestrator.DiggerCommandApply, orgName, applyJobToken.Value, backendHostName, impactedProjects[i], impactedProjectsSourceMapping))
 			if err != nil {
 				log.Printf("Error creating jobs: %v %v", projectName, err)
 				return fmt.Errorf("error creating jobs")

--- a/backend/controllers/github_test.go
+++ b/backend/controllers/github_test.go
@@ -735,7 +735,7 @@ func TestJobsTreeWithOneJobsAndTwoProjects(t *testing.T) {
 	graph, err := configuration.CreateProjectDependencyGraph(projects)
 	assert.NoError(t, err)
 
-	_, result, err := utils.ConvertJobsToDiggerJobs(1, jobs, projectMap, impactedProjectsSourceMapping, graph, 41584295, "", 2, "diggerhq", "parallel_jobs_demo", "diggerhq/parallel_jobs_demo", 123, "test", orchestrator_scheduler.BatchTypeApply)
+	_, result, err := utils.ConvertJobsToDiggerJobs("", 1, jobs, projectMap, impactedProjectsSourceMapping, graph, 41584295, "", 2, "diggerhq", "parallel_jobs_demo", "diggerhq/parallel_jobs_demo", 123, "test", orchestrator_scheduler.BatchTypeApply)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(result))
 	parentLinks, err := models.DB.GetDiggerJobParentLinksChildId(&result["dev"].DiggerJobID)
@@ -766,7 +766,7 @@ func TestJobsTreeWithTwoDependantJobs(t *testing.T) {
 
 	impactedProjectsSourceMapping := make(map[string]configuration.ProjectToSourceMapping)
 
-	_, result, err := utils.ConvertJobsToDiggerJobs(1, jobs, projectMap, impactedProjectsSourceMapping, graph, 123, "", 2, "", "", "test", 123, "test", orchestrator_scheduler.BatchTypeApply)
+	_, result, err := utils.ConvertJobsToDiggerJobs("", 1, jobs, projectMap, impactedProjectsSourceMapping, graph, 123, "", 2, "", "", "test", 123, "test", orchestrator_scheduler.BatchTypeApply)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(result))
 
@@ -801,7 +801,7 @@ func TestJobsTreeWithTwoIndependentJobs(t *testing.T) {
 
 	impactedProjectsSourceMapping := make(map[string]configuration.ProjectToSourceMapping)
 
-	_, result, err := utils.ConvertJobsToDiggerJobs(1, jobs, projectMap, impactedProjectsSourceMapping, graph, 123, "", 2, "", "", "test", 123, "test", orchestrator_scheduler.BatchTypeApply)
+	_, result, err := utils.ConvertJobsToDiggerJobs("", 1, jobs, projectMap, impactedProjectsSourceMapping, graph, 123, "", 2, "", "", "test", 123, "test", orchestrator_scheduler.BatchTypeApply)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(result))
 	parentLinks, err := models.DB.GetDiggerJobParentLinksChildId(&result["dev"].DiggerJobID)
@@ -848,7 +848,7 @@ func TestJobsTreeWithThreeLevels(t *testing.T) {
 
 	impactedProjectsSourceMapping := make(map[string]configuration.ProjectToSourceMapping)
 
-	_, result, err := utils.ConvertJobsToDiggerJobs(1, jobs, projectMap, impactedProjectsSourceMapping, graph, 123, "", 2, "", "", "test", 123, "test", orchestrator_scheduler.BatchTypeApply)
+	_, result, err := utils.ConvertJobsToDiggerJobs("", 1, jobs, projectMap, impactedProjectsSourceMapping, graph, 123, "", 2, "", "", "test", 123, "test", orchestrator_scheduler.BatchTypeApply)
 	assert.NoError(t, err)
 	assert.Equal(t, 6, len(result))
 	parentLinks, err := models.DB.GetDiggerJobParentLinksChildId(&result["111"].DiggerJobID)

--- a/backend/utils/graphs.go
+++ b/backend/utils/graphs.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ConvertJobsToDiggerJobs jobs is map with project name as a key and a Job as a value
-func ConvertJobsToDiggerJobs(organisationId uint, jobsMap map[string]orchestrator.Job, projectMap map[string]configuration.Project, impactedProjectsSourceMapping map[string]configuration.ProjectToSourceMapping, projectsGraph graph.Graph[string, configuration.Project], githubInstallationId int64, branch string, prNumber int, repoOwner string, repoName string, repoFullName string, commentId int64, diggerConfigStr string, batchType orchestrator_scheduler.DiggerBatchType) (*uuid.UUID, map[string]*models.DiggerJob, error) {
+func ConvertJobsToDiggerJobs(jobType orchestrator.DiggerCommand, organisationId uint, jobsMap map[string]orchestrator.Job, projectMap map[string]configuration.Project, impactedProjectsSourceMapping map[string]configuration.ProjectToSourceMapping, projectsGraph graph.Graph[string, configuration.Project], githubInstallationId int64, branch string, prNumber int, repoOwner string, repoName string, repoFullName string, commentId int64, diggerConfigStr string, batchType orchestrator_scheduler.DiggerBatchType) (*uuid.UUID, map[string]*models.DiggerJob, error) {
 	result := make(map[string]*models.DiggerJob)
 	organisation, err := models.DB.GetOrganisationById(organisationId)
 	if err != nil {
@@ -35,7 +35,7 @@ func ConvertJobsToDiggerJobs(organisationId uint, jobsMap map[string]orchestrato
 			return nil, nil, fmt.Errorf("error creating job token")
 		}
 
-		marshalled, err := json.Marshal(orchestrator.JobToJson(job, organisationName, jobToken.Value, backendHostName, projectMap[projectName], impactedProjectsSourceMapping))
+		marshalled, err := json.Marshal(orchestrator.JobToJson(job, jobType, organisationName, jobToken.Value, backendHostName, projectMap[projectName], impactedProjectsSourceMapping))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cli/cmd/digger/main.go
+++ b/cli/cmd/digger/main.go
@@ -169,8 +169,7 @@ func gitHubCI(lock core_locking.Lock, policyChecker core_policy.Checker, backend
 		log.Printf("Warn: Overriding commenting strategy to Comments-per-run")
 
 		strategy := &reporting.CommentPerRunStrategy{
-			Project:   jobSpec.ProjectName,
-			IsPlan:    jobSpec.IsPlan(),
+			Title:     fmt.Sprintf("%v for %v", jobSpec.JobType, jobSpec.ProjectName),
 			TimeOfRun: time.Now(),
 		}
 		cireporter := &reporting.CiReporter{

--- a/cli/pkg/reporting/reporting.go
+++ b/cli/pkg/reporting/reporting.go
@@ -109,8 +109,7 @@ type ReportStrategy interface {
 }
 
 type CommentPerRunStrategy struct {
-	IsPlan    bool
-	Project   string
+	Title     string
 	TimeOfRun time.Time
 }
 
@@ -121,12 +120,8 @@ func (strategy *CommentPerRunStrategy) Report(ciService orchestrator.PullRequest
 	}
 
 	var reportTitle string
-	if strategy.Project != "" {
-		if strategy.IsPlan {
-			reportTitle = fmt.Sprintf("Plan for %v (%v)", strategy.Project, strategy.TimeOfRun.Format("2006-01-02 15:04:05 (MST)"))
-		} else {
-			reportTitle = fmt.Sprintf("Apply for %v (%v)", strategy.Project, strategy.TimeOfRun.Format("2006-01-02 15:04:05 (MST)"))
-		}
+	if strategy.Title != "" {
+		reportTitle = strategy.Title + " " + strategy.TimeOfRun.Format("2006-01-02 15:04:05 (MST)")
 	} else {
 		reportTitle = "Digger run report at " + strategy.TimeOfRun.Format("2006-01-02 15:04:05 (MST)")
 	}

--- a/ee/cli/cmd/digger/main_test.go
+++ b/ee/cli/cmd/digger/main_test.go
@@ -896,7 +896,7 @@ func TestGitHubNewPullRequestContext(t *testing.T) {
 	}
 
 	event := context.Event.(github.PullRequestEvent)
-	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, map[string]configuration.Workflow{})
+	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs("", &event, impactedProjects, requestedProject, map[string]configuration.Workflow{})
 	if err != nil {
 		assert.NoError(t, err)
 		log.Println(err)

--- a/libs/orchestrator/json_models.go
+++ b/libs/orchestrator/json_models.go
@@ -17,6 +17,7 @@ type StageJson struct {
 }
 
 type JobJson struct {
+	JobType                 DiggerCommand                                   `json:"job_type"`
 	ProjectName             string                                          `json:"projectName"`
 	ProjectDir              string                                          `json:"projectDir"`
 	ProjectWorkspace        string                                          `json:"projectWorkspace"`
@@ -47,7 +48,7 @@ func (j *JobJson) IsApply() bool {
 	return slices.Contains(j.Commands, "digger apply")
 }
 
-func JobToJson(job Job, organisationName string, jobToken string, backendHostname string, project digger_config.Project, impactedSources map[string]digger_config.ProjectToSourceMapping) JobJson {
+func JobToJson(job Job, jobType DiggerCommand, organisationName string, jobToken string, backendHostname string, project digger_config.Project, impactedSources map[string]digger_config.ProjectToSourceMapping) JobJson {
 	stateRole, commandRole := "", ""
 	if project.AwsRoleToAssume != nil {
 		stateRole = project.AwsRoleToAssume.State
@@ -55,6 +56,7 @@ func JobToJson(job Job, organisationName string, jobToken string, backendHostnam
 
 	}
 	return JobJson{
+		JobType:                 jobType,
 		ProjectName:             job.ProjectName,
 		ProjectDir:              job.ProjectDir,
 		ProjectWorkspace:        job.ProjectWorkspace,

--- a/libs/orchestrator/utils.go
+++ b/libs/orchestrator/utils.go
@@ -36,5 +36,5 @@ func GetCommandFromComment(comment string) (*DiggerCommand, error) {
 			return &value, nil
 		}
 	}
-	return nil, fmt.Errorf("Unreqcognised command: %v", comment)
+	return nil, fmt.Errorf("Unrecognised command: %v", comment)
 }

--- a/libs/orchestrator/utils.go
+++ b/libs/orchestrator/utils.go
@@ -1,7 +1,9 @@
 package orchestrator
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 )
 
 func ParseProjectName(comment string) string {
@@ -11,4 +13,28 @@ func ParseProjectName(comment string) string {
 		return match[1]
 	}
 	return ""
+}
+
+type DiggerCommand string
+
+const DiggerCommandPlan DiggerCommand = "plan"
+const DiggerCommandApply DiggerCommand = "apply"
+const DiggerCommandLock DiggerCommand = "lock"
+const DiggerCommandUnlock DiggerCommand = "unlock"
+
+func GetCommandFromComment(comment string) (*DiggerCommand, error) {
+	supportedCommands := map[string]DiggerCommand{
+		"digger plan":   DiggerCommandPlan,
+		"digger apply":  DiggerCommandApply,
+		"digger unlock": DiggerCommandUnlock,
+		"digger lock":   DiggerCommandLock,
+	}
+	diggerCommand := strings.ToLower(comment)
+	diggerCommand = strings.TrimSpace(diggerCommand)
+	for command, value := range supportedCommands {
+		if strings.HasPrefix(diggerCommand, command) {
+			return &value, nil
+		}
+	}
+	return nil, fmt.Errorf("Unreqcognised command: %v", comment)
 }


### PR DESCRIPTION
Fixes #1494

Include an argument called JobType in the JobSpec to be able to tell the type of a given job (plan, apply, unlock, lock)
Use this field to display report title in the comment reliably (previously we had been deriving it from the list of commands in the jobspec):

<img width="782" alt="Screenshot 2024-05-22 at 16 17 23" src="https://github.com/diggerhq/digger/assets/1627972/0d0bbca7-1b25-449e-9804-1996f4f9ef0a">


