### PR TITLE
add flag to ignore all external directories per project

### DIFF
--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -562,6 +562,11 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 		// normalize paths
 		projectDir := path.Join(pathPrefix, atlantisProject.Dir)
 		atlantisProject.Autoplan.WhenModified, err = GetPatternsRelativeToRepo(projectDir, atlantisProject.Autoplan.WhenModified)
+
+		if parsingConfig.TriggerProjectsFromDirOnly {
+			atlantisProject.Autoplan.WhenModified, err = FilterPathsOutsideOfProjectPath(projectDir, atlantisProject.Autoplan.WhenModified)
+		}
+
 		if err != nil {
 			return fmt.Errorf("could not normalize patterns: %v", err)
 		}

--- a/libs/digger_config/utils.go
+++ b/libs/digger_config/utils.go
@@ -20,7 +20,7 @@ func FilterPathsOutsideOfProjectPath(projectPath string, patterns []string) ([]s
 	res := make([]string, 0)
 	for _, pattern := range patterns {
 		if strings.HasPrefix(pattern, projectPath) {
-			res = append(res, path.Join(pattern))
+			res = append(res, pattern)
 		}
 	}
 	return res, nil

--- a/libs/digger_config/utils.go
+++ b/libs/digger_config/utils.go
@@ -5,12 +5,23 @@ import (
 	"log"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 func GetPatternsRelativeToRepo(projectPath string, patterns []string) ([]string, error) {
 	res := make([]string, 0)
 	for _, pattern := range patterns {
 		res = append(res, path.Join(projectPath, pattern))
+	}
+	return res, nil
+}
+
+func FilterPathsOutsideOfProjectPath(projectPath string, patterns []string) ([]string, error) {
+	res := make([]string, 0)
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, projectPath) {
+			res = append(res, path.Join(pattern))
+		}
 	}
 	return res, nil
 }

--- a/libs/digger_config/utils_test.go
+++ b/libs/digger_config/utils_test.go
@@ -45,3 +45,13 @@ func TestGetPatternsRelativeToRepo(t *testing.T) {
 	assert.Equal(t, "myProject/terraform/environments/devel/*.hcl", res[0])
 
 }
+
+func TestFilterPathsOutsideOfProjectPath(t *testing.T) {
+	projectDir := "staging/aws/us-east-1/k8s"
+	includePatterns := []string{"staging/aws/us-east-1/k8s/*.hcl", "staging/terragrunt-root.hcl vpc/*.tf*", "staging/aws/us-east-1/aws_region.tfvars", "staging/aws/aws_assume_role_arn.tfvars", "staging/aws/us-east-1/k8s/*.tf*"}
+	res, _ := FilterPathsOutsideOfProjectPath(projectDir, includePatterns)
+	assert.Equal(t, 2, len(res))
+	assert.Equal(t, "staging/aws/us-east-1/k8s/*.hcl", res[0])
+	assert.Equal(t, "staging/aws/us-east-1/k8s/*.tf*", res[1])
+
+}

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -137,24 +137,25 @@ type GenerateProjectsConfigYaml struct {
 }
 
 type TerragruntParsingConfig struct {
-	GitRoot                  *string  `yaml:"gitRoot,omitempty"`
-	AutoPlan                 bool     `yaml:"autoPlan"`
-	AutoMerge                bool     `yaml:"autoMerge"`
-	IgnoreParentTerragrunt   *bool    `yaml:"ignoreParentTerragrunt,omitempty"`
-	CreateParentProject      bool     `yaml:"createParentProject"`
-	IgnoreDependencyBlocks   bool     `yaml:"ignoreDependencyBlocks"`
-	IgnoreIncludeBlocks      bool     `yaml:"ignoreIncludeBlocks"`
-	Parallel                 *bool    `yaml:"parallel,omitempty"`
-	CreateWorkspace          bool     `yaml:"createWorkspace"`
-	CreateProjectName        bool     `yaml:"createProjectName"`
-	DefaultTerraformVersion  string   `yaml:"defaultTerraformVersion"`
-	DefaultWorkflow          string   `yaml:"defaultWorkflow"`
-	FilterPath               string   `yaml:"filterPath"`
-	OutputPath               string   `yaml:"outputPath"`
-	PreserveWorkflows        *bool    `yaml:"preserveWorkflows,omitempty"`
-	PreserveProjects         bool     `yaml:"preserveProjects"`
-	CascadeDependencies      *bool    `yaml:"cascadeDependencies,omitempty"`
-	DefaultApplyRequirements []string `yaml:"defaultApplyRequirements"`
+	GitRoot                    *string  `yaml:"gitRoot,omitempty"`
+	AutoPlan                   bool     `yaml:"autoPlan"`
+	AutoMerge                  bool     `yaml:"autoMerge"`
+	IgnoreParentTerragrunt     *bool    `yaml:"ignoreParentTerragrunt,omitempty"`
+	CreateParentProject        bool     `yaml:"createParentProject"`
+	IgnoreDependencyBlocks     bool     `yaml:"ignoreDependencyBlocks"`
+	IgnoreIncludeBlocks        bool     `yaml:"ignoreIncludeBlocks"`
+	TriggerProjectsFromDirOnly bool     `yaml:"triggerProjectsFromDirOnly"`
+	Parallel                   *bool    `yaml:"parallel,omitempty"`
+	CreateWorkspace            bool     `yaml:"createWorkspace"`
+	CreateProjectName          bool     `yaml:"createProjectName"`
+	DefaultTerraformVersion    string   `yaml:"defaultTerraformVersion"`
+	DefaultWorkflow            string   `yaml:"defaultWorkflow"`
+	FilterPath                 string   `yaml:"filterPath"`
+	OutputPath                 string   `yaml:"outputPath"`
+	PreserveWorkflows          *bool    `yaml:"preserveWorkflows,omitempty"`
+	PreserveProjects           bool     `yaml:"preserveProjects"`
+	CascadeDependencies        *bool    `yaml:"cascadeDependencies,omitempty"`
+	DefaultApplyRequirements   []string `yaml:"defaultApplyRequirements"`
 	//NumExecutors                   int64	`yaml:"numExecutors"`
 	ProjectHclFiles                []string                    `yaml:"projectHclFiles"`
 	CreateHclProjectChilds         bool                        `yaml:"createHclProjectChilds"`


### PR DESCRIPTION
This will introduce a parameter called `triggerProjectsFromDirOnly` which if set will cause generation to not have include_patterns outside of the project directories itself:

Usage: 

```
generate_projects:
  terragrunt_parsing:
    parallel: true
    createProjectName: true
    createWorkspace: true
    defaultWorkflow: default
    triggerProjectsFromDirOnly: true
```
it will cause generated projects to only be reflected from the directory itself, for example if the expected include_patterns would be:

"staging/aws/us-east-1/k8s/*.hcl", "staging/terragrunt-root.hcl vpc/*.tf*", "staging/aws/us-east-1/aws_region.tfvars", "staging/aws/aws_assume_role_arn.tfvars", "staging/aws/us-east-1/k8s/*.tf*"

and the project directory is staging/aws/us-east-1/k8s then only these paths will be considered: 

"staging/aws/us-east-1/k8s/*.hcl", "staging/aws/us-east-1/k8s/*.tf*"

-----
----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to filter project paths based on a directory flag, enhancing project update triggers.
	- Added a function to filter patterns based on a specified project path for more precise file handling.

- **Bug Fixes**
	- Improved error handling for pattern normalization during configuration loading.

- **Tests**
	- Added tests for the new path filtering function to ensure correct functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->