### PR TITLE
add additional inputs for dynamic names

### DIFF
--- a/backend/utils/github.go
+++ b/backend/utils/github.go
@@ -231,15 +231,16 @@ func TriggerGithubWorkflow(client *github.Client, repoOwner string, repoName str
 		return fmt.Errorf("could not marshal json string: %v", err)
 	}
 
+	batchIdShort := job.Batch.ID.String()[:8]
+	diggerCommand := fmt.Sprintf("digger %v", job.Batch.BatchType)
+	projectName := jobSpec.ProjectName
+	requestedBy := jobSpec.RequestedBy
+	prNumber := *jobSpec.PullRequestNumber
 	inputs := orchestrator_scheduler.WorkflowInput{
-		Id:            job.DiggerJobID,
-		BatchId:       job.Batch.ID.String()[:8],
-		JobString:     jobString,
-		CommentId:     strconv.FormatInt(commentId, 10),
-		DiggerCommand: fmt.Sprintf("digger %v", job.Batch.BatchType),
-		ProjectName:   jobSpec.ProjectName,
-		RequestedBy:   jobSpec.RequestedBy,
-		PrNumber:      fmt.Sprintf("%v", *jobSpec.PullRequestNumber),
+		Id:        job.DiggerJobID,
+		JobString: jobString,
+		CommentId: strconv.FormatInt(commentId, 10),
+		RunName:   fmt.Sprintf("[%v] %v %v By: %v PR: %v", batchIdShort, diggerCommand, projectName, requestedBy, prNumber),
 	}
 
 	_, err = client.Actions.CreateWorkflowDispatchEventByFileName(context.Background(), repoOwner, repoName, job.WorkflowFile, github.CreateWorkflowDispatchEventRequest{

--- a/libs/orchestrator/scheduler/models.go
+++ b/libs/orchestrator/scheduler/models.go
@@ -18,26 +18,18 @@ const (
 )
 
 type WorkflowInput struct {
-	JobString     string `json:"job"`
-	Id            string `json:"id"`
-	BatchId       string `json:batch_id`
-	CommentId     string `json:"comment_id"`
-	DiggerCommand string `json:"job_type"`
-	ProjectName   string `json:"project_name"`
-	RequestedBy   string `json:"requested_by"`
-	PrNumber      string `json:"pr_number"`
+	JobString string `json:"job"`
+	Id        string `json:"id"`
+	CommentId string `json:"comment_id"`
+	RunName   string `json:"run_name"`
 }
 
 func (w *WorkflowInput) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"id":             w.Id,
-		"batch_id":       w.BatchId,
-		"job":            w.JobString,
-		"comment_id":     w.CommentId,
-		"digger_command": w.DiggerCommand,
-		"project_name":   w.ProjectName,
-		"requested_by":   w.RequestedBy,
-		"pr_number":      w.PrNumber,
+		"id":         w.Id,
+		"job":        w.JobString,
+		"comment_id": w.CommentId,
+		"run_name":   w.RunName,
 	}
 }
 

--- a/libs/orchestrator/scheduler/models.go
+++ b/libs/orchestrator/scheduler/models.go
@@ -18,16 +18,26 @@ const (
 )
 
 type WorkflowInput struct {
-	JobString string `json:"job"`
-	Id        string `json:"id"`
-	CommentId string `json:"comment_id"`
+	JobString     string `json:"job"`
+	Id            string `json:"id"`
+	BatchId       string `json:batch_id`
+	CommentId     string `json:"comment_id"`
+	DiggerCommand string `json:"job_type"`
+	ProjectName   string `json:"project_name"`
+	RequestedBy   string `json:"requested_by"`
+	PrNumber      string `json:"pr_number"`
 }
 
 func (w *WorkflowInput) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"id":         w.Id,
-		"job":        w.JobString,
-		"comment_id": w.CommentId,
+		"id":             w.Id,
+		"batch_id":       w.BatchId,
+		"job":            w.JobString,
+		"comment_id":     w.CommentId,
+		"digger_command": w.DiggerCommand,
+		"project_name":   w.ProjectName,
+		"requested_by":   w.RequestedBy,
+		"pr_number":      w.PrNumber,
 	}
 }
 


### PR DESCRIPTION
Breaking change as it requires workflows to include additional outputs to work.

Suggest bumping up to v0.5.x for this one

Changing from:

<img width="1895" alt="Screenshot 2024-06-02 at 12 39 38" src="https://github.com/diggerhq/digger/assets/1627972/80ac187b-822a-4949-9bff-34c315e3f22a">


To:

<img width="1857" alt="Screenshot 2024-06-02 at 12 39 57" src="https://github.com/diggerhq/digger/assets/1627972/77316652-de9c-4328-977b-5050ea6907a1">


New digger_workflow.yml needs additional outputs after this is deployed:


```
name: Digger Workflow

on:
  workflow_dispatch:
    inputs:
      id:
        description: 'run identifier'
        required: false
      batch_id:
        description: 'batch identifier'
        required: false
      job:
        required: true
      comment_id:
        required: true
      digger_command:
        description: 'the type of the job (plan, apply, unlock)'
        required: false
      requested_by:
        description: 'the actor username'
        required: false
      project_name:
        description: 'project name'
        required: false
      pr_number:
        description: 'pr number'
        required: false
```

