### PR TITLE
restructure docs to have no columns

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -18,20 +18,6 @@
     "type": "github",
     "url": "https://github.com/diggerhq/digger"
   },
-  "tabs": [
-    {
-      "name": "Digger Community Edition",
-      "url": "ce"
-    },
-    {
-      "name": "Digger Team",
-      "url": "team"
-    },
-    {
-      "name": "Digger Enterprise",
-      "url": "ee"
-    }
-  ],
   "anchors": [
     {
       "name": "Slack",
@@ -66,7 +52,6 @@
       "group": "Digger Enterprise",
       "pages": [
         "ee/ee-setup",
-        "ee/dashboard",
         "ee/drift-detection",
         "ee/rbac",
         "ee/opa",
@@ -165,10 +150,6 @@
         "ce/troubleshooting/action-errors",
         "ce/troubleshooting/comments"
       ]
-    },
-    {
-      "group": "Getting Started",
-      "pages": ["team/getting-started/gha-aws"]
     }
   ],
   "footerSocials": {


### PR DESCRIPTION
simplify docs to avoid having tabs for CE/team/digger enterprise and focus on functionality based split as it used to be before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined navigation by removing outdated sections related to Digger Community Edition, Digger Team, and Digger Enterprise.
	- Simplified the "Getting Started" group for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->