### PR TITLE
pull env vars for cli

### DIFF
--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/diggerhq/digger/libs/scheduler"
 	"github.com/diggerhq/digger/libs/spec"
 	"github.com/diggerhq/digger/libs/storage"
+	"github.com/samber/lo"
 	"log"
 	"os"
 	"time"
@@ -82,6 +83,11 @@ func RunSpec(
 	if err != nil {
 		usage.ReportErrorAndExit(spec.VCS.Actor, fmt.Sprintf("could not get plan storage: %v", err), 8)
 	}
+
+	workflow := diggerConfig.Workflows[job.ProjectName]
+	stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+	job.StateEnvVars = lo.Assign(job.StateEnvVars, stateEnvVars)
+	job.CommandEnvVars = lo.Assign(job.CommandEnvVars, commandEnvVars)
 
 	jobs := []scheduler.Job{job}
 


### PR DESCRIPTION
before this change, variables were not overriden from when using backend spec:

<img width="1091" alt="Screenshot 2024-07-12 at 17 10 52" src="https://github.com/user-attachments/assets/8491ed9b-060d-4fc6-ac60-ff960231a6f4">

After change: secret is overriden:

<img width="1012" alt="Screenshot 2024-07-12 at 17 15 21" src="https://github.com/user-attachments/assets/9aa8f582-79d9-4b3f-bcc1-ee4b7ca3b98e">

Test PR: https://github.com/diggerhq/test-tfvar-env/pull/5