### PR TITLE
refresh job token before triggering job

### DIFF
--- a/.github/workflows/next_deploy.yml
+++ b/.github/workflows/next_deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - develop    # change to main if needed
-      - fix/use-correct-installation-id-for-queue-item
+      - fix/refresh-jobtoken-before-run
 jobs:
   deploy:
     name: Deploy app

--- a/next/services/runs.go
+++ b/next/services/runs.go
@@ -68,6 +68,12 @@ func RunQueuesStateMachine(queueItem *model.DiggerRunQueueItem, service ci.PullR
 			return fmt.Errorf("could not get vcs token: %v", err)
 		}
 
+		err = dbmodels.DB.RefreshDiggerJobTokenExpiry(planJob)
+		if err != nil {
+			log.Printf("could not refresh job token expiry: %v", err)
+			return fmt.Errorf("could not refresh job token from expiry: %v", err)
+		}
+
 		ciBackend.TriggerWorkflow(*spec, *runName, *vcsToken)
 
 		// change status to RunPendingPlan
@@ -149,6 +155,12 @@ func RunQueuesStateMachine(queueItem *model.DiggerRunQueueItem, service ci.PullR
 		if err != nil {
 			log.Printf("could not get vcs token: %v", err)
 			return fmt.Errorf("could not get spec: %v", err)
+		}
+
+		err = dbmodels.DB.RefreshDiggerJobTokenExpiry(job)
+		if err != nil {
+			log.Printf("could not refresh job token expiry: %v", err)
+			return fmt.Errorf("could not refresh job token from expiry: %v", err)
 		}
 
 		ciBackend.TriggerWorkflow(*spec, *runName, *vcsToken)

--- a/next/services/scheduler.go
+++ b/next/services/scheduler.go
@@ -77,6 +77,12 @@ func TriggerJob(gh utils.GithubClientProvider, ciBackend ci_backends.CiBackend, 
 		return fmt.Errorf("could not get variable spec from job: %v", err)
 	}
 
+	err = dbmodels.DB.RefreshDiggerJobTokenExpiry(job)
+	if err != nil {
+		log.Printf("could not refresh job token expiry: %v", err)
+		return fmt.Errorf("could not refresh job token from expiry: %v", err)
+	}
+
 	spec, err := GetSpecFromJob(*job)
 	if err != nil {
 		log.Printf("could not get spec: %v", err)


### PR DESCRIPTION
Digger Team: When a run is queued and waits to be applied until user approved. We precreate job token and the expiry is set to two hours later. It means if a user waits more than that time before approving the token would have expired and job would h ave failed. In this PR we always refresh the token just before triggering the job in order to make sure that token would have not expired