### PR TITLE
also use opentofu on merge

### DIFF
--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -458,6 +458,7 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				ProjectWorkspace:   project.Workspace,
 				ProjectWorkflow:    project.Workflow,
 				Terragrunt:         project.Terragrunt,
+				OpenTofu:           project.OpenTofu,
 				Commands:           workflow.Configuration.OnCommitToDefault,
 				ApplyStage:         scheduler.ToConfigStage(workflow.Apply),
 				PlanStage:          scheduler.ToConfigStage(workflow.Plan),


### PR DESCRIPTION
The value of opentofu from digger.yml was not passed to the merge event

closes #1706