### PR TITLE
Update setup-opentofu to fix issues with 1.6.x downloads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -275,7 +275,7 @@ runs:
       if: inputs.setup-terragrunt == 'true'
 
     - name: Setup OpenTofu
-      uses: opentofu/setup-opentofu@v1.0.3
+      uses: opentofu/setup-opentofu@v1.0.5
       with:
         tofu_version: ${{ inputs.opentofu-version }}
         tofu_wrapper: false


### PR DESCRIPTION
- Upgrades `opentofu/setup-opentofu` to `1.0.5`
   - Needed to fix [No matching version found when used version 1.6.0](https://github.com/opentofu/setup-opentofu/issues/43)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the OpenToFu setup action to version 1.0.5.
  
- **Improvements**
	- Clarified descriptions and requirements for existing input parameters.
  
- **Bug Fixes**
	- Retained validation logic for Google authentication inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->