### PR TITLE
do not run license key checker for external contributions

### DIFF
--- a/.github/workflows/libs_test.yml
+++ b/.github/workflows/libs_test.yml
@@ -38,8 +38,22 @@ jobs:
       - name: Start Azurite service
         run: azurite --silent &
 
+      - name: Determine if PR is from external contributor
+        id: pr_check
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+          echo "is_external=false" >> $GITHUB_OUTPUT
+          else
+          echo "is_external=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Test
-        run: go test -v ./...
+        run: |
+          if [ "${{ steps.pr_check.outputs.is_external }}" = "true" ]; then
+            go test -v -tags=external ./...
+          else
+            go test -v ./...
+          fi
         env:
           DIGGER_LICENSE_KEY: ${{ secrets.TEST_DIGGER_LICENSE_KEY}}
         working-directory: libs

--- a/libs/license/license_test.go
+++ b/libs/license/license_test.go
@@ -1,3 +1,6 @@
+// use this to ignore tests from external contributions
+//go:build !external
+
 package license
 
 import (


### PR DESCRIPTION
currently contributions have a failing tests because the license key checker secret is not available on pull request contributions. We selectively ignore this test when a contribution is coming from external 

example of failing tests: https://github.com/diggerhq/digger/pull/1738