### PR TITLE
Cache Go dependencies when building CLI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -264,7 +264,6 @@ runs:
         tofu_wrapper: false
       if: inputs.setup-opentofu == 'true'
 
-
     - name: Setup Checkov
       run: |
         python3 -m venv .venv
@@ -278,8 +277,36 @@ runs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.21.1'
+        go-version-file: '${{ github.action_path }}/cli/go.mod'
+        cache: false
       if: ${{ !startsWith(github.action_ref, 'v') }}
+
+    - name: Determine Golang cache paths
+      id: golang-env
+      run: |
+        echo "build-cache-path=$(go env GOCACHE)" >>"$GITHUB_OUTPUT"
+        echo "module-cache-path=$(go env GOMODCACHE)" >>"$GITHUB_OUTPUT"
+      shell: bash
+      if: ${{ !startsWith(github.action_ref, 'v') }}
+
+    - name: Copy Digger CLI go.sum for cache key
+      run: |
+        if [[ ${{ inputs.ee }} == "true" ]]; then
+          cp "$GITHUB_ACTION_PATH/ee/cli/go.sum" "$GITHUB_WORKSPACE/.digger.go.sum"
+        else
+          cp "$GITHUB_ACTION_PATH/cli/go.sum" "$GITHUB_WORKSPACE/.digger.go.sum"
+        fi
+      shell: bash
+      if: ${{ !startsWith(github.action_ref, 'v') }}
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.golang-env.outputs.build-cache-path }}
+          ${{ steps.golang-env.outputs.module-cache-path }}
+        key: digger-cli-cache-${{ hashFiles('.digger.go.sum') }}
+        restore-keys: digger-cli-cache-
+      if: ${{ !startsWith(github.action_ref, 'v') && inputs.cache-dependencies == 'true' }}
 
     - name: Adding required env vars for next step
       uses: actions/github-script@v7

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,4 @@
+---
 name: run-digger
 description: Manage terraform collaboration
 author: Digger
@@ -29,14 +30,14 @@ inputs:
     required: false
     default: 'false'
   google-auth-credentials:
-      description: Service account key used got Google auth (mutually exclusive with 'google-workload-identity-provider' input)
-      required: false
+    description: Service account key used got Google auth (mutually exclusive with 'google-workload-identity-provider' input)
+    required: false
   google-workload-identity-provider:
-      description: Workload identity provider to be used for Google OIDC auth (mutually exclusive with 'google-auth-credentials' input)
-      required: false
+    description: Workload identity provider to be used for Google OIDC auth (mutually exclusive with 'google-auth-credentials' input)
+    required: false
   google-workload-identity-provider-audience:
-      description: "'audience' parameter configured in Google's Workload Identity Provider (if specified). To be used when the 'google-workload-identity-provider' input is specified"
-      required: false
+    description: "'audience' parameter configured in Google's Workload Identity Provider (if specified). To be used when the 'google-workload-identity-provider' input is specified"
+    required: false
   google-service-account:
     description: Service account to be used when the 'google-workload-identity-provider' input is specified)
     required: false
@@ -224,9 +225,9 @@ runs:
     - name: Configure OIDC Azure credentials
       uses: azure/login@v2.1.1
       with:
-          client-id: ${{ inputs.azure-client-id }}
-          tenant-id: ${{ inputs.azure-tenant-id }}
-          subscription-id: ${{ inputs.azure-subscription-id }}
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        subscription-id: ${{ inputs.azure-subscription-id }}
       if: ${{ inputs.setup-azure == 'true' && inputs.azure-client-id != '' }}
 
     - uses: actions/cache/restore@v4
@@ -326,12 +327,12 @@ runs:
           else
             cd $GITHUB_ACTION_PATH/cli
           fi
-        
           go build -o digger ./cmd/digger
           chmod +x digger
           PATH=$PATH:$(pwd)
           cd $GITHUB_WORKSPACE
           digger
+
     - name: run digger
       if: ${{ startsWith(github.action_ref, 'v') }}
       env:
@@ -360,9 +361,9 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.ee }} == "true" ]]; then
-          curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-ee-cli-${{ runner.os  }}-${{ runner.arch }} -o digger
+          curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-ee-cli-${{ runner.os }}-${{ runner.arch }} -o digger
         else
-          curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-cli-${{ runner.os  }}-${{ runner.arch }} -o digger
+          curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-cli-${{ runner.os }}-${{ runner.arch }} -o digger
         fi
         chmod +x digger
         PATH=$PATH:$(pwd)


### PR DESCRIPTION
Enables dependency caching of the Digger CLI binary being built in a deploy when not using version tags (I'm using hashes for immutability). Since it seems I can't use `hashFiles` for files outside of the workspace of the Terraform code repo running the action we copy that file to one that shouldn't collide with any source files so that we can ensure the cache key is sufficiently unique (maybe not unique enough? not sure).

I'm reusing the `cache-dependencies` input here because of the name and the description provided indicating that it should probably cover this instead of just Terraform providers, and people turning that on likely want this too.

Also pins the go version used by setup-go to the one in `cli`'s dependency file.
