### PR TITLE
docs: update to match latest version of v0.6.x

### DIFF
--- a/docs/cloud-providers/authenticating-with-oidc-on-aws.mdx
+++ b/docs/cloud-providers/authenticating-with-oidc-on-aws.mdx
@@ -10,8 +10,7 @@ name: Digger Workflow
 on:
   workflow_dispatch:
     inputs:
-      id:
-        description: 'run identifier'
+      run_name:
         required: false
       spec:
         required: true

--- a/docs/getting-started/github-actions-+-aws.mdx
+++ b/docs/getting-started/github-actions-+-aws.mdx
@@ -63,11 +63,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: ${{github.event.inputs.id}}
-        run: echo job id ${{ inputs.id }}
+      - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
+        run: echo "job id ${{ fromJSON(github.event.inputs.spec).job_id }}"
       - uses: diggerhq/digger@vLatest
         with:
-          digger-spec: ${{ inputs.digger-spec }}
+          digger-spec: ${{ inputs.spec }}
           setup-aws: true
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/docs/getting-started/github-actions-and-gcp.mdx
+++ b/docs/getting-started/github-actions-and-gcp.mdx
@@ -62,8 +62,8 @@ jobs:
       statuses: write      # required to validate combined PR status
     steps:
     - uses: actions/checkout@v4
-    - name: ${{github.event.inputs.id}}
-      run: echo job id ${{ inputs.id }}
+    - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
+      run: echo "job id ${{ fromJSON(github.event.inputs.spec).job_id }}"
     - id: 'auth'
       uses: 'google-github-actions/auth@v1'
       with:

--- a/docs/howto/multiacc-aws.mdx
+++ b/docs/howto/multiacc-aws.mdx
@@ -69,8 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: ${{github.event.inputs.id}}
-        run: echo job id ${{ inputs.id }}
+      - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
+        run: echo "job id ${{ fromJSON(github.event.inputs.spec).job_id }}"
       - uses: diggerhq/digger@vLatest
         with:
           digger-spec: ${{ inputs.spec }}

--- a/docs/troubleshooting/comments.mdx
+++ b/docs/troubleshooting/comments.mdx
@@ -9,6 +9,6 @@ Sometimes the link to job status leads to the PR instead of the Action job. E.g.
 The likely reason is that the step that exposes the job id is missing from the workflow file. Add it right after checkout (most importantly, before Digger):
 
 ```
-- name: ${{github.event.inputs.id}}
-        run: echo job id ${{ inputs.id }}
+- name: ${{ fromJSON(github.event.inputs.spec).job_id }}
+  run: echo "job id ${{ fromJSON(github.event.inputs.spec).job_id }}"
 ```


### PR DESCRIPTION
The latest release of digger v0.6.x introduced some changes to the workflow inputs and therefore some job steps have to be adjusted accordingly