### PR TITLE
Fix: Correct indentation on github-actions with aws inputs

### DIFF
--- a/docs/getting-started/github-actions-+-aws.mdx
+++ b/docs/getting-started/github-actions-+-aws.mdx
@@ -43,11 +43,11 @@ name: Digger Workflow
 
 on:
   workflow_dispatch:
-  inputs:
-    spec:
-      required: true
-    run_name:
-      required: false
+    inputs:
+      spec:
+        required: true
+      run_name:
+        required: false
 
 run-name: '${{inputs.run_name}}'
 


### PR DESCRIPTION
Why do we need this change?
=======================
The live documentation had inputs at the same level as the workflow-dispatch, this will result in an error if folks just copy/paste the results and attempt to run.

What effects does this change have?
=======================
* Fixes the indentation that the inputs are required in the workflow_dispatch:, and not at the same level.
* Fixes: #1601 1601