### PR TITLE
handle crashes in goroutine events

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -309,6 +309,12 @@ func handleInstallationDeletedEvent(installation *github.InstallationEvent, appI
 }
 
 func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullRequestEvent, ciBackendProvider ci_backends.CiBackendProvider, appId int64) error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Recovered from panic in handlePullRequestEvent handler: %v", r)
+		}
+	}()
+
 	installationId := *payload.Installation.ID
 	repoName := *payload.Repo.Name
 	repoOwner := *payload.Repo.Owner.Login
@@ -684,6 +690,12 @@ func getBatchType(jobs []orchestrator_scheduler.Job) orchestrator_scheduler.Digg
 }
 
 func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.IssueCommentEvent, ciBackendProvider ci_backends.CiBackendProvider, appId int64, postCommentHooks []IssueCommentHook) error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Recovered from panic in handleIssueCommentEvent handler: %v", r)
+		}
+	}()
+
 	installationId := *payload.Installation.ID
 	repoName := *payload.Repo.Name
 	repoOwner := *payload.Repo.Owner.Login


### PR DESCRIPTION
at the moment our webhook handler spawns a goroutine event. However if there is a panic in this goroutine it seems that it causes a crash of the gonic, this pr adds a recovery logic in both handling issue comment and pull request goroutines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for pull request and issue comment events to improve application stability.
	- Streamlined processing of pull request events, including checks for branch existence and impacted projects.
	- Optimized handling of issue comments to only process relevant comments.

- **Bug Fixes**
	- Implemented panic recovery mechanisms to prevent application crashes during event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->