### PR TITLE
ensure that the job refreshes after variables are saved

### DIFF
--- a/backend/services/scheduler.go
+++ b/backend/services/scheduler.go
@@ -103,19 +103,19 @@ func TriggerJob(gh utils.GithubClientProvider, ciBackend ci_backends.CiBackend, 
 	runName, err := GetRunNameFromJob(*job)
 	if err != nil {
 		log.Printf("could not get run name: %v", err)
-		return fmt.Errorf("coult not get run name %v", err)
+		return fmt.Errorf("could not get run name %v", err)
 	}
 
 	spec, err := GetSpecFromJob(*job)
 	if err != nil {
 		log.Printf("could not get spec: %v", err)
-		return fmt.Errorf("coult not get spec %v", err)
+		return fmt.Errorf("could not get spec %v", err)
 	}
 
 	vcsToken, err := GetVCSTokenFromJob(*job, gh)
 	if err != nil {
 		log.Printf("could not get vcs token: %v", err)
-		return fmt.Errorf("coult not get vcs token: %v", err)
+		return fmt.Errorf("could not get vcs token: %v", err)
 	}
 
 	err = ciBackend.TriggerWorkflow(*spec, *runName, *vcsToken)

--- a/next/services/runs.go
+++ b/next/services/runs.go
@@ -43,7 +43,7 @@ func RunQueuesStateMachine(queueItem *model.DiggerRunQueueItem, service ci.PullR
 			return fmt.Errorf("could not get run name: %v", err)
 		}
 
-		err = RefreshVariableSpecForJob(*planJob)
+		err = RefreshVariableSpecForJob(planJob)
 		if err != nil {
 			log.Printf("could not get variable spec from job: %v", err)
 			return fmt.Errorf("could not get variable spec from job: %v", err)
@@ -51,7 +51,7 @@ func RunQueuesStateMachine(queueItem *model.DiggerRunQueueItem, service ci.PullR
 
 		// NOTE: We have to refresh both plan and apply jobs since we want to use exact same variables
 		// in both of these jobs
-		err = RefreshVariableSpecForJob(*applyJob)
+		err = RefreshVariableSpecForJob(applyJob)
 		if err != nil {
 			log.Printf("could not get variable spec from job: %v", err)
 			return fmt.Errorf("could not get variable spec from job: %v", err)

--- a/next/services/scheduler.go
+++ b/next/services/scheduler.go
@@ -67,10 +67,10 @@ func TriggerJob(gh utils.GithubClientProvider, ciBackend ci_backends.CiBackend, 
 	runName, err := GetRunNameFromJob(*job)
 	if err != nil {
 		log.Printf("could not get run name: %v", err)
-		return fmt.Errorf("coult not get run name %v", err)
+		return fmt.Errorf("could not get run name %v", err)
 	}
 
-	err = RefreshVariableSpecForJob(*job)
+	err = RefreshVariableSpecForJob(job)
 	if err != nil {
 		log.Printf("could not get variable spec from job: %v", err)
 		return fmt.Errorf("could not get variable spec from job: %v", err)
@@ -79,13 +79,13 @@ func TriggerJob(gh utils.GithubClientProvider, ciBackend ci_backends.CiBackend, 
 	spec, err := GetSpecFromJob(*job, lib_spec.SpecTypeApplyBeforeMergeJob)
 	if err != nil {
 		log.Printf("could not get spec: %v", err)
-		return fmt.Errorf("coult not get spec %v", err)
+		return fmt.Errorf("could not get spec %v", err)
 	}
 
 	vcsToken, err := GetVCSTokenFromJob(*job, gh)
 	if err != nil {
 		log.Printf("could not get vcs token: %v", err)
-		return fmt.Errorf("coult not get vcs token: %v", err)
+		return fmt.Errorf("could not get vcs token: %v", err)
 	}
 
 	err = ciBackend.TriggerWorkflow(*spec, *runName, *vcsToken)


### PR DESCRIPTION
during variable refresh method the job was not passed as a pointer, therefore it was not refreshing the value for the next step of creating the spec and it was being passed as nil

Also fixed a typo in logs "coult" -> "could"