### PR TITLE
do not generate projects on load

### DIFF
--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -68,7 +68,7 @@ func RunSpec(
 	if err != nil {
 		usage.ReportErrorAndExit(spec.VCS.Actor, fmt.Sprintf("could not get changed files: %v", err), 1)
 	}
-	diggerConfig, _, _, err := digger_config.LoadDiggerConfig("./", true, changedFiles)
+	diggerConfig, _, _, err := digger_config.LoadDiggerConfig("./", false, changedFiles)
 	if err != nil {
 		usage.ReportErrorAndExit(spec.VCS.Actor, fmt.Sprintf("Failed to read Digger digger_config. %s", err), 4)
 	}

--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -84,7 +84,7 @@ func RunSpec(
 		usage.ReportErrorAndExit(spec.VCS.Actor, fmt.Sprintf("could not get plan storage: %v", err), 8)
 	}
 
-	workflow := diggerConfig.Workflows[job.ProjectName]
+	workflow := diggerConfig.Workflows[job.ProjectWorkflow]
 	stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
 	job.StateEnvVars = lo.Assign(job.StateEnvVars, stateEnvVars)
 	job.CommandEnvVars = lo.Assign(job.CommandEnvVars, commandEnvVars)


### PR DESCRIPTION
- we do not need to perform projects generation while loading digger.yml in spec logic because we only need it for loading worklow env vars, which is available in the loading without "generation" of projects

- also fix a logical bug in loading of env vars because we were trying to load projectName which never exists, its actualy the workflow name which we should load from the diggerConfig workflows