### PR TITLE
ignore certain events in pullrequest event

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -357,6 +357,11 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 		}
 	}
 
+	if !slices.Contains([]string{"closed", "opened", "reopened", "synchronize", "converted_to_draft"}, action) {
+		log.Printf("The action %v is not one that we should act on, ignoring webhook event", action)
+		return nil
+	}
+
 	commentReporterManager := utils.InitCommentReporterManager(ghService, prNumber)
 	if _, exists := os.LookupEnv("DIGGER_REPORT_BEFORE_LOADING_CONFIG"); exists {
 		_, err := commentReporterManager.UpdateComment(":construction_worker: Digger starting....")
@@ -605,7 +610,6 @@ func getDiggerConfigForPR(gh utils.GithubClientProvider, orgId uint, prLabels []
 		return "", nil, nil, nil, nil, nil, fmt.Errorf("error loading digger.yml: %v", err)
 	}
 
-	log.Printf("Digger config loadded successfully\n")
 	return diggerYmlStr, ghService, config, dependencyGraph, &prBranch, &prCommitSha, nil
 }
 


### PR DESCRIPTION
This issue was introduced because of the configurability of "always commenting on pull request when digger starts"  and that introduced a bug that when a label was changed it would fire a pull request event and digger would leave repeated comments for those changes. We add an explicit ignore logic for events outside of the ones we expect to avoid it 