### PR TITLE
rely on variables spec within orchestrator, not on workflow config

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -519,7 +519,7 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 		return fmt.Errorf("error processing event")
 	}
 
-	jobsForImpactedProjects, _, err := dg_github.ConvertGithubPullRequestEventToJobs(payload, impactedProjects, nil, *config)
+	jobsForImpactedProjects, _, err := dg_github.ConvertGithubPullRequestEventToJobs(payload, impactedProjects, nil, *config, false)
 	if err != nil {
 		log.Printf("Error converting event to jobsForImpactedProjects: %v", err)
 		utils.InitCommentReporter(ghService, prNumber, fmt.Sprintf(":x: Error converting event to jobsForImpactedProjects: %v", err))

--- a/cli/cmd/digger/default.go
+++ b/cli/cmd/digger/default.go
@@ -54,6 +54,7 @@ var defaultCmd = &cobra.Command{
 					lib_spec.BackendApiProvider{},
 					lib_spec.BasicPolicyProvider{},
 					lib_spec.PlanStorageProvider{},
+					lib_spec.VariablesProvider{},
 					comment_updater.CommentUpdaterProviderBasic{},
 				)
 			}

--- a/cli/cmd/digger/main_test.go
+++ b/cli/cmd/digger/main_test.go
@@ -900,7 +900,7 @@ func TestGitHubNewPullRequestContext(t *testing.T) {
 	}
 
 	event := context.Event.(github.PullRequestEvent)
-	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig)
+	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig, false)
 	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "dir")
 
 	assert.NoError(t, err)
@@ -995,7 +995,7 @@ func TestGitHubNewPullRequestInMultiEnvProjectContext(t *testing.T) {
 	impactedProjects, requestedProject, prNumber, err := dggithub.ProcessGitHubEvent(ghEvent, &diggerConfig, prManager)
 	assert.NoError(t, err)
 	event := context.Event.(github.PullRequestEvent)
-	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig)
+	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig, false)
 	spew.Dump(lock.MapLock)
 	assert.Equal(t, pullRequestNumber, prNumber)
 	assert.Equal(t, 1, len(jobs))

--- a/cli/cmd/digger/run_spec.go
+++ b/cli/cmd/digger/run_spec.go
@@ -40,6 +40,7 @@ var runSpecCmd = &cobra.Command{
 			lib_spec.BackendApiProvider{},
 			lib_spec.BasicPolicyProvider{},
 			lib_spec.PlanStorageProvider{},
+			lib_spec.VariablesProvider{},
 			comment_summary.CommentUpdaterProviderBasic{},
 		)
 		if err != nil {

--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -135,7 +135,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		}
 		workflow := diggerConfig.Workflows[projectConfig.Workflow]
 
-		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, true)
 
 		planStorage, err := storage.NewPlanStorage(ghToken, repoOwner, repositoryName, nil)
 		if err != nil {
@@ -170,7 +170,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			}
 			workflow := diggerConfig.Workflows[projectConfig.Workflow]
 
-			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, true)
 
 			StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(projectConfig)
 
@@ -234,7 +234,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		coversAllImpactedProjects := false
 		err = nil
 		if prEvent, ok := ghEvent.(github.PullRequestEvent); ok {
-			jobs, coversAllImpactedProjects, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig)
+			jobs, coversAllImpactedProjects, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig, true)
 		} else if commentEvent, ok := ghEvent.(github.IssueCommentEvent); ok {
 			prBranchName, _, err := githubPrService.GetBranchName(*commentEvent.Issue.Number)
 

--- a/cli/pkg/integration/integration_test.go
+++ b/cli/pkg/integration/integration_test.go
@@ -396,7 +396,7 @@ func TestHappyPath(t *testing.T) {
 	impactedProjects, requestedProject, prNumber, err := dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
 	event := ghEvent.(github.PullRequestEvent)
-	jobs, _, err := dg_github.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, *diggerConfig)
+	jobs, _, err := dg_github.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, *diggerConfig, false)
 	assert.NoError(t, err)
 	zipManager := storage.Zipper{}
 	planStorage := &storage.GithubPlanStorage{
@@ -439,7 +439,7 @@ func TestHappyPath(t *testing.T) {
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
 	prEvent := ghEvent.(github.PullRequestEvent)
-	jobs, _, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig)
+	jobs, _, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig, false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -551,7 +551,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	impactedProjects, requestedProject, prNumber, err := dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
 	pEvent := ghEvent.(github.PullRequestEvent)
-	jobs, _, err := dg_github.ConvertGithubPullRequestEventToJobs(&pEvent, impactedProjects, requestedProject, *diggerConfig)
+	jobs, _, err := dg_github.ConvertGithubPullRequestEventToJobs(&pEvent, impactedProjects, requestedProject, *diggerConfig, false)
 	assert.NoError(t, err)
 
 	zipManager := storage.Zipper{}
@@ -769,7 +769,7 @@ workflows:
 	impactedProjects, requestedProject, prNumber, err := dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
 	pEvent := ghEvent.(github.PullRequestEvent)
-	jobs, _, err := dg_github.ConvertGithubPullRequestEventToJobs(&pEvent, impactedProjects, requestedProject, *diggerConfig)
+	jobs, _, err := dg_github.ConvertGithubPullRequestEventToJobs(&pEvent, impactedProjects, requestedProject, *diggerConfig, false)
 	assert.NoError(t, err)
 
 	zipManager := storage.Zipper{}

--- a/ee/cli/cmd/digger/default.go
+++ b/ee/cli/cmd/digger/default.go
@@ -53,6 +53,7 @@ var defaultCmd = &cobra.Command{
 					lib_spec.BackendApiProvider{},
 					policy.AdvancedPolicyProvider{},
 					lib_spec.PlanStorageProvider{},
+					lib_spec.VariablesProvider{},
 					comment_summary.CommentUpdaterProviderBasic{},
 				)
 			}

--- a/ee/cli/cmd/digger/main_test.go
+++ b/ee/cli/cmd/digger/main_test.go
@@ -900,7 +900,7 @@ func TestGitHubNewPullRequestContext(t *testing.T) {
 	}
 
 	event := context.Event.(github.PullRequestEvent)
-	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig)
+	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig, false)
 	if err != nil {
 		assert.NoError(t, err)
 		log.Println(err)
@@ -1001,7 +1001,7 @@ func TestGitHubNewPullRequestInMultiEnvProjectContext(t *testing.T) {
 	impactedProjects, requestedProject, prNumber, err := dggithub.ProcessGitHubEvent(ghEvent, &diggerConfig, &prManager)
 	assert.NoError(t, err)
 	event := context.Event.(github.PullRequestEvent)
-	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig)
+	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig, false)
 
 	assert.Equal(t, pullRequestNumber, prNumber)
 	assert.Equal(t, 1, len(jobs))

--- a/ee/cli/cmd/digger/run_spec.go
+++ b/ee/cli/cmd/digger/run_spec.go
@@ -41,6 +41,7 @@ var runSpecCmd = &cobra.Command{
 			lib_spec.BackendApiProvider{},
 			policy.AdvancedPolicyProvider{},
 			lib_spec.PlanStorageProvider{},
+			lib_spec.VariablesProvider{},
 			comment_summary.CommentUpdaterProviderBasic{},
 		)
 		if err != nil {

--- a/libs/ci/azure/azure.go
+++ b/libs/ci/azure/azure.go
@@ -442,7 +442,7 @@ func ConvertAzureEventToCommands(parseAzureContext Azure, impactedProjects []dig
 			}
 
 			prNumber := parseAzureContext.Event.(AzurePrEvent).Resource.PullRequestId
-			stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars)
+			stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars, true)
 			StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 			jobs = append(jobs, scheduler.Job{
 				ProjectName:        project.Name,
@@ -472,7 +472,7 @@ func ConvertAzureEventToCommands(parseAzureContext Azure, impactedProjects []dig
 			}
 
 			prNumber := parseAzureContext.Event.(AzurePrEvent).Resource.PullRequestId
-			stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars)
+			stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars, true)
 			StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 			jobs = append(jobs, scheduler.Job{
 				ProjectName:        project.Name,
@@ -502,7 +502,7 @@ func ConvertAzureEventToCommands(parseAzureContext Azure, impactedProjects []dig
 				if !ok {
 					return nil, false, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 				}
-				stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars)
+				stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars, true)
 				StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 				jobs = append(jobs, scheduler.Job{
 					ProjectName:        project.Name,
@@ -557,7 +557,7 @@ func ConvertAzureEventToCommands(parseAzureContext Azure, impactedProjects []dig
 					if !ok {
 						return nil, false, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 					}
-					stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars)
+					stateEnvVars, commandEnvVars := digger_config2.CollectTerraformEnvConfig(workflow.EnvVars, true)
 					StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 					jobs = append(jobs, scheduler.Job{
 						ProjectName:        project.Name,

--- a/libs/ci/generic/events.go
+++ b/libs/ci/generic/events.go
@@ -148,7 +148,7 @@ func CreateJobsForProjects(projects []digger_config.Project, command string, eve
 		}
 
 		runEnvVars := GetRunEnvVars(defaultBranch, prBranch, project.Name, project.Dir)
-		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, false)
 		StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 		workspace := project.Workspace
 		jobs = append(jobs, scheduler.Job{

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -353,7 +353,7 @@ func (svc GithubService) CheckBranchExists(branchName string) (bool, error) {
 	return true, nil
 }
 
-func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impactedProjects []digger_config.Project, requestedProject *digger_config.Project, config digger_config.DiggerConfig) ([]scheduler.Job, bool, error) {
+func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impactedProjects []digger_config.Project, requestedProject *digger_config.Project, config digger_config.DiggerConfig, performEnvVarInterpolation bool) ([]scheduler.Job, bool, error) {
 	workflows := config.Workflows
 	jobs := make([]scheduler.Job, 0)
 
@@ -368,7 +368,7 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 
 		runEnvVars := generic.GetRunEnvVars(defaultBranch, prBranch, project.Name, project.Dir)
 
-		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, performEnvVarInterpolation)
 		pullRequestNumber := payload.PullRequest.Number
 
 		StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)

--- a/libs/ci/gitlab/gitlab.go
+++ b/libs/ci/gitlab/gitlab.go
@@ -357,7 +357,7 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 				return nil, true, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 			}
 
-			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, true)
 			StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 			jobs = append(jobs, scheduler.Job{
 				ProjectName:        project.Name,
@@ -385,7 +385,7 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 			if !ok {
 				return nil, true, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 			}
-			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, true)
 			var StateEnvProvider *stscreds.WebIdentityRoleProvider
 			var CommandEnvProvider *stscreds.WebIdentityRoleProvider
 			if project.AwsRoleToAssume != nil {
@@ -455,7 +455,7 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 					if workspaceOverride != "" {
 						workspace = workspaceOverride
 					}
-					stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+					stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, true)
 					StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 					jobs = append(jobs, scheduler.Job{
 						ProjectName:        project.Name,

--- a/libs/ci/gitlab/webhooks.go
+++ b/libs/ci/gitlab/webhooks.go
@@ -46,7 +46,7 @@ func ConvertGithubPullRequestEventToJobs(payload *gitlab.MergeEvent, impactedPro
 
 		runEnvVars := generic.GetRunEnvVars(defaultBranch, prBranch, project.Name, project.Dir)
 
-		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, false)
 		pullRequestNumber := payload.ObjectAttributes.IID
 		namespace := payload.Project.PathWithNamespace
 		sender := payload.User.Username

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -688,7 +688,7 @@ func retrieveConfigFile(workingDir string) (string, error) {
 	return "", nil
 }
 
-func CollectTerraformEnvConfig(envs *TerraformEnvConfig) (map[string]string, map[string]string) {
+func CollectTerraformEnvConfig(envs *TerraformEnvConfig, performInterpolation bool) (map[string]string, map[string]string) {
 	stateEnvVars := map[string]string{}
 	commandEnvVars := map[string]string{}
 
@@ -697,7 +697,11 @@ func CollectTerraformEnvConfig(envs *TerraformEnvConfig) (map[string]string, map
 			if envvar.Value != "" {
 				stateEnvVars[envvar.Name] = envvar.Value
 			} else if envvar.ValueFrom != "" {
-				stateEnvVars[envvar.Name] = os.Getenv(envvar.ValueFrom)
+				if performInterpolation {
+					stateEnvVars[envvar.Name] = os.Getenv(envvar.ValueFrom)
+				} else {
+					stateEnvVars[envvar.Name] = fmt.Sprintf("$DIGGER_%v", envvar.ValueFrom)
+				}
 			}
 		}
 
@@ -705,7 +709,11 @@ func CollectTerraformEnvConfig(envs *TerraformEnvConfig) (map[string]string, map
 			if envvar.Value != "" {
 				commandEnvVars[envvar.Name] = envvar.Value
 			} else if envvar.ValueFrom != "" {
-				commandEnvVars[envvar.Name] = os.Getenv(envvar.ValueFrom)
+				if performInterpolation {
+					commandEnvVars[envvar.Name] = os.Getenv(envvar.ValueFrom)
+				} else {
+					commandEnvVars[envvar.Name] = fmt.Sprintf("$DIGGER_%v", envvar.ValueFrom)
+				}
 			}
 		}
 	}

--- a/libs/scheduler/convert.go
+++ b/libs/scheduler/convert.go
@@ -16,7 +16,7 @@ func ConvertProjectsToJobs(actor string, repoNamespace string, command string, p
 			return nil, true, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 		}
 
-		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars)
+		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, false)
 		StateEnvProvider, CommandEnvProvider := GetStateAndCommandProviders(project)
 		jobs = append(jobs, Job{
 			ProjectName:      project.Name,

--- a/libs/spec/models.go
+++ b/libs/spec/models.go
@@ -40,7 +40,7 @@ type VariableSpec struct {
 	Name           string `json:"name"`
 	Value          string `json:"value"`
 	IsSecret       bool   `json:"is_secret"`
-	IsInterpolated bool   `json:"is_secret"`
+	IsInterpolated bool   `json:"is_interpolated"`
 }
 
 type SpecType string

--- a/libs/spec/models.go
+++ b/libs/spec/models.go
@@ -37,9 +37,10 @@ type PolicySpec struct {
 }
 
 type VariableSpec struct {
-	Name     string `json:"name"`
-	Value    string `json:"value"`
-	IsSecret bool   `json:"is_secret"`
+	Name           string `json:"name"`
+	Value          string `json:"value"`
+	IsSecret       bool   `json:"is_secret"`
+	IsInterpolated bool   `json:"is_secret"`
 }
 
 type SpecType string

--- a/libs/spec/variables_provider.go
+++ b/libs/spec/variables_provider.go
@@ -27,6 +27,9 @@ func (p VariablesProvider) GetVariables(variables []VariableSpec) (map[string]st
 				return nil, fmt.Errorf("could not decrypt value using private key: %v", err)
 			}
 			res[v.Name] = string(value)
+		} else if v.IsInterpolated {
+			// if it is an interpolated value we get it form env variable of the variable
+			res[v.Name] = os.Getenv(v.Value)
 		} else {
 			res[v.Name] = v.Value
 		}

--- a/next/controllers/github.go
+++ b/next/controllers/github.go
@@ -387,7 +387,7 @@ func handlePullRequestEvent(gh next_utils.GithubClientProvider, payload *github.
 		return fmt.Errorf("error processing event")
 	}
 
-	jobsForImpactedProjects, _, err := dg_github.ConvertGithubPullRequestEventToJobs(payload, impactedProjects, nil, *config)
+	jobsForImpactedProjects, _, err := dg_github.ConvertGithubPullRequestEventToJobs(payload, impactedProjects, nil, *config, false)
 	if err != nil {
 		log.Printf("Error converting event to jobsForImpactedProjects: %v", err)
 		backend_utils.InitCommentReporter(ghService, prNumber, fmt.Sprintf(":x: Error converting event to jobsForImpactedProjects: %v", err))


### PR DESCRIPTION
To make the cli executor less smart and rely only on spec we make this change which means that the executor will only rely on the passed variablespec to load the env variables on the client side.

For orchestrator we pull all variables from the workflow, if a variable needs interpolation we save its value is $DIGGER_variable_value_to_pull_from

At the time of generating spec for job we then take all the values, check for duplciates (fail if there are duplicates) and then we create a list of variables to be loaded on the client side

we also added an extra flag called is_interpolated to indicate if this variable should be interpolated or no