### PR TITLE
Add issues: read permissions to docs

### DIFF
--- a/docs/ce/cloud-providers/authenticating-with-oidc-on-aws.mdx
+++ b/docs/ce/cloud-providers/authenticating-with-oidc-on-aws.mdx
@@ -24,6 +24,7 @@ jobs:
       contents: write      # required to merge PRs
       id-token: write      # required for workload-identity-federation
       pull-requests: write # required to post PR comments
+      issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
 
     steps:

--- a/docs/ce/getting-started/github-actions-+-aws.mdx
+++ b/docs/ce/getting-started/github-actions-+-aws.mdx
@@ -55,11 +55,12 @@ jobs:
   digger-job:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # required to merge PRs
-      actions: write # required for plan persistence
-      id-token: write # required for workload-identity-federation
+      contents: write      # required to merge PRs
+      actions: write       # required for plan persistence
+      id-token: write      # required for workload-identity-federation
       pull-requests: write # required to post PR comments
-      statuses: write # required to validate combined PR status
+      issues: read         # required to check if PR number is an issue or not
+      statuses: write      # required to validate combined PR status
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/ce/getting-started/github-actions-and-gcp.mdx
+++ b/docs/ce/getting-started/github-actions-and-gcp.mdx
@@ -59,6 +59,7 @@ jobs:
       actions: write       # required for plan persistence
       id-token: write      # required for workload-identity-federation
       pull-requests: write # required to post PR comments
+      issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
     steps:
     - uses: actions/checkout@v4

--- a/docs/ce/howto/multiacc-aws.mdx
+++ b/docs/ce/howto/multiacc-aws.mdx
@@ -61,11 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: development                      # CHANGE ME !!!
     permissions:
-      contents: write # required to merge PRs
-      actions: write # required for plan persistence
-      id-token: write # required for workload-identity-federation
+      contents: write      # required to merge PRs
+      actions: write       # required for plan persistence
+      id-token: write      # required for workload-identity-federation
       pull-requests: write # required to post PR comments
-      statuses: write # required to validate combined PR status
+      issues: read         # required to check if PR number is an issue or not
+      statuses: write      # required to validate combined PR status
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/team/getting-started/gha-aws.mdx
+++ b/docs/team/getting-started/gha-aws.mdx
@@ -48,11 +48,12 @@ jobs:
   digger-job:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # required to merge PRs
-      actions: write # required for plan persistence
-      id-token: write # required for workload-identity-federation
+      contents: write      # required to merge PRs
+      actions: write       # required for plan persistence
+      id-token: write      # required for workload-identity-federation
       pull-requests: write # required to post PR comments
-      statuses: write # required to validate combined PR status
+      issues: read         # required to check if PR number is an issue or not
+      statuses: write      # required to validate combined PR status
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #1710

Starting from digger v0.6.41, at least `issues: read` permission is required to check if PR number is an issue or not. It should be clearly stated in the document so that other folks are not confused.

I'm not sure when `issues:write` is needed, please add another note where appropriate.