### PR TITLE
Feature: Added in skip_merge_check option to workflow configuration

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -358,9 +358,10 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			msg := fmt.Sprintf("Failed to check if PR is mergeable. %v", err)
 			return nil, msg, fmt.Errorf(msg)
 		}
-		log.Printf("PR status, mergeable: %v, merged: %v\n", isMergeable, isMerged)
-		if !isMergeable && !isMerged {
+		log.Printf("PR status, mergeable: %v, merged: %v and skipMergeCheck %v\n", isMergeable, isMerged, job.SkipMergeCheck)
+		if !isMergeable && !isMerged && !job.SkipMergeCheck {
 			comment := reportApplyMergeabilityError(reporter)
+			prService.SetStatus(*job.PullRequestNumber, "failure", job.ProjectName+"/apply")
 
 			return nil, comment, fmt.Errorf(comment)
 		} else {
@@ -633,7 +634,7 @@ func RunJob(
 				return fmt.Errorf(msg)
 			}
 			planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, planJsonOutput)
-			log.Printf(strings.Join(messages, "\n"))
+			log.Print(strings.Join(messages, "\n"))
 			if err != nil {
 				msg := fmt.Sprintf("Failed to validate plan %v", err)
 				log.Printf(msg)

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -175,11 +175,12 @@ workflows:
 
 ### WorkflowConfiguration
 
-| Key                    | Type                                                                    | Default | Required | Description                                                   | Notes |
-| ---------------------- | ----------------------------------------------------------------------- | ------- | -------- | ------------------------------------------------------------- | ----- |
-| on_pull_request_pushed | array of enums\[digger plan, digger apply, digger lock, digger unlock\] | \[\]    | no       | list of stages to run when pull request is pushed             |       |
-| on_pull_request_closed | array of enums\[digger plan, digger apply, digger lock, digger unlock\] | \[\]    | no       | list of stages to run when pull request is closed             |       |
-| on_commit_to_default   | array of enums\[digger plan, digger apply, digger lock, digger unlock\] | \[\]    | no       | list of stages to run when commit is pushed to default branch |       |
+| Key                    | Type                                                                    | Default | Required | Description                                                          | Notes |
+| ---------------------- | ----------------------------------------------------------------------- | ------- | -------- | -------------------------------------------------------------------- | ----- |
+| on_pull_request_pushed | array of enums\[digger plan, digger apply, digger lock, digger unlock\] | \[\]    | no       | list of stages to run when pull request is pushed                    |       |
+| on_pull_request_closed | array of enums\[digger plan, digger apply, digger lock, digger unlock\] | \[\]    | no       | list of stages to run when pull request is closed                    |       |
+| on_commit_to_default   | array of enums\[digger plan, digger apply, digger lock, digger unlock\] | \[\]    | no       | list of stages to run when commit is pushed to default branch        |       |
+| skip_merge_check       | boolean                                                                    | false   | no       | Allow a workflow to skip mergeability checks and run digger commands |       |
 
 ### Step
 

--- a/libs/ci/generic/events.go
+++ b/libs/ci/generic/events.go
@@ -147,6 +147,13 @@ func CreateJobsForProjects(projects []digger_config.Project, command string, eve
 			return nil, fmt.Errorf("failed to find workflow config '%s' for project '%s'", project.Workflow, project.Name)
 		}
 
+		var skipMerge bool
+		if workflow.Configuration != nil {
+			skipMerge = workflow.Configuration.SkipMergeCheck
+		} else {
+			skipMerge = false
+		}
+
 		runEnvVars := GetRunEnvVars(defaultBranch, prBranch, project.Name, project.Dir)
 		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, false)
 		StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
@@ -170,6 +177,7 @@ func CreateJobsForProjects(projects []digger_config.Project, command string, eve
 			RequestedBy:        requestedBy,
 			StateEnvProvider:   StateEnvProvider,
 			CommandEnvProvider: CommandEnvProvider,
+			SkipMergeCheck:     skipMerge,
 		})
 	}
 	return jobs, nil

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -500,6 +500,7 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck: 	skipMerge,
 			})
 		} else if *payload.Action == "closed" {
 			jobs = append(jobs, scheduler.Job{
@@ -521,6 +522,7 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck: 	skipMerge,
 			})
 		} else if *payload.Action == "converted_to_draft" {
 			var commands []string
@@ -549,6 +551,7 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck: 	skipMerge,
 			})
 		}
 

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -445,6 +445,13 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 			return nil, false, fmt.Errorf("failed to find workflow config '%s' for project '%s'", project.Workflow, project.Name)
 		}
 
+		var skipMerge bool
+		if workflow.Configuration != nil {
+			skipMerge = workflow.Configuration.SkipMergeCheck
+		} else {
+			skipMerge = false
+		}
+
 		runEnvVars := generic.GetRunEnvVars(defaultBranch, prBranch, project.Name, project.Dir)
 
 		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, performEnvVarInterpolation)
@@ -471,6 +478,7 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck: 	skipMerge,
 			})
 		} else if *payload.Action == "opened" || *payload.Action == "reopened" || *payload.Action == "synchronize" {
 			jobs = append(jobs, scheduler.Job{

--- a/libs/ci/gitlab/gitlab.go
+++ b/libs/ci/gitlab/gitlab.go
@@ -357,6 +357,13 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 				return nil, true, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 			}
 
+			var skipMerge bool
+			if workflow.Configuration != nil {
+				skipMerge = workflow.Configuration.SkipMergeCheck
+			} else {
+				skipMerge = false
+			}
+
 			stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, true)
 			StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 			jobs = append(jobs, scheduler.Job{
@@ -376,6 +383,7 @@ func ConvertGitLabEventToCommands(event GitLabEvent, gitLabContext *GitLabContex
 				CommandEnvVars:     commandEnvVars,
 				StateEnvProvider:   StateEnvProvider,
 				CommandEnvProvider: CommandEnvProvider,
+				SkipMergeCheck: 	skipMerge,
 			})
 		}
 		return jobs, true, nil

--- a/libs/ci/gitlab/webhooks.go
+++ b/libs/ci/gitlab/webhooks.go
@@ -51,6 +51,14 @@ func ConvertGithubPullRequestEventToJobs(payload *gitlab.MergeEvent, impactedPro
 		namespace := payload.Project.PathWithNamespace
 		sender := payload.User.Username
 
+
+		var skipMerge bool
+		if workflow.Configuration != nil {
+			skipMerge = workflow.Configuration.SkipMergeCheck
+		} else {
+			skipMerge = false
+		}
+
 		StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 		if payload.ObjectAttributes.Action == "merge" && payload.ObjectAttributes.TargetBranch == defaultBranch {
 			jobs = append(jobs, scheduler.Job{
@@ -71,6 +79,7 @@ func ConvertGithubPullRequestEventToJobs(payload *gitlab.MergeEvent, impactedPro
 				RequestedBy:        sender,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck:     skipMerge,
 			})
 		} else if payload.ObjectAttributes.Action == "open" || payload.ObjectAttributes.Action == "reopen" || payload.ObjectAttributes.Action == "synchronize" {
 			jobs = append(jobs, scheduler.Job{
@@ -92,6 +101,7 @@ func ConvertGithubPullRequestEventToJobs(payload *gitlab.MergeEvent, impactedPro
 				RequestedBy:        sender,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck:    	skipMerge,
 			})
 		} else if payload.ObjectAttributes.Action == "close" {
 			jobs = append(jobs, scheduler.Job{
@@ -113,6 +123,7 @@ func ConvertGithubPullRequestEventToJobs(payload *gitlab.MergeEvent, impactedPro
 				RequestedBy:        sender,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck:    	skipMerge,
 			})
 			//	TODO: Figure how to detect gitlab's "PR converted to draft" event
 		} else if payload.ObjectAttributes.Action == "converted_to_draft" {
@@ -142,6 +153,7 @@ func ConvertGithubPullRequestEventToJobs(payload *gitlab.MergeEvent, impactedPro
 				RequestedBy:        sender,
 				CommandEnvProvider: CommandEnvProvider,
 				StateEnvProvider:   StateEnvProvider,
+				SkipMergeCheck:   	skipMerge,
 			})
 		}
 

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -55,6 +55,7 @@ type WorkflowConfiguration struct {
 	OnPullRequestClosed           []string
 	OnPullRequestConvertedToDraft []string
 	OnCommitToDefault             []string
+	SkipMergeCheck				  bool
 }
 
 type TerraformEnvConfig struct {
@@ -86,6 +87,7 @@ func defaultWorkflow() *Workflow {
 			OnPullRequestPushed:           []string{"digger plan"},
 			OnPullRequestConvertedToDraft: []string{},
 			OnPullRequestClosed:           []string{"digger unlock"},
+			SkipMergeCheck: 			  false,
 		},
 		Plan: &Stage{
 			Steps: []Step{

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -121,6 +121,7 @@ func copyWorkflowConfiguration(config *WorkflowConfigurationYaml) *WorkflowConfi
 	result.OnPullRequestPushed = config.OnPullRequestPushed
 	result.OnCommitToDefault = config.OnCommitToDefault
 	result.OnPullRequestConvertedToDraft = config.OnPullRequestConvertedToDraft
+	result.SkipMergeCheck = config.SkipMergeCheck
 	return &result
 }
 

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -358,6 +358,7 @@ func LoadDiggerConfigYaml(workingDir string, generateProjects bool, changedFiles
 		}
 	}
 
+
 	return configYaml, nil
 }
 

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -54,6 +54,7 @@ type WorkflowConfigurationYaml struct {
 	// pull request converted to draft
 	OnPullRequestConvertedToDraft []string `yaml:"on_pull_request_to_draft"`
 	OnCommitToDefault             []string `yaml:"on_commit_to_default"`
+	SkipMergeCheck				  bool    `yaml:"skip_merge_check"`
 }
 
 func (s *StageYaml) ToCoreStage() Stage {
@@ -166,6 +167,7 @@ func (w *WorkflowYaml) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			OnCommitToDefault:   []string{"digger unlock"},
 			OnPullRequestPushed: []string{"digger plan"},
 			OnPullRequestClosed: []string{"digger unlock"},
+			SkipMergeCheck:      false,
 		},
 		Plan: &StageYaml{
 			Steps: []StepYaml{

--- a/libs/scheduler/convert.go
+++ b/libs/scheduler/convert.go
@@ -16,6 +16,13 @@ func ConvertProjectsToJobs(actor string, repoNamespace string, command string, p
 			return nil, true, fmt.Errorf("failed to find workflow digger_config '%s' for project '%s'", project.Workflow, project.Name)
 		}
 
+		var skipMerge bool
+		if workflow.Configuration != nil {
+			skipMerge = workflow.Configuration.SkipMergeCheck
+		} else {
+			skipMerge = false
+		}
+
 		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, false)
 		StateEnvProvider, CommandEnvProvider := GetStateAndCommandProviders(project)
 		jobs = append(jobs, Job{
@@ -37,6 +44,7 @@ func ConvertProjectsToJobs(actor string, repoNamespace string, command string, p
 			CommandEnvVars:     commandEnvVars,
 			StateEnvProvider:   StateEnvProvider,
 			CommandEnvProvider: CommandEnvProvider,
+			SkipMergeCheck: 	skipMerge,
 		})
 	}
 	return jobs, true, nil

--- a/libs/scheduler/jobs.go
+++ b/libs/scheduler/jobs.go
@@ -26,6 +26,7 @@ type Job struct {
 	CommandEnvVars     map[string]string
 	StateEnvProvider   *stscreds.WebIdentityRoleProvider
 	CommandEnvProvider *stscreds.WebIdentityRoleProvider
+	SkipMergeCheck	   bool
 }
 
 type Step struct {

--- a/libs/scheduler/json_models.go
+++ b/libs/scheduler/json_models.go
@@ -42,6 +42,7 @@ type JobJson struct {
 	BackendHostname         string            `json:"backend_hostname"`
 	BackendOrganisationName string            `json:"backend_organisation_hostname"`
 	BackendJobToken         string            `json:"backend_job_token"`
+	SkipMergeCheck          bool              `json:"skip_merge_check"`
 }
 
 func (j *JobJson) IsPlan() bool {
@@ -85,6 +86,7 @@ func JobToJson(job Job, jobType DiggerCommand, organisationName string, branch s
 		BackendHostname:         backendHostname,
 		BackendJobToken:         jobToken,
 		BackendOrganisationName: organisationName,
+		SkipMergeCheck:          job.SkipMergeCheck,
 	}
 }
 
@@ -107,6 +109,7 @@ func JsonToJob(jobJson JobJson) Job {
 		CommandEnvVars:     jobJson.CommandEnvVars,
 		StateEnvProvider:   GetProviderFromRole(jobJson.StateRoleName, jobJson.AwsRoleRegion),
 		CommandEnvProvider: GetProviderFromRole(jobJson.CommandRoleName, jobJson.AwsRoleRegion),
+		SkipMergeCheck:     jobJson.SkipMergeCheck,
 	}
 }
 


### PR DESCRIPTION
This adds a new configuration option to workflow configuration, `skip_merge_check` this override default behavior of Digger to check if a PR is in a mergeable state before allowing commands like `terraform apply`. 

Our use case is we keep multiple environments in the same repo and some environments and certain accounts should have branch protection controls in place, which exist at a repo level not at a directory level.  This option allows us to let developer environments bypass protections or other rules and apply state, even if the branch has not passed checks. 

Usage:
```yaml
    workflow_configuration:
      on_pull_request_pushed: ["digger plan"]
      on_pull_request_closed: ["digger unlock"]
      on_commit_to_default: ["digger unlock"]
      skip_merge_check: true                                    # skips the pr mergeability check before running apply command
```

