### PR TITLE
use common provider for fetching gitlab client

### DIFF
--- a/backend/utils/gitlab.go
+++ b/backend/utils/gitlab.go
@@ -12,12 +12,13 @@ import (
 )
 
 type GitlabProvider interface {
-	NewClient(token string, baseUrl string) (*gitlab.Client, error)
+	NewClient(token string) (*gitlab.Client, error)
 }
 
 type GitlabClientProvider struct{}
 
-func (g GitlabClientProvider) NewClient(token string, baseUrl string) (*gitlab.Client, error) {
+func (g GitlabClientProvider) NewClient(token string) (*gitlab.Client, error) {
+	baseUrl := os.Getenv("DIGGER_GITLAB_BASE_URL")
 	if baseUrl == "" {
 		client, err := gitlab.NewClient(token)
 		return client, err
@@ -29,9 +30,8 @@ func (g GitlabClientProvider) NewClient(token string, baseUrl string) (*gitlab.C
 
 func GetGitlabService(gh GitlabProvider, projectId int, repoName string, repoFullName string, prNumber int, discussionId string) (*orchestrator_gitlab.GitLabService, error) {
 	token := os.Getenv("DIGGER_GITLAB_ACCESS_TOKEN")
-	baseUrl := os.Getenv("DIGGER_GITLAB_BASE_URL")
 
-	client, err := gh.NewClient(token, baseUrl)
+	client, err := gh.NewClient(token)
 	if err != nil {
 		return nil, fmt.Errorf("could not get gitlab client: %v", err)
 	}

--- a/ee/backend/ci_backends/provider.go
+++ b/ee/backend/ci_backends/provider.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/diggerhq/digger/backend/ci_backends"
-	"github.com/xanzy/go-gitlab"
+	"github.com/diggerhq/digger/backend/utils"
 	"log"
 	"os"
 )
@@ -21,7 +21,7 @@ func (b EEBackendProvider) GetCiBackend(options ci_backends.CiBackendOptions) (c
 		if token == "" {
 			return nil, fmt.Errorf("missing environment variable: DIGGER_GITLAB_ACCESS_TOKEN")
 		}
-		client, err := gitlab.NewClient(token)
+		client, err := utils.GitlabClientProvider{}.NewClient(token)
 		if err != nil {
 			return nil, fmt.Errorf("could not create gitlab client: %v", err)
 		}


### PR DESCRIPTION
to be able to configure private gitlab vcs in one area throughout the codebase