### PR TITLE
always set right provider in ee

### DIFF
--- a/ee/cli/pkg/vcs/providers.go
+++ b/ee/cli/pkg/vcs/providers.go
@@ -37,6 +37,12 @@ func (v VCSProviderAdvanced) GetPrService(vcsSpec spec.VcsSpec) (ci.PullRequestS
 
 func (v VCSProviderAdvanced) GetOrgService(vcsSpec spec.VcsSpec) (ci.OrgService, error) {
 	switch vcsSpec.VcsType {
+	case "github":
+		token := os.Getenv("GITHUB_TOKEN")
+		if token == "" {
+			return nil, fmt.Errorf("failed to get github service: GITHUB_TOKEN not specified")
+		}
+		return github2.GithubServiceProviderAdvanced{}.NewService(token, vcsSpec.RepoName, vcsSpec.RepoOwner)
 	case "gitlab":
 		token := os.Getenv("GITLAB_TOKEN")
 		if token == "" {


### PR DESCRIPTION
always fetch teams list from DIGGER_GITHUB_HOSTNAME env variable if set 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced VCS provider support to handle GitHub organization services
	- Added GitHub-specific token retrieval and service initialization for organization-level operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->