### PR TITLE
Update variables.mdx

### DIFF
--- a/docs/team/features/variables.mdx
+++ b/docs/team/features/variables.mdx
@@ -2,28 +2,28 @@
 title: "Variables & Secrets"
 ---
 
-Digger supports per-project Variables that are made available as environment variables to terraform / opentofu at runtime.
+Digger supports per-project Variables that are made available as environment variables to Terraform / OpenTofu at runtime.
 Variables are stored on the backend and passed to the job via the Job Spec.
 
-You can manage variables in the TFVars tab of every project.
+You can manage variables in the `TFVars` tab of every project.
 
 There are 2 types of variables: Plain Text and Secret.
 
 # Plain Text variables
 
-They are stored on the backend as-is and are not secured in any special way beyond standard transport and at-rest encryption in the infrastructure. Plain Text variable should only be used for non-sensitive data, like configuration parameters that differ across environments.
+They are stored on the backend as-is and are not secured in any special way beyond standard transport and at-rest encryption in the infrastructure. Plain Text variables should only be used for non-sensitive data, like configuration parameters that differ across environments.
 
 # Secret variables
 
 These variables are stored in the database encrypted with your organisation's Secret Key. It's an RSA public key that you can create in Organisation Settings. You will not be able to create Secret Variables until you have created your Secret Key as follows:
 
-1. Go to your Organisation Settings and click Create Secrets Key
+1. Go to your Organisation Settings and click Create Secret Key
 2. Copy the private key and save it in your GitHub Actions as an org-level secret named `DIGGER_PRIVATE_KEY`
 
 <Note>
   The key pair is generated in the front-end, and only shown once. At no point
-  the private key is saved or accessed by Digger services. If you lose your
-  private key, you will also lose ability to decrypt your secrets created using
+  is the private key saved or accessed by Digger services. If you lose your
+  private key, you will also lose the ability to decrypt your secrets created using
   that key - so you will need to re-create all your secrets in all projects.
 </Note>
 


### PR DESCRIPTION
docs: Fix spelling mistake in concepts 

`terraform / opentofu` => `Terraform/OpenTofu`
`Plain Text variable` => `Plain Text variables`
`Create Secrets Key` => `Create Secret Key`
`At no point the private key is saved` => `At no point is the private key saved`
`lose ability to decrypt your secrets` => `lose the ability to decrypt your secrets`

Documentation Correction:

* [`digger/docs/team/features/variables.mdx`]

Corrected typos in the sentence directing users about
the variable reference.






