### PR TITLE
feat/configurable initial message

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/diggerhq/digger/backend/ci_backends"
 	"github.com/diggerhq/digger/backend/locking"

--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/diggerhq/digger/backend/ci_backends"
 	"github.com/diggerhq/digger/backend/locking"
@@ -377,7 +378,7 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 	}
 
 	commentReporterManager := utils.InitCommentReporterManager(ghService, prNumber)
-	if _, exists := os.LookupEnv("DIGGER_REPORT_BEFORE_LOADING"); exists {
+	if _, exists := os.LookupEnv("DIGGER_REPORT_BEFORE_LOADING_CONFIG"); exists {
 		_, err := commentReporterManager.UpdateComment(":construction_worker: Digger starting....")
 		if err != nil {
 			log.Printf("Error initializing comment reporter: %v", err)
@@ -693,7 +694,7 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		return fmt.Errorf("error getting ghService to post error comment")
 	}
 	commentReporterManager := utils.InitCommentReporterManager(ghService, issueNumber)
-	if _, exists := os.LookupEnv("DIGGER_REPORT_BEFORE_LOADING"); exists {
+	if _, exists := os.LookupEnv("DIGGER_REPORT_BEFORE_LOADING_CONFIG"); exists {
 		_, err := commentReporterManager.UpdateComment(":construction_worker: Digger starting....")
 		if err != nil {
 			log.Printf("Error initializing comment reporter: %v", err)


### PR DESCRIPTION
- **make initial message pre loading digger config configurable**
- **rename config**

Users have complained that sometimes the process for loading diggerconfig takes *minuates* but digger doesn't leave any feedback in the meanwhile so  we added the ability to make digger always comment before performing the digger.yml config load in this way the users get immediate feedback that something is going on .. 

Flag is DIGGER_REPORT_BEFORE_LOADING_CONFIG=1
