### PR TITLE
Create latest_tag

### DIFF
--- a/.github/workflows/latest_tag
+++ b/.github/workflows/latest_tag
@@ -1,0 +1,36 @@
+name: Update latest tag for every new latest release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  update_latest_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check if the latest release
+        id: check_latest_release
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+          if [[ "refs/tags/$latest_release" == "${{ github.ref }}" ]]; then
+            echo "::set-output name=is_latest::true"
+          else
+            echo "::set-output name=is_latest::false"
+          fi
+      - name: Update latest tag
+        if: steps.check_latest_release.outputs.is_latest == 'true'
+        uses: EndBug/latest-tag@latest
+        with:
+          ref: latest
+          description: Latest tag
+          force-branch: false
+
+      - name: Upload release asset
+        if: steps.check_latest_release.outputs.is_latest == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: LICENSE


### PR DESCRIPTION
Based on discussion in #1535 we bring back the action which updates the latest tag on every release. It has previously been [removed](https://github.com/diggerhq/digger/commit/8cff4b5fbfae8771c148695351315ef976ad5311) and thought of as redundant but that is not the case