### PR TITLE
Allow to use opentofu with generate_projects

### DIFF
--- a/docs/ce/howto/specify-terraform-version.mdx
+++ b/docs/ce/howto/specify-terraform-version.mdx
@@ -21,7 +21,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-And similarly for openTofu:
+And similarly for OpenTofu:
 
 ```
 jobs:
@@ -37,3 +37,7 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+<Note>
+When you use OpenTofu, you also need to enable `opentofu: true` in the project settings in digger.yml.
+</Note>

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -115,6 +115,7 @@ workflows:
 | name                     | string                                               |        | yes      | name of the project                                                | must be unique                                                                                             |
 | dir                      | string                                               |        | yes      | directory containing the project                                   |                                                                                                            |
 | workspace                | string                                               | default | no       | terraform workspace to use                                         |                                                                                                           |
+| opentofu                 | boolean                                              | false   | no       | whether to use opentofu                                            |                                                                                                           |
 | terragrunt               | boolean                                              | false   | no       | whether to use terragrunt                                          |                                                                                                           |
 | workflow                 | string                                               | default | no       | workflow to use                                                    | default workflow will be created for you described in workflow section                                    |
 | include\_patterns        | array of strings                                     | \[\]    | no       | list of directory glob patterns to include, e.g. `./modules`       | see [Include / Exclude Patterns](/ce/howto/include-exclude-patterns)                                         |
@@ -124,10 +125,25 @@ workflows:
 
 ### GenerateProjects
 
-| Key     | Type   | Default | Required | Description                         | Notes |
-| ------- | ------ | ------- | -------- | ----------------------------------- | ----- |
-| include | string |         | no       | glob pattern to include directories |       |
-| exclude | string |         | no       | glob pattern to exclude directories |       |
+| Key     | Type                                               | Default | Required | Description                         | Notes |
+| ------- | -------------------------------------------------- | ------- | -------- | ----------------------------------- | ----- |
+| include | string                                             |         | no       | glob pattern to include directories |       |
+| exclude | string                                             |         | no       | glob pattern to exclude directories |       |
+| blocks  | array of [Block](/ce/reference/digger.yml#block)   | \[\]    | no       | list of blocks to generate projects |       |
+
+### Block
+
+| Key                | Type                                                  | Default | Required | Description                                                   | Notes                                                                  |
+| ------------------ | ----------------------------------------------------- | ------- | -------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| block_name         | string                                                |         | no       | name of the block                                             |                                                                        |
+| workflow           | string                                                | default | no       | workflow to use                                               | default workflow will be created for you described in workflow section |
+| workflow_file      | string                                                |         | no       | name of workflow file for GitHub Actions                      |                                                                        |
+| aws_role_to_assume | [RoleToAssume](/ce/reference/digger.yml#roletoassume) |         | no       | A string representing the AWS role to assume for this project |                                                                        |
+| include            | string                                                |         | no       | glob pattern to include directories                           | only for terraform and opentofu                                        |
+| exclude            | string                                                |         | no       | glob pattern to exclude directories                           | only for terraform and opentofu                                        |
+| opentofu           | boolean                                               | false   | no       | whether to use opentofu                                       | only for opentofu                                                      |
+| terragrunt         | boolean                                               | false   | no       | whether to use terragrunt                                     | only for terragrunt                                                    |
+| root_dir           | string                                                |         | no       | root directory of terragrunt projects                         | only for terragrunt                                                    |
 
 ### Workflows
 

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -302,6 +302,7 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string, 
 								Dir:             dir,
 								Workflow:        workflow,
 								Workspace:       "default",
+								OpenTofu:        b.OpenTofu,
 								AwsRoleToAssume: b.AwsRoleToAssume,
 								Generated:       true,
 							}

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -87,15 +87,18 @@ type EnvVarYaml struct {
 }
 
 type BlockYaml struct {
-	// these flags for terraform only
+	// these flags are only for terraform and opentofu
 	Include string `yaml:"include"`
 	Exclude string `yaml:"exclude"`
 
-	// these flags are only for terragrunt only
+	// these flags are only for terragrunt
 	Terragrunt bool    `yaml:"terragrunt"`
 	RootDir    *string `yaml:"root_dir"`
 
-	// these flags for both terraform and terragrunt
+	// these flags are only for opentofu
+	OpenTofu bool `yaml:"opentofu"`
+
+	// common flags
 	BlockName       string                      `yaml:"block_name"`
 	Workflow        string                      `yaml:"workflow"`
 	WorkflowFile    string                      `yaml:"workflow_file"`


### PR DESCRIPTION
The current implementation allows the use of opentofu in statically defined projects, but not in projects dynamically generated by generate_projects.

This patch adds the opentofu flag to the blocks in generate_projects as well, making opentofu available in a more dynamic environment. I also added the opentofu attribute and the missing type definition of Block type in digger.yml reference.