### PR TITLE
use hostname in both github and caching

### DIFF
--- a/backend/controllers/cache.go
+++ b/backend/controllers/cache.go
@@ -52,15 +52,8 @@ func (d DiggerController) UpdateRepoCache(c *gin.Context) {
 		return
 	}
 
-	cloneUrl := repo.RepoUrl
+	cloneUrl := fmt.Sprintf("https://%v/%v", utils.GetGithubHostname(), repo.RepoFullName)
 	branch := request.Branch
-
-	//ghInstallation, err := models.DB.GetInstallationForRepo(repoFullName)
-	//if err != nil {
-	//	log.Printf("could not get repo: %v", err)
-	//	c.String(500, fmt.Sprintf("coulnt not get repository %v %v", repoFullName, orgId))
-	//	return
-	//}
 
 	_, token, err := utils.GetGithubService(d.GithubClientProvider, installationId, repoFullName, repoOwner, repoName)
 	if err != nil {

--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -1163,7 +1163,7 @@ func (d DiggerController) GithubAppCallbackPage(c *gin.Context) {
 		repoFullName := *repo.FullName
 		repoOwner := strings.Split(*repo.FullName, "/")[0]
 		repoName := *repo.Name
-		repoUrl := fmt.Sprintf("https://github.com/%v", repoFullName)
+		repoUrl := fmt.Sprintf("https://%v/%v", utils.GetGithubHostname(), repoFullName)
 		_, err := models.DB.GithubRepoAdded(installationId64, *installation.AppID, *installation.Account.Login, *installation.Account.ID, repoFullName)
 		if err != nil {
 			log.Printf("github repos added error: %v", err)


### PR DESCRIPTION
a quick patch fix because we have not been loading hostname correctly in the caching and also in the repo callback