### PR TITLE
revert includeparentblocks flag

### DIFF
--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -526,7 +526,6 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 		parsingConfig.CreateHclProjectChilds,
 		ignoreParentTerragrunt,
 		parsingConfig.IgnoreDependencyBlocks,
-		parsingConfig.IgnoreIncludeBlocks,
 		cascadeDependencies,
 		parsingConfig.DefaultWorkflow,
 		parsingConfig.DefaultApplyRequirements,

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -143,7 +143,6 @@ type TerragruntParsingConfig struct {
 	IgnoreParentTerragrunt     *bool    `yaml:"ignoreParentTerragrunt,omitempty"`
 	CreateParentProject        bool     `yaml:"createParentProject"`
 	IgnoreDependencyBlocks     bool     `yaml:"ignoreDependencyBlocks"`
-	IgnoreIncludeBlocks        bool     `yaml:"ignoreIncludeBlocks"`
 	TriggerProjectsFromDirOnly bool     `yaml:"triggerProjectsFromDirOnly"`
 	Parallel                   *bool    `yaml:"parallel,omitempty"`
 	CreateWorkspace            bool     `yaml:"createWorkspace"`


### PR DESCRIPTION
reverting the ignoreIncludeBlocks terragrunt generation flag since it seems to have introduced some regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of Terragrunt configurations for improved parsing and validation.
  
- **Bug Fixes**
	- Improved error handling for missing configuration files, providing clearer feedback.
	- Streamlined dependency resolution process by enforcing stricter rules on configuration files.

- **Refactor**
	- Simplified function signatures by removing unnecessary parameters related to include blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->