### PR TITLE
dont use tofu wrapper script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -256,6 +256,7 @@ runs:
       uses: opentofu/setup-opentofu@v1.0.3
       with:
         tofu_version: ${{ inputs.opentofu-version }}
+        tofu_wrapper: false
       if: inputs.setup-opentofu == 'true'
 
 


### PR DESCRIPTION
Since we are using `tofu show` to parse the plan JSON the wrapper scripts causes parsing this value to fail.

```
Running command: opentofu [show -no-color -json /home/runner/work/tofu-test/tofu-test/example/org-tofu-test-1-example.tfplan]
Failed to Run digger plan command. error checking for empty plan: Error while parsing json file: Unable to parse the plan file: invalid character 'c' looking for beginning of value
```