### PR TITLE
suport ignore include blocks for terragrunt

### DIFF
--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -516,7 +516,28 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 		workflowFile = parsingConfig.WorkflowFile
 	}
 
-	atlantisConfig, _, err := atlantis.Parse(root, parsingConfig.ProjectHclFiles, projectExternalChilds, parsingConfig.AutoMerge, parallel, parsingConfig.FilterPath, parsingConfig.CreateHclProjectChilds, ignoreParentTerragrunt, parsingConfig.IgnoreDependencyBlocks, parsingConfig.IgnoreIncludeBlocks, cascadeDependencies, parsingConfig.DefaultWorkflow, parsingConfig.DefaultApplyRequirements, parsingConfig.AutoPlan, parsingConfig.DefaultTerraformVersion, parsingConfig.CreateProjectName, parsingConfig.CreateWorkspace, parsingConfig.PreserveProjects, parsingConfig.UseProjectMarkers, executionOrderGroups)
+	atlantisConfig, _, err := atlantis.Parse(
+		root,
+		parsingConfig.ProjectHclFiles,
+		projectExternalChilds,
+		parsingConfig.AutoMerge,
+		parallel,
+		parsingConfig.FilterPath,
+		parsingConfig.CreateHclProjectChilds,
+		ignoreParentTerragrunt,
+		parsingConfig.IgnoreDependencyBlocks,
+		parsingConfig.IgnoreIncludeBlocks,
+		cascadeDependencies,
+		parsingConfig.DefaultWorkflow,
+		parsingConfig.DefaultApplyRequirements,
+		parsingConfig.AutoPlan,
+		parsingConfig.DefaultTerraformVersion,
+		parsingConfig.CreateProjectName,
+		parsingConfig.CreateWorkspace,
+		parsingConfig.PreserveProjects,
+		parsingConfig.UseProjectMarkers,
+		executionOrderGroups,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to autogenerate digger_config, error during parse: %v", err)
 	}

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -516,27 +516,7 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 		workflowFile = parsingConfig.WorkflowFile
 	}
 
-	atlantisConfig, _, err := atlantis.Parse(
-		root,
-		parsingConfig.ProjectHclFiles,
-		projectExternalChilds,
-		parsingConfig.AutoMerge,
-		parallel,
-		parsingConfig.FilterPath,
-		parsingConfig.CreateHclProjectChilds,
-		ignoreParentTerragrunt,
-		parsingConfig.IgnoreDependencyBlocks,
-		cascadeDependencies,
-		parsingConfig.DefaultWorkflow,
-		parsingConfig.DefaultApplyRequirements,
-		parsingConfig.AutoPlan,
-		parsingConfig.DefaultTerraformVersion,
-		parsingConfig.CreateProjectName,
-		parsingConfig.CreateWorkspace,
-		parsingConfig.PreserveProjects,
-		parsingConfig.UseProjectMarkers,
-		executionOrderGroups,
-	)
+	atlantisConfig, _, err := atlantis.Parse(root, parsingConfig.ProjectHclFiles, projectExternalChilds, parsingConfig.AutoMerge, parallel, parsingConfig.FilterPath, parsingConfig.CreateHclProjectChilds, ignoreParentTerragrunt, parsingConfig.IgnoreDependencyBlocks, parsingConfig.IgnoreIncludeBlocks, cascadeDependencies, parsingConfig.DefaultWorkflow, parsingConfig.DefaultApplyRequirements, parsingConfig.AutoPlan, parsingConfig.DefaultTerraformVersion, parsingConfig.CreateProjectName, parsingConfig.CreateWorkspace, parsingConfig.PreserveProjects, parsingConfig.UseProjectMarkers, executionOrderGroups)
 	if err != nil {
 		return fmt.Errorf("failed to autogenerate digger_config, error during parse: %v", err)
 	}

--- a/libs/digger_config/terragrunt/atlantis/generate.go
+++ b/libs/digger_config/terragrunt/atlantis/generate.go
@@ -118,7 +118,7 @@ func sliceUnion(a, b []string) []string {
 }
 
 // Parses the terragrunt digger_config at `path` to find all modules it depends on
-func getDependencies(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, gitRoot string, cascadeDependencies bool, path string, terragruntOptions *options.TerragruntOptions) ([]string, error) {
+func getDependencies(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, ignoreIncludeBlocks bool, gitRoot string, cascadeDependencies bool, path string, terragruntOptions *options.TerragruntOptions) ([]string, error) {
 	res, err, _ := requestGroup.Do(path, func() (interface{}, error) {
 		// Check if this path has already been computed
 		cachedResult, ok := getDependenciesCache.get(path)
@@ -139,7 +139,7 @@ func getDependencies(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, g
 		}
 
 		dependencies := []string{}
-		if len(includes) > 0 {
+		if !ignoreIncludeBlocks && len(includes) > 0 {
 			for _, includeDep := range includes {
 				getDependenciesCache.set(includeDep.Path, getDependenciesOutput{nil, err})
 				dependencies = append(dependencies, includeDep.Path)
@@ -256,7 +256,7 @@ func getDependencies(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, g
 			depPath := dep
 			terrOpts, _ := options.NewTerragruntOptionsWithConfigPath(depPath)
 			terrOpts.OriginalTerragruntConfigPath = terragruntOptions.OriginalTerragruntConfigPath
-			childDeps, err := getDependencies(ignoreParentTerragrunt, ignoreDependencyBlocks, gitRoot, cascadeDependencies, depPath, terrOpts)
+			childDeps, err := getDependencies(ignoreParentTerragrunt, ignoreDependencyBlocks, ignoreIncludeBlocks, gitRoot, cascadeDependencies, depPath, terrOpts)
 			if err != nil {
 				continue
 			}
@@ -313,7 +313,7 @@ func getDependencies(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, g
 }
 
 // Creates an AtlantisProject for a directory
-func createProject(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, gitRoot string, cascadeDependencies bool, defaultWorkflow string, defaultApplyRequirements []string, autoPlan bool, defaultTerraformVersion string, createProjectName bool, createWorkspace bool, sourcePath string) (*AtlantisProject, []string, error) {
+func createProject(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, ignoreIncludeBlocks bool, gitRoot string, cascadeDependencies bool, defaultWorkflow string, defaultApplyRequirements []string, autoPlan bool, defaultTerraformVersion string, createProjectName bool, createWorkspace bool, sourcePath string) (*AtlantisProject, []string, error) {
 	options, err := options.NewTerragruntOptionsWithConfigPath(sourcePath)
 
 	var potentialProjectDependencies []string
@@ -324,7 +324,7 @@ func createProject(ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, git
 	options.RunTerragrunt = terraform.Run
 	options.Env = getEnvs()
 
-	dependencies, err := getDependencies(ignoreParentTerragrunt, ignoreDependencyBlocks, gitRoot, cascadeDependencies, sourcePath, options)
+	dependencies, err := getDependencies(ignoreParentTerragrunt, ignoreDependencyBlocks, ignoreIncludeBlocks, gitRoot, cascadeDependencies, sourcePath, options)
 	if err != nil {
 		return nil, potentialProjectDependencies, err
 	}
@@ -434,7 +434,7 @@ func projectNameFromDir(projectDir string) string {
 	return projectName
 }
 
-func createHclProject(defaultWorkflow string, defaultApplyRequirements []string, autoplan bool, useProjectMarkers bool, defaultTerraformVersion string, ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, gitRoot string, cascadeDependencies bool, createProjectName bool, createWorkspace bool, sourcePaths []string, workingDir string, projectHcl string) (*AtlantisProject, error) {
+func createHclProject(defaultWorkflow string, defaultApplyRequirements []string, autoplan bool, useProjectMarkers bool, defaultTerraformVersion string, ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, ignoreIncludeBlocks bool, gitRoot string, cascadeDependencies bool, createProjectName bool, createWorkspace bool, sourcePaths []string, workingDir string, projectHcl string) (*AtlantisProject, error) {
 	var projectHclDependencies []string
 	var childDependencies []string
 	workflow := defaultWorkflow
@@ -507,7 +507,7 @@ func createHclProject(defaultWorkflow string, defaultApplyRequirements []string,
 		options.RunTerragrunt = terraform.Run
 		options.Env = getEnvs()
 
-		dependencies, err := getDependencies(ignoreParentTerragrunt, ignoreDependencyBlocks, gitRoot, cascadeDependencies, sourcePath, options)
+		dependencies, err := getDependencies(ignoreParentTerragrunt, ignoreDependencyBlocks, ignoreIncludeBlocks, gitRoot, cascadeDependencies, sourcePath, options)
 		if err != nil {
 			return nil, err
 		}
@@ -660,7 +660,7 @@ func getAllTerragruntProjectHclFiles(projectHclFiles []string, gitRoot string) m
 	return uniqueHclFileAbsPaths
 }
 
-func Parse(gitRoot string, projectHclFiles []string, createHclProjectExternalChilds bool, autoMerge bool, parallel bool, filterPath string, createHclProjectChilds bool, ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, cascadeDependencies bool, defaultWorkflow string, defaultApplyRequirements []string, autoPlan bool, defaultTerraformVersion string, createProjectName bool, createWorkspace bool, preserveProjects bool, useProjectMarkers bool, executionOrderGroups bool) (*AtlantisConfig, map[string][]string, error) {
+func Parse(gitRoot string, projectHclFiles []string, createHclProjectExternalChilds bool, autoMerge bool, parallel bool, filterPath string, createHclProjectChilds bool, ignoreParentTerragrunt bool, ignoreDependencyBlocks bool, ignoreIncludeBlocks bool, cascadeDependencies bool, defaultWorkflow string, defaultApplyRequirements []string, autoPlan bool, defaultTerraformVersion string, createProjectName bool, createWorkspace bool, preserveProjects bool, useProjectMarkers bool, executionOrderGroups bool) (*AtlantisConfig, map[string][]string, error) {
 	// Ensure the gitRoot has a trailing slash and is an absolute path
 	absoluteGitRoot, err := filepath.Abs(gitRoot)
 	if err != nil {
@@ -726,7 +726,7 @@ func Parse(gitRoot string, projectHclFiles []string, createHclProjectExternalChi
 
 				errGroup.Go(func() error {
 					defer sem.Release(1)
-					project, projDeps, err := createProject(ignoreParentTerragrunt, ignoreDependencyBlocks, gitRoot, cascadeDependencies, defaultWorkflow, defaultApplyRequirements, autoPlan, defaultTerraformVersion, createProjectName, createWorkspace, terragruntPath)
+					project, projDeps, err := createProject(ignoreParentTerragrunt, ignoreDependencyBlocks, ignoreIncludeBlocks, gitRoot, cascadeDependencies, defaultWorkflow, defaultApplyRequirements, autoPlan, defaultTerraformVersion, createProjectName, createWorkspace, terragruntPath)
 					if err != nil {
 						return err
 					}
@@ -785,7 +785,7 @@ func Parse(gitRoot string, projectHclFiles []string, createHclProjectExternalChi
 
 			errGroup.Go(func() error {
 				defer sem.Release(1)
-				project, err := createHclProject(defaultWorkflow, defaultApplyRequirements, autoPlan, useProjectMarkers, defaultTerraformVersion, ignoreParentTerragrunt, ignoreDependencyBlocks, gitRoot, cascadeDependencies, createProjectName, createWorkspace, terragruntFiles, workingDir, projectHcl)
+				project, err := createHclProject(defaultWorkflow, defaultApplyRequirements, autoPlan, useProjectMarkers, defaultTerraformVersion, ignoreParentTerragrunt, ignoreDependencyBlocks, ignoreIncludeBlocks, gitRoot, cascadeDependencies, createProjectName, createWorkspace, terragruntFiles, workingDir, projectHcl)
 				if err != nil {
 					return err
 				}

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -143,6 +143,7 @@ type TerragruntParsingConfig struct {
 	IgnoreParentTerragrunt   *bool    `yaml:"ignoreParentTerragrunt,omitempty"`
 	CreateParentProject      bool     `yaml:"createParentProject"`
 	IgnoreDependencyBlocks   bool     `yaml:"ignoreDependencyBlocks"`
+	IgnoreIncludeBlocks      bool     `yaml:"ignoreIncludeBlocks"`
 	Parallel                 *bool    `yaml:"parallel,omitempty"`
 	CreateWorkspace          bool     `yaml:"createWorkspace"`
 	CreateProjectName        bool     `yaml:"createProjectName"`


### PR DESCRIPTION
supporting a special flag in generate projects which would ignore includes during terragrunt project generation:

```
generate_projects:
  terragrunt_parsing:
    parallel: true
    createProjectName: true
    createWorkspace: true
    defaultWorkflow: default
    ignoreIncludeBlocks: true
```

The flag `ignoreIncludeBlocks` being true will cause any terragrunt include blocks to not be included

```
include {
  path = find_in_parent_folders("terragrunt.hcl")
}
```