### PR TITLE
supporting path mirror lookup with precedence during repo policy lookup (ee)

### DIFF
--- a/cli/pkg/core/policy/policy.go
+++ b/cli/pkg/core/policy/policy.go
@@ -5,16 +5,16 @@ import (
 )
 
 type Provider interface {
-	GetAccessPolicy(organisation string, repository string, projectname string) (string, error)
-	GetPlanPolicy(organisation string, repository string, projectname string) (string, error)
+	GetAccessPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
+	GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
 	GetDriftPolicy() (string, error)
 	GetOrganisation() string // TODO: remove this method from here since out of place
 }
 
 type Checker interface {
 	// TODO refactor arguments - use AccessPolicyContext
-	CheckAccessPolicy(ciService orchestrator.OrgService, prService *orchestrator.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error)
-	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, planOutput string) (bool, []string, error)
+	CheckAccessPolicy(ciService orchestrator.OrgService, prService *orchestrator.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error)
+	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
 }
 

--- a/cli/pkg/policy/policy_test.go
+++ b/cli/pkg/policy/policy_test.go
@@ -50,11 +50,11 @@ func (s *OpaExamplePolicyProvider) GetOrganisation() string {
 type DiggerDefaultPolicyProvider struct {
 }
 
-func (s *DiggerDefaultPolicyProvider) GetAccessPolicy(_ string, _ string, _ string) (string, error) {
+func (s *DiggerDefaultPolicyProvider) GetAccessPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return DefaultAccessPolicy, nil
 }
 
-func (s *DiggerDefaultPolicyProvider) GetPlanPolicy(_ string, _ string, _ string) (string, error) {
+func (s *DiggerDefaultPolicyProvider) GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n", nil
 }
 
@@ -69,7 +69,7 @@ func (s *DiggerDefaultPolicyProvider) GetOrganisation() string {
 type DiggerExamplePolicyProvider struct {
 }
 
-func (s *DiggerExamplePolicyProvider) GetAccessPolicy(_ string, _ string, _ string) (string, error) {
+func (s *DiggerExamplePolicyProvider) GetAccessPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n" +
 		"\n" +
 		"user_permissions := {\n" +
@@ -85,7 +85,7 @@ func (s *DiggerExamplePolicyProvider) GetAccessPolicy(_ string, _ string, _ stri
 		"", nil
 }
 
-func (s *DiggerExamplePolicyProvider) GetPlanPolicy(_ string, _ string, _ string) (string, error) {
+func (s *DiggerExamplePolicyProvider) GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n", nil
 }
 
@@ -100,7 +100,7 @@ func (s *DiggerExamplePolicyProvider) GetOrganisation() string {
 type DiggerExamplePolicyProvider2 struct {
 }
 
-func (s *DiggerExamplePolicyProvider2) GetAccessPolicy(_ string, _ string, _ string) (string, error) {
+func (s *DiggerExamplePolicyProvider2) GetAccessPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n" +
 		"\n" +
 		"user_permissions := {\n" +
@@ -119,7 +119,7 @@ func (s *DiggerExamplePolicyProvider2) GetAccessPolicy(_ string, _ string, _ str
 		"", nil
 }
 
-func (s *DiggerExamplePolicyProvider2) GetPlanPolicy(_ string, _ string, _ string) (string, error) {
+func (s *DiggerExamplePolicyProvider2) GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n\ndeny[sprintf(message, [resource.address])] {\n  message := \"Cannot create EC2 instances!\"\n  resource := input.terraform.resource_changes[_]\n  resource.change.actions[_] == \"create\"\n  resource[type] == \"aws_instance\"\n}\n", nil
 }
 
@@ -223,7 +223,7 @@ func TestDiggerAccessPolicyChecker_Check(t *testing.T) {
 				PolicyProvider: tt.fields.PolicyProvider,
 			}
 			ciService := utils.MockPullRequestManager{Teams: []string{"engineering"}}
-			got, err := p.CheckAccessPolicy(ciService, nil, tt.organisation, tt.name, tt.name, tt.command, nil, tt.requestedBy, tt.planPolicyViolations)
+			got, err := p.CheckAccessPolicy(ciService, nil, tt.organisation, tt.name, tt.name, "", tt.command, nil, tt.requestedBy, tt.planPolicyViolations)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiggerPolicyChecker.CheckAccessPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -275,7 +275,7 @@ func TestDiggerPlanPolicyChecker_Check(t *testing.T) {
 			var p = &DiggerPolicyChecker{
 				PolicyProvider: tt.fields.PolicyProvider,
 			}
-			got, _, err := p.CheckPlanPolicy("", "", "", tt.planJsonOutput)
+			got, _, err := p.CheckPlanPolicy("", "", "", "", tt.planJsonOutput)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiggerPolicyChecker.CheckPlanPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cli/pkg/utils/mocks.go
+++ b/cli/pkg/utils/mocks.go
@@ -25,11 +25,11 @@ func (tf *MockTerraform) Plan() (bool, string, string, error) {
 type MockPolicyChecker struct {
 }
 
-func (t MockPolicyChecker) CheckAccessPolicy(ciService orchestrator.OrgService, prService *orchestrator.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, command string, ptr *int, requestedBy string, planPolicyViolations []string) (bool, error) {
+func (t MockPolicyChecker) CheckAccessPolicy(ciService orchestrator.OrgService, prService *orchestrator.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error) {
 	return false, nil
 }
 
-func (t MockPolicyChecker) CheckPlanPolicy(projectName string, SCMOrganisation string, command string, requestedBy string) (bool, []string, error) {
+func (t MockPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error) {
 	return false, nil, nil
 }
 

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -59,7 +59,7 @@ func (p DiggerRepoPolicyProvider) getPolicyFileContents(repo string, projectName
 	var contents string
 	err := utils.CloneGitRepoAndDoAction(p.ManagementRepoUrl, "main", p.GitToken, func(basePath string) error {
 		// we start with the project directory path prefixes as the highest priority
-		prefixes := GetPrefixesForPath(projectDir, fileName)
+		prefixes := GetPrefixesForPath(path.Join(basePath, projectDir), fileName)
 
 		// we also add a known location as a least priority item
 		orgAccesspath := path.Join(basePath, "policies", fileName)

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -48,7 +48,12 @@ func GetPrefixesForPath(path string, fileName string) []string {
 		prefixes = append(prefixes, filepath.Join(parts[:i+1]...))
 	}
 	prefixes = lo.Map(prefixes, func(item string, index int) string {
-		return item + string(filepath.Separator) + fileName
+		// if it was an absolute path to start with then result should be absolute
+		if parts[0] == "" {
+			return string(filepath.Separator) + item + string(filepath.Separator) + fileName
+		} else {
+			return item + string(filepath.Separator) + fileName
+		}
 	})
 	slices.Reverse(prefixes)
 

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -47,15 +47,16 @@ func GetPrefixesForPath(path string, fileName string) []string {
 	for i := range parts {
 		prefixes = append(prefixes, filepath.Join(parts[:i+1]...))
 	}
-	prefixes = lo.Map(prefixes, func(item string, index int) string {
-		// if it was an absolute path to start with then result should be absolute
+
+	slices.Reverse(prefixes)
+	prefixes = lo.FilterMap(prefixes, func(item string, index int) (string, bool) {
+		// if input path was absolute then result should be absolute and ignore last item ""
 		if parts[0] == "" {
-			return string(filepath.Separator) + item + string(filepath.Separator) + fileName
+			return string(filepath.Separator) + item + string(filepath.Separator) + fileName, index < len(prefixes)-1
 		} else {
-			return item + string(filepath.Separator) + fileName
+			return item + string(filepath.Separator) + fileName, index < len(prefixes)
 		}
 	})
-	slices.Reverse(prefixes)
 
 	return prefixes
 }

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -73,6 +73,7 @@ func (p DiggerRepoPolicyProvider) getPolicyFileContents(repo string, projectName
 		for _, pathPrefix := range prefixes {
 			var err error
 			contents, err = getContents(pathPrefix)
+			log.Printf("path: %v contents: %v, err: %v", pathPrefix, contents, err)
 			if err == nil {
 				return nil
 			}

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -1,11 +1,14 @@
 package policy
 
 import (
-	"fmt"
 	"github.com/diggerhq/digger/ee/cli/pkg/utils"
+	"github.com/samber/lo"
 	"log"
 	"os"
 	"path"
+	"path/filepath"
+	"slices"
+	"strings"
 )
 
 const DefaultAccessPolicy = `
@@ -31,31 +34,55 @@ func getContents(filePath string) (string, error) {
 	return string(contents), nil
 }
 
-func (p DiggerRepoPolicyProvider) getPolicyFileContents(repo string, projectName string, fileName string) (string, error) {
+// GetPrefixesForPath
+// @path is the total path example /dev/vpc/subnets
+// @filename is the name of the file to search for example access.rego
+// returns the list of prefixes in priority order example:
+// /dev/vpc/subnets/access.rego
+// /dev/vpc/access.rego
+// /dev/access.rego
+func GetPrefixesForPath(path string, fileName string) []string {
+	var prefixes []string
+	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	for i := range parts {
+		prefixes = append(prefixes, filepath.Join(parts[:i+1]...))
+	}
+	prefixes = lo.Map(prefixes, func(item string, index int) string {
+		return item + string(filepath.Separator) + fileName
+	})
+	slices.Reverse(prefixes)
+
+	return prefixes
+}
+
+func (p DiggerRepoPolicyProvider) getPolicyFileContents(repo string, projectName string, projectDir string, fileName string) (string, error) {
 	var contents string
 	err := utils.CloneGitRepoAndDoAction(p.ManagementRepoUrl, "main", p.GitToken, func(basePath string) error {
+		// we start with the project directory path prefixes as the highest priority
+		prefixes := GetPrefixesForPath(projectDir, fileName)
+
+		// we also add a known location as a least priority item
 		orgAccesspath := path.Join(basePath, "policies", fileName)
 		repoAccesspath := path.Join(basePath, "policies", repo, fileName)
 		projectAccessPath := path.Join(basePath, "policies", repo, projectName, fileName)
+		prefixes = append(prefixes, projectAccessPath)
+		prefixes = append(prefixes, repoAccesspath)
+		prefixes = append(prefixes, orgAccesspath)
 
-		log.Printf("loading repo orgAccess %v repoAccess %v projectAcces %v", orgAccesspath, repoAccesspath, projectAccessPath)
-		var err error
-		contents, err = getContents(projectAccessPath)
-		if os.IsNotExist(err) {
-			contents, err = getContents(repoAccesspath)
+		log.Printf("loading repo with following presedence %v", prefixes)
+		for _, pathPrefix := range prefixes {
+			var err error
+			contents, err = getContents(pathPrefix)
+			if err == nil {
+				return nil
+			}
 			if os.IsNotExist(err) {
-				contents, err = getContents(orgAccesspath)
-				if os.IsNotExist(err) {
-					return nil
-				} else {
-					fmt.Errorf("could not find any matching policy for %v,%v", repo, projectName)
-				}
+				continue
 			} else {
 				return err
 			}
-		} else {
-			return err
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -65,11 +92,11 @@ func (p DiggerRepoPolicyProvider) getPolicyFileContents(repo string, projectName
 }
 
 // GetPolicy fetches policy for particular project,  if not found then it will fallback to org level policy
-func (p DiggerRepoPolicyProvider) GetAccessPolicy(organisation string, repo string, projectName string) (string, error) {
-	return p.getPolicyFileContents(repo, projectName, "access.rego")
+func (p DiggerRepoPolicyProvider) GetAccessPolicy(organisation string, repo string, projectName string, projectDir string) (string, error) {
+	return p.getPolicyFileContents(repo, projectName, projectDir, "access.rego")
 }
 
-func (p DiggerRepoPolicyProvider) GetPlanPolicy(organisation string, repo string, projectName string) (string, error) {
+func (p DiggerRepoPolicyProvider) GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "", nil
 }
 

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -75,7 +75,6 @@ func (p DiggerRepoPolicyProvider) getPolicyFileContents(repo string, projectName
 		prefixes = append(prefixes, repoAccesspath)
 		prefixes = append(prefixes, orgAccesspath)
 
-		log.Printf("loading repo with following presedence %v", prefixes)
 		for _, pathPrefix := range prefixes {
 			var err error
 			contents, err = getContents(pathPrefix)

--- a/ee/cli/pkg/policy/policy_test.go
+++ b/ee/cli/pkg/policy/policy_test.go
@@ -14,6 +14,12 @@ func init() {
 
 func TestGetPrefixesForPath(t *testing.T) {
 	prefixes := GetPrefixesForPath("dev/vpc/subnets", "access.rego")
-	assert.Equal(t, prefixes, []string{"dev/vpc/subnets/access.rego", "dev/vpc/access.rego", "dev/access.rego"})
+	assert.Equal(t, []string{"dev/vpc/subnets/access.rego", "dev/vpc/access.rego", "dev/access.rego"}, prefixes)
+	log.Printf("%v", prefixes)
+}
+
+func TestGetPrefixesForPathAbsolute(t *testing.T) {
+	prefixes := GetPrefixesForPath("/dev/vpc/subnets", "access.rego")
+	assert.Equal(t, []string{"/dev/vpc/subnets/access.rego", "/dev/vpc/access.rego", "/dev/access.rego"}, prefixes)
 	log.Printf("%v", prefixes)
 }

--- a/ee/cli/pkg/policy/policy_test.go
+++ b/ee/cli/pkg/policy/policy_test.go
@@ -1,0 +1,19 @@
+package policy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"log"
+	"os"
+	"testing"
+)
+
+func init() {
+	log.SetOutput(os.Stdout)
+	log.SetFlags(log.Ldate | log.Ltime)
+}
+
+func TestGetPrefixesForPath(t *testing.T) {
+	prefixes := GetPrefixesForPath("dev/vpc/subnets", "access.rego")
+	assert.Equal(t, prefixes, []string{"dev/vpc/subnets/access.rego", "dev/vpc/access.rego", "dev/access.rego"})
+	log.Printf("%v", prefixes)
+}


### PR DESCRIPTION
Supports placing access policies in the same path of a project or any level above it. Precendence for  policies further down the path is higher than the policies in the paths above it