### PR TITLE
use correct installation id for queue item

### DIFF
--- a/.github/workflows/next_deploy.yml
+++ b/.github/workflows/next_deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop    # change to main if needed
-      - feat/github-orgid-endpoint
+      - fix/use-correct-installation-id-for-queue-item)
 jobs:
   deploy:
     name: Deploy app

--- a/.github/workflows/next_deploy.yml
+++ b/.github/workflows/next_deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop    # change to main if needed
-      - fix/use-correct-installation-id-for-queue-item)
+      - fix/use-correct-installation-id-for-queue-item
 jobs:
   deploy:
     name: Deploy app

--- a/next/controllers/runs.go
+++ b/next/controllers/runs.go
@@ -22,10 +22,17 @@ func processSingleQueueItem(gh next_utils.GithubClientProvider, queueItem model.
 		log.Printf("could not get repo: %v", err)
 		return fmt.Errorf("could not get repo: %v", err)
 	}
+
+	installation, err := dbmodels.DB.GetGithubAppInstallationByOrgAndRepo(repo.OrganizationID, repo.RepoFullName, dbmodels.GithubAppInstallActive)
+	if err != nil {
+		log.Printf("could not get github installation: %v", err)
+		return fmt.Errorf("could not get github installation: %v", err)
+	}
+
 	repoFullName := repo.RepoFullName
 	repoOwner := repo.RepoOrganisation
 	repoName := repo.RepoName
-	service, _, err := next_utils.GetGithubService(gh, dr.GithubInstallationID, repoFullName, repoOwner, repoName)
+	service, _, err := next_utils.GetGithubService(gh, installation.GithubInstallationID, repoFullName, repoOwner, repoName)
 	if err != nil {
 		log.Printf("failed to get github service for DiggerRun ID: %v: %v", dr.ID, err)
 		return fmt.Errorf("failed to get github service for DiggerRun ID: %v: %v", dr.ID, err)


### PR DESCRIPTION
We are storing the github_installation_id in the runs table, however when the github app is reinstalled this can change, causing us not able to initialise the github app correctly. Instead we are now fetching it from org_id and repo name from the repo table linked from project, this is gauranteed to be always up to date

we should probably also delete the column github_installation_id in the digger_runs table to avoid future confusion