### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -428,11 +428,9 @@ runs:
       name: cache-save
       if: ${{ always() && inputs.cache-dependencies == 'true' && steps.restore_cache.outputs.cache-hit != 'true' }}
       with:
-        path: |
-          ${{ steps.golang-env.outputs.build-cache-path }}
-          ${{ steps.golang-env.outputs.module-cache-path }}
-        key: digger-cli-cache-${{ hashFiles('.digger.go.sum') }}
-
+        path: ${{ github.workspace }}/cache
+        key: digger-cache-${{ hashFiles('**/cache') }}
+        
 branding:
   icon: globe
   color: purple


### PR DESCRIPTION

Seems that a terraform caching bug was introduced after renaming the cache-key in #1750 and its fixed in this PR to have a same cache name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Optimized caching mechanism for improved performance.
  
- **Chores**
	- Updated cache path and key format for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->