### PR TITLE
handle automating branch deletion

### DIFF
--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -334,6 +334,17 @@ func (svc GithubService) GetBranchName(prNumber int) (string, string, error) {
 	return pr.Head.GetRef(), pr.Head.GetSHA(), nil
 }
 
+func (svc GithubService) CheckBranchExists(branchName string) (bool, error) {
+	_, resp, err := svc.Client.Repositories.GetBranch(context.Background(), svc.Owner, svc.RepoName, branchName, 3)
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impactedProjects []digger_config.Project, requestedProject *digger_config.Project, config digger_config.DiggerConfig) ([]scheduler.Job, bool, error) {
 	workflows := config.Workflows
 	jobs := make([]scheduler.Job, 0)


### PR DESCRIPTION
Fixes #1656 

In case github is configured for automatic branch deletion it will fail if a PR is merged, since digger will not be able to load digger.yml from the branch. We add additional check to see if the action is PR closed and the branch does not exist. In this case we bail early to avoid the noisy comment on the PR after it is merged. Screenshot shows error with digger cloud (without the fix) versus the locally commited fix which no longer comments that error (https://github.com/diggerhq/branch-deletion-test/pull/5)

![Screenshot 2024-08-13 at 14 55 41](https://github.com/user-attachments/assets/68befccb-fa78-4d79-aaea-e82474c5eaa3)
<img width="1576" alt="Screenshot 2024-08-13 at 14 55 21" src="https://github.com/user-attachments/assets/bb5ca548-177d-48a2-b936-ffa0ecaa774f">

