### PR TITLE
feat/plan summary in collapsible

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -518,9 +518,9 @@ func reportPlanSummary(reporter reporting.Reporter, summary string) {
 	var formatter func(string) string
 
 	if reporter.SupportsMarkdown() {
-		formatter = coreutils.GetTerraformOutputAsCollapsibleComment("Plan summary", true)
+		formatter = coreutils.AsCollapsibleComment("Plan summary", true)
 	} else {
-		formatter = coreutils.GetTerraformOutputAsComment("Plan summary")
+		formatter = coreutils.AsComment("Plan summary")
 	}
 
 	_, _, err := reporter.Report(summary, formatter)

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -319,10 +319,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					if err != nil {
 						log.Printf("Failed to report plan. %v", err)
 					}
-					_, _, err = reporter.Report("\n"+planSummary, coreutils.AsComment("Terraform plan summary"))
-					if err != nil {
-						log.Printf("Failed to report summary of plan. %v", err)
-					}
+					reportPlanSummary(reporter, planSummary)
 				}
 			} else {
 				reportEmptyPlanOutput(reporter, projectLock.LockId())
@@ -514,6 +511,21 @@ func reportTerraformPlanOutput(reporter reporting.Reporter, projectId string, pl
 	_, _, err := reporter.Report(plan, formatter)
 	if err != nil {
 		log.Printf("Failed to report plan. %v", err)
+	}
+}
+
+func reportPlanSummary(reporter reporting.Reporter, summary string) {
+	var formatter func(string) string
+
+	if reporter.SupportsMarkdown() {
+		formatter = coreutils.GetTerraformOutputAsCollapsibleComment("Plan summary", true)
+	} else {
+		formatter = coreutils.GetTerraformOutputAsComment("Plan summary")
+	}
+
+	_, _, err := reporter.Report(summary, formatter)
+	if err != nil {
+		log.Printf("Failed to report plan summary. %v", err)
 	}
 }
 

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -523,7 +523,7 @@ func reportPlanSummary(reporter reporting.Reporter, summary string) {
 		formatter = coreutils.AsComment("Plan summary")
 	}
 
-	_, _, err := reporter.Report(summary, formatter)
+	_, _, err := reporter.Report("\n"+summary, formatter)
 	if err != nil {
 		log.Printf("Failed to report plan summary. %v", err)
 	}

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -518,7 +518,7 @@ func reportPlanSummary(reporter reporting.Reporter, summary string) {
 	var formatter func(string) string
 
 	if reporter.SupportsMarkdown() {
-		formatter = coreutils.AsCollapsibleComment("Plan summary", true)
+		formatter = coreutils.AsCollapsibleComment("Plan summary", false)
 	} else {
 		formatter = coreutils.AsComment("Plan summary")
 	}

--- a/libs/comment_utils/utils/comments.go
+++ b/libs/comment_utils/utils/comments.go
@@ -27,10 +27,16 @@ func GetTerraformOutputAsComment(summary string) func(string) string {
 }
 
 func AsCollapsibleComment(summary string, open bool) func(string) string {
+	var openTag string
+	if open {
+		openTag = "open=\"true\""
+	} else {
+		openTag = ""
+	}
 	return func(comment string) string {
-		return fmt.Sprintf(`<details><summary>` + summary + `</summary>
-  ` + comment + `
-</details>`)
+		return fmt.Sprintf(`<details %v><summary>`+summary+`</summary>
+  `+comment+`
+</details>`, openTag)
 	}
 }
 


### PR DESCRIPTION
Make the plan summary in its own collapsible comment and collapsed by default. Before:

<img width="972" alt="Screenshot 2024-08-19 at 16 26 25" src="https://github.com/user-attachments/assets/1e552ecf-40b8-41b1-965f-99fa3da8036f">


After (plan summary gets its own collapsible comment and is collapsed by default):

<img width="930" alt="Screenshot 2024-08-19 at 16 26 29" src="https://github.com/user-attachments/assets/f1aefd1d-5815-4a3f-a961-dbe3730f6733">
