### PR TITLE
make the max number of projects configurable

### DIFF
--- a/backend/config/envgetters.go
+++ b/backend/config/envgetters.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func GetMaxProjectsCreated() int {
+	// the maximum number of impacted projects possible for a change
+	// digger will fail when this number exceeds it
+	// default value of 0 or negative means unlimited allowed
+	maxProjects := os.Getenv("DIGGER_MAX_PROJECTS_IMPACTED")
+	maxProjectsNum, err := strconv.Atoi(maxProjects)
+	if err != nil {
+		fmt.Printf("Error converting env var to number: %v\n", err)
+		return 0
+	}
+	return maxProjectsNum
+}

--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -404,10 +404,10 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 
 	// ratio of impacted projects to changed files should be less than MAX_RATIO
 	maxProjects := config2.GetMaxProjectsCreated()
-	if maxProjects < 0 {
+	if maxProjects > 0 {
 		if len(impactedProjects) > maxProjects {
 			log.Printf("Error the number impacted projects %v exceeds maximum allowed: %v", len(impactedProjects), maxProjects)
-			commentReporterManager.UpdateComment(fmt.Sprintf("Error the number impacted projects %v exceeds maximum allowed: %v", len(impactedProjects), maxProjects))
+			commentReporterManager.UpdateComment(fmt.Sprintf(":x: Error the number impacted projects %v exceeds maximum allowed: %v", len(impactedProjects), maxProjects))
 			log.Printf("Information about the event:")
 			log.Printf("GH payload: %v", payload)
 			log.Printf("PR changed files: %v", changedFiles)
@@ -794,10 +794,10 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 
 	// ratio of impacted projects to changed files should be less than MAX_RATIO
 	maxProjects := config2.GetMaxProjectsCreated()
-	if maxProjects < 0 {
+	if maxProjects > 0 {
 		if len(impactedProjects) > maxProjects {
 			log.Printf("Error the number impacted projects %v exceeds maximum allowed: %v", len(impactedProjects), maxProjects)
-			commentReporterManager.UpdateComment(fmt.Sprintf("Error the number impacted projects %v exceeds maximum allowed: %v", len(impactedProjects), maxProjects))
+			commentReporterManager.UpdateComment(fmt.Sprintf(":x: Error the number impacted projects %v exceeds maximum allowed: %v", len(impactedProjects), maxProjects))
 			log.Printf("Information about the event:")
 			log.Printf("GH payload: %v", payload)
 			log.Printf("PR changed files: %v", changedFiles)


### PR DESCRIPTION
Adds a parameter DIGGER_MAX_PROJECTS_IMPACTED which default to 0 (unlimited) and if set it limits the number of projects impacted allowed per change. This is a safety measure like a hard limit to ensure that digger will never trigger alot of jobs at once.
<img width="926" alt="Screenshot 2024-11-27 at 16 45 07" src="https://github.com/user-attachments/assets/abb7bf8c-110b-4df9-83d1-c5d7aeaaaf2e">
