### PR TITLE
fix string serialization

### DIFF
--- a/libs/comment_utils/summary/updater.go
+++ b/libs/comment_utils/summary/updater.go
@@ -24,7 +24,7 @@ func (b BasicCommentUpdater) UpdateComment(jobs []scheduler.SerializedJob, prNum
 	}
 	firstJobSpec := jobSpecs[0]
 	jobType := firstJobSpec.JobType
-	isPlan := jobType == orchestrator.DiggerCommandPlan
+	isPlan := jobType == string(orchestrator.DiggerCommandPlan)
 	jobTypeTitle := cases.Title(language.AmericanEnglish).String(string(jobType))
 	message := ""
 	if isPlan {

--- a/libs/orchestrator/json_models.go
+++ b/libs/orchestrator/json_models.go
@@ -18,7 +18,7 @@ type StageJson struct {
 }
 
 type JobJson struct {
-	JobType                 DiggerCommand     `json:"job_type"`
+	JobType                 string            `json:"job_type"`
 	ProjectName             string            `json:"projectName"`
 	ProjectDir              string            `json:"projectDir"`
 	ProjectWorkspace        string            `json:"projectWorkspace"`
@@ -58,7 +58,7 @@ func JobToJson(job Job, jobType DiggerCommand, organisationName string, jobToken
 		commandRole = project.AwsRoleToAssume.Command
 	}
 	return JobJson{
-		JobType:                 jobType,
+		JobType:                 string(jobType),
 		ProjectName:             job.ProjectName,
 		ProjectDir:              job.ProjectDir,
 		ProjectWorkspace:        job.ProjectWorkspace,


### PR DESCRIPTION
fix for https://github.com/diggerhq/digger/issues/1513

The new JobType field in the JobSpec had a special type of `DiggerCommand` which is just an enum of strings. It seems that it cannot be serialized from backend to cli as a json. 

<img width="1095" alt="Screenshot 2024-05-30 at 12 32 41" src="https://github.com/diggerhq/digger/assets/1627972/dedecb61-fd8b-4fbd-9e1d-6ded86461ed1">


We make the field in the JobSpec a string and now it serialized correctly:

<img width="1054" alt="Screenshot 2024-05-30 at 12 32 12" src="https://github.com/diggerhq/digger/assets/1627972/30d618ad-dc4d-4df6-849a-18374a47122e">
