### PR TITLE
improvements to render group sourcing

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -747,7 +747,8 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		return fmt.Errorf("error convertingjobs")
 	}
 
-	if config.CommentRenderMode == dg_configuration.CommentRenderModeGroupByModule {
+	if config.CommentRenderMode == dg_configuration.CommentRenderModeGroupByModule && *diggerCommand == orchestrator.DiggerCommandPlan {
+
 		sourceDetails, err := comment_updater.PostInitialSourceComments(ghService, issueNumber, impactedProjectsSourceMapping)
 		if err != nil {
 			log.Printf("PostInitialSourceComments error: %v", err)

--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -747,7 +747,8 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		return fmt.Errorf("error convertingjobs")
 	}
 
-	if config.CommentRenderMode == dg_configuration.CommentRenderModeGroupByModule && *diggerCommand == orchestrator.DiggerCommandPlan {
+	if config.CommentRenderMode == dg_configuration.CommentRenderModeGroupByModule &&
+		(*diggerCommand == orchestrator.DiggerCommandPlan || *diggerCommand == orchestrator.DiggerCommandApply) {
 
 		sourceDetails, err := comment_updater.PostInitialSourceComments(ghService, issueNumber, impactedProjectsSourceMapping)
 		if err != nil {

--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -580,8 +580,9 @@ func UpdateCommentsForBatchGroup(gh utils.GithubClientProvider, batch *models.Di
 		return fmt.Errorf("error loading digger config from batch: %v", err)
 	}
 
-	if diggerConfigYml.CommentRenderMode != nil &&
-		*diggerConfigYml.CommentRenderMode != digger_config.CommentRenderModeGroupByModule {
+	if batch.BatchType != orchestrator.DiggerCommandPlan ||
+		(diggerConfigYml.CommentRenderMode != nil &&
+			*diggerConfigYml.CommentRenderMode != digger_config.CommentRenderModeGroupByModule) {
 		log.Printf("render mode is not group_by_module, skipping")
 		return nil
 	}

--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -580,10 +580,14 @@ func UpdateCommentsForBatchGroup(gh utils.GithubClientProvider, batch *models.Di
 		return fmt.Errorf("error loading digger config from batch: %v", err)
 	}
 
-	if batch.BatchType != orchestrator.DiggerCommandPlan ||
-		(diggerConfigYml.CommentRenderMode != nil &&
-			*diggerConfigYml.CommentRenderMode != digger_config.CommentRenderModeGroupByModule) {
+	if diggerConfigYml.CommentRenderMode != nil &&
+		*diggerConfigYml.CommentRenderMode != digger_config.CommentRenderModeGroupByModule {
 		log.Printf("render mode is not group_by_module, skipping")
+		return nil
+	}
+
+	if batch.BatchType != orchestrator.DiggerCommandPlan && batch.BatchType != orchestrator.DiggerCommandApply {
+		log.Printf("command is not plan or apply, skipping")
 		return nil
 	}
 

--- a/libs/comment_utils/summary/updater.go
+++ b/libs/comment_utils/summary/updater.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"github.com/diggerhq/digger/libs/orchestrator"
 	"github.com/diggerhq/digger/libs/orchestrator/scheduler"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"log"
-	"strings"
 )
 
 type CommentUpdater interface {
@@ -24,7 +25,7 @@ func (b BasicCommentUpdater) UpdateComment(jobs []scheduler.SerializedJob, prNum
 	firstJobSpec := jobSpecs[0]
 	jobType := firstJobSpec.JobType
 	isPlan := jobType == orchestrator.DiggerCommandPlan
-	jobTypeTitle := strings.ToTitle(string(jobType))
+	jobTypeTitle := cases.Title(language.AmericanEnglish).String(string(jobType))
 	message := ""
 	if isPlan {
 		message = message + fmt.Sprintf("| Project | Status | %v | + | ~ | - |\n", jobTypeTitle)

--- a/libs/comment_utils/summary/updater.go
+++ b/libs/comment_utils/summary/updater.go
@@ -5,6 +5,7 @@ import (
 	"github.com/diggerhq/digger/libs/orchestrator"
 	"github.com/diggerhq/digger/libs/orchestrator/scheduler"
 	"log"
+	"strings"
 )
 
 type CommentUpdater interface {
@@ -21,23 +22,24 @@ func (b BasicCommentUpdater) UpdateComment(jobs []scheduler.SerializedJob, prNum
 		return err
 	}
 	firstJobSpec := jobSpecs[0]
-	isPlan := firstJobSpec.IsPlan()
-
+	jobType := firstJobSpec.JobType
+	isPlan := jobType == orchestrator.DiggerCommandPlan
+	jobTypeTitle := strings.ToTitle(string(jobType))
 	message := ""
 	if isPlan {
-		message = message + fmt.Sprintf("| Project | Status | Plan | + | ~ | - |\n")
+		message = message + fmt.Sprintf("| Project | Status | %v | + | ~ | - |\n", jobTypeTitle)
 		message = message + fmt.Sprintf("|---------|--------|------|---|---|---|\n")
 	} else {
-		message = message + fmt.Sprintf("| Project | Status | Apply |\n")
+		message = message + fmt.Sprintf("| Project | Status | %v |\n", jobTypeTitle)
 		message = message + fmt.Sprintf("|---------|--------|-------|\n")
 	}
 	for i, job := range jobs {
 		jobSpec := jobSpecs[i]
 		prCommentUrl := job.PRCommentUrl
 		if isPlan {
-			message = message + fmt.Sprintf("|%v **%v** |<a href='%v'>%v</a> | <a href='%v'>plan</a> | %v | %v | %v|\n", job.Status.ToEmoji(), jobSpec.ProjectName, *job.WorkflowRunUrl, job.Status.ToString(), prCommentUrl, job.ResourcesCreated, job.ResourcesUpdated, job.ResourcesDeleted)
+			message = message + fmt.Sprintf("|%v **%v** |<a href='%v'>%v</a> | <a href='%v'>%v</a> | %v | %v | %v|\n", job.Status.ToEmoji(), jobSpec.ProjectName, *job.WorkflowRunUrl, job.Status.ToString(), prCommentUrl, jobTypeTitle, job.ResourcesCreated, job.ResourcesUpdated, job.ResourcesDeleted)
 		} else {
-			message = message + fmt.Sprintf("|%v **%v** |<a href='%v'>%v</a> | <a href='%v'>apply</a> |\n", job.Status.ToEmoji(), jobSpec.ProjectName, *job.WorkflowRunUrl, job.Status.ToString(), prCommentUrl)
+			message = message + fmt.Sprintf("|%v **%v** |<a href='%v'>%v</a> | <a href='%v'>%v</a> |\n", job.Status.ToEmoji(), jobSpec.ProjectName, *job.WorkflowRunUrl, job.Status.ToString(), prCommentUrl, jobTypeTitle)
 		}
 	}
 


### PR DESCRIPTION
- perform grouping comment only for plan and apply commands
- label the title of the summaries comment according to command (Apply, Plan, Lock, Unlock), it was a bug before that unlock was labeled as "apply"