### PR TITLE
handle duplicate locks existing during unlock phase

### DIFF
--- a/backend/locking/backend_locking.go
+++ b/backend/locking/backend_locking.go
@@ -20,18 +20,12 @@ func (lock BackendDBLock) Lock(lockId int, resource string) (bool, error) {
 }
 
 func (lock BackendDBLock) Unlock(resource string) (bool, error) {
-	theLock, err := models.DB.GetDiggerLock(resource)
+	// delete all locks that match this resource
+	l := models.DiggerLock{}
+	err := models.DB.GormDB.Where("resource=?", resource).Delete(&l).Error
 	if err != nil {
-		if err != nil {
-			return false, fmt.Errorf("could not get lock record: %v", err)
-		}
+		return false, fmt.Errorf("could not delete all locks: %v", err)
 	}
-
-	err = models.DB.DeleteDiggerLock(theLock)
-	if err != nil {
-		return false, fmt.Errorf("could not delete lock record: %v", err)
-	}
-
 	return true, nil
 }
 

--- a/backend/models/storage.go
+++ b/backend/models/storage.go
@@ -1245,13 +1245,3 @@ func (db *Database) GetDiggerLock(resource string) (*DiggerLock, error) {
 	}
 	return lock, nil
 }
-
-func (db *Database) DeleteDiggerLock(lock *DiggerLock) error {
-	log.Printf("DeleteDiggerLock Deleting: %v, %v", lock.LockId, lock.Resource)
-	result := db.GormDB.Delete(lock)
-	if result.Error != nil {
-		return result.Error
-	}
-	log.Printf("DeleteDiggerLock %v %v has been deleted successfully\n", lock.LockId, lock.Resource)
-	return nil
-}

--- a/libs/locking/locking.go
+++ b/libs/locking/locking.go
@@ -123,6 +123,7 @@ func reportLockingFailed(r reporting.Reporter, comment string) {
 }
 
 func (projectLock *PullRequestLock) verifyNoHangingLocks() (bool, error) {
+	// TODO: Also include CI type (github, gitlab etc. into this lockID in order to avoid collision across VCS)
 	lockId := projectLock.LockId()
 	transactionId, err := projectLock.InternalLock.GetLock(lockId)
 


### PR DESCRIPTION
Issue: It seems that duplicate locks have made it to the DB table

I'm not sure yet how this has happened but in order to circumvent this issue during unlock of a lock we remove all the records that match in the DB.

Yet to further investigate why duplicate locks are occuring