### PR TITLE
fix github setup callback page

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -1050,12 +1050,7 @@ func GithubAppCallbackPage(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error updating GitHub installation"})
 		return
 	}
-	//TODO move to config; same for all other os.Getenv() calls in this file
-	callbackSuccessRedirectURL := os.Getenv("CALLBACK_SUCCESS_REDIRECT_URL")
-	if callbackSuccessRedirectURL == "" {
-		callbackSuccessRedirectURL = "/repos"
-	}
-	c.Redirect(http.StatusFound, callbackSuccessRedirectURL)
+	c.HTML(http.StatusOK, "github_success.tmpl", gin.H{})
 }
 
 func GithubReposPage(c *gin.Context) {

--- a/backend/templates/github_success.tmpl
+++ b/backend/templates/github_success.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Digger github setup</title>
+  <title>Digger github app installed</title>
   <meta name="description" content="">
   <meta name="author" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/backend/templates/github_success.tmpl
+++ b/backend/templates/github_success.tmpl
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Digger github setup</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<div class="container">
+  <section class="header">
+    <h1 class="title-heading">App installation successful</h1>
+    <p>You can now close this tab.</p>
+  </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
It was redirecting to /repos which now leads to a 404 page

Now it presents a success screen:

<img width="961" alt="Screenshot 2024-06-03 at 09 46 31" src="https://github.com/diggerhq/digger/assets/1627972/eeddcf30-4de7-400f-9241-83395cc4430f">

fix for #1542