### PR TITLE
Bug: Added Check to StateEnvProvider before use

### DIFF
--- a/libs/scheduler/aws.go
+++ b/libs/scheduler/aws.go
@@ -185,10 +185,12 @@ func(job *Job) AuthBackendConfig() error {
 
 func(job *Job) AuthTerragrunt() error {
 	var err error
-	job.StateEnvVars, err = populateKeys(job.StateEnvVars, *job.StateEnvProvider)
-	if err != nil {
-		log.Printf("Failed to get keys from role (StateEnvProvider): %v", err)
-		return fmt.Errorf("failed to get (state) keys from role: %v", err)
+	if(job.StateEnvProvider != nil) {
+		job.StateEnvVars, err = populateKeys(job.StateEnvVars, *job.StateEnvProvider)
+		if err != nil {
+			log.Printf("Failed to get keys from role (StateEnvProvider): %v", err)
+			return fmt.Errorf("failed to get (state) keys from role: %v", err)
+		}
 	}
 
 	if job.CommandEnvProvider != nil {		


### PR DESCRIPTION
Added this to address this issue: 
```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19ff873]
goroutine 1 [running]:
github.com/diggerhq/digger/libs/scheduler.(*Job).AuthTerragrunt(0xc000a547f0)
	/home/runner/work/digger/digger/libs/scheduler/aws.go:188 +0x33
github.com/diggerhq/digger/libs/scheduler.(*Job).PopulateAwsCredentialsEnvVarsForJob(0xc000a547f0)
	/home/runner/work/digger/digger/libs/scheduler/aws.go:111 +0xa6
github.com/diggerhq/digger/cli/pkg/digger.run({_, _}, {{0xc000131710, 0x25}, {0xc000131740, 0x25}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...)
	/home/runner/work/digger/digger/cli/pkg/digger/digger.go:201 +0x319
github.com/diggerhq/digger/cli/pkg/digger.RunJobs({0xc000a55560, 0x1, 0x2cccc4a?}, {0x3574380, 0xc000914cc0}, {0x3527e60, 0xc000914d80}, {0x355ada0, 0x4ec6420}, {0x355ef98, ...}, ...)
	/home/runner/work/digger/digger/cli/pkg/digger/digger.go:96 +0x1478
github.com/diggerhq/digger/cli/pkg/spec.RunSpec({{0x0, 0x0}, {0xc0009161f0, 0x10}, {0xc000916200, 0xa}, {0x0, 0x0}, {{0xc0009161ec, 0x4}, ...}, ...}, ...)
	/home/runner/work/digger/digger/cli/pkg/spec/spec.go:153 +0x186d
main.init.func1(0xc0006b9600?, {0x2cc8279?, 0x4?, 0x2cc8229?})
	/home/runner/work/digger/digger/cli/cmd/digger/default.go:35 +0x15a
github.com/spf13/cobra.(*Command).execute(0x4e274c0, {0x4ec6420, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x4e277a0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
main.main()
	/home/runner/work/digger/digger/cli/cmd/digger/main.go:74 +0xe7
Error: Process completed with exit code 2.

```