### PR TITLE
Stop automatically upgrading module/provider versions

### DIFF
--- a/libs/execution/opentofu.go
+++ b/libs/execution/opentofu.go
@@ -16,7 +16,6 @@ type OpenTofu struct {
 }
 
 func (tf OpenTofu) Init(params []string, envs map[string]string) (string, string, error) {
-	params = append(params, "-upgrade=true")
 	params = append(params, "-input=false")
 	params = append(params, "-no-color")
 	stdout, stderr, _, err := tf.runOpentofuCommand("init", true, envs, params...)

--- a/libs/execution/tf.go
+++ b/libs/execution/tf.go
@@ -25,7 +25,6 @@ type Terraform struct {
 }
 
 func (tf Terraform) Init(params []string, envs map[string]string) (string, string, error) {
-	params = append(params, "-upgrade=true")
 	params = append(params, "-input=false")
 	params = append(params, "-no-color")
 	stdout, stderr, _, err := tf.runTerraformCommand("init", true, envs, params...)


### PR DESCRIPTION
Please feel free to close this Pull Request if this was an intentional design decision, but I feel as though Digger should not upgrade modules/providers as this can lead to discrepancies when running plans locally vs the CI. Digger should adhere to the project's terraform lock file.

## Release Notes

```
- Digger no longer automatically upgrades modules/providers with the `--upgrade` flag when initializing a project. To restore the old behaviour you can use the `extra_args` field to pass `--upgrade` in the plan/apply steps in digger.yaml (https://docs.digger.dev/ce/reference/digger.yml#example-using-all-keys).
```