### PR TITLE
respond immediately to github webhook

### DIFF
--- a/backend/controllers/github_test.go
+++ b/backend/controllers/github_test.go
@@ -706,7 +706,7 @@ func TestGithubHandleIssueCommentEvent(t *testing.T) {
 	var payload github.IssueCommentEvent
 	err := json.Unmarshal([]byte(issueCommentPayload), &payload)
 	assert.NoError(t, err)
-	err = handleIssueCommentEvent(gh, &payload, nil, 0)
+	err = handleIssueCommentEvent(gh, &payload, nil, 0, make([]IssueCommentHook, 0))
 	assert.NoError(t, err)
 
 	jobs, err := models.DB.GetPendingParentDiggerJobs(nil)


### PR DESCRIPTION
Since we are performing alot of operations such as cloning within the webhook handlign and it is prone to timeout of the http request, which may lead to github retrying the webhook. 

In order to avoid this we perform this asyncronously in a goroutine and immediately respond to the http request as "accepted"
