### PR TITLE
also post on empty plan

### DIFF
--- a/libs/terraform_utils/plan_summary_test.go
+++ b/libs/terraform_utils/plan_summary_test.go
@@ -20,6 +20,14 @@ func TestPlanOutputNonEmpty(t *testing.T) {
 	assert.False(t, isEmpty)
 }
 
+func TestGetPlanSummaryOnlyOutputsChanged(t *testing.T) {
+	onlyOutputsChangedJson := "{\"format_version\":\"1.2\",\"terraform_version\":\"1.7.3\",\"planned_values\":{\"outputs\":{\"tt\":{\"sensitive\":false,\"type\":\"string\",\"value\":\"yy\"}},\"root_module\":{}},\"output_changes\":{\"tt\":{\"actions\":[\"create\"],\"before\":null,\"after\":\"yy\",\"after_unknown\":false,\"before_sensitive\":false,\"after_sensitive\":false}},\"prior_state\":{\"format_version\":\"1.0\",\"terraform_version\":\"1.7.3\",\"values\":{\"outputs\":{\"tt\":{\"sensitive\":false,\"value\":\"yy\",\"type\":\"string\"}},\"root_module\":{}}},\"configuration\":{\"root_module\":{\"outputs\":{\"tt\":{\"expression\":{\"constant_value\":\"yy\"}}}}},\"timestamp\":\"2024-07-12T14:50:56Z\",\"errored\":false}\n"
+	isEmpty, _, err := GetPlanSummary(onlyOutputsChangedJson)
+	assert.Nil(t, err)
+	assert.False(t, isEmpty)
+
+}
+
 func TestPlanOutputInvalidJsonFailsGracefully(t *testing.T) {
 	InvalidJson := "{\"format_version\":\" notsovalid"
 	_, _, err := GetPlanSummary(InvalidJson)


### PR DESCRIPTION
fixes #1557

We were not properly detecting empty plans when only outputs have changed

Also a refactor to use tfjson.Plan type from library instead of our custom types

Tested the fix here: https://github.com/diggerhq/test-tfvar-env/pull/4