### PR TITLE
Fix drift check logic for no chnages

### DIFF
--- a/libs/iac_utils/terraform.go
+++ b/libs/iac_utils/terraform.go
@@ -39,8 +39,11 @@ func (tu TerraformUtils) GetSummaryFromPlanJson(planJson string) (bool, *IacSumm
 		}
 	}
 
-	if tfplan.OutputChanges != nil {
-		isPlanEmpty = false
+	for _, change := range tfplan.OutputChanges {
+		if len(change.Actions) != 1 || change.Actions[0] != "no-op" {
+			isPlanEmpty = false
+			break
+		}
 	}
 
 	planSummary := IacSummary{}


### PR DESCRIPTION
## Description
Terraform show command output json can contain `output_changes` even if there are no changes required in plan, it will list all those changes with action `no-op`, so a normal `nil` check will not work with this, Due to this issue current code is resulting into false positives where drift checker will send notifications even if there are no changes detected

## Solution
Here I have checked for action in `output_changes` in a similar way we do in `resource_changes`