### PR TITLE
fix send correct repo name in setstatus reporting

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -131,7 +131,6 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 		}
 
 		currentJob := jobs[0]
-		repoNameForBackendReporting := strings.ReplaceAll(currentJob.Namespace, "/", "-")
 		projectNameForBackendReporting := currentJob.ProjectName
 		// TODO: handle the apply result summary as well to report it to backend. Possibly reporting changed resources as well
 		// Some kind of generic terraform operation summary might need to be introduced
@@ -143,7 +142,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 		prNumber := *currentJob.PullRequestNumber
 
 		iacUtils := iac_utils.GetIacUtilsIacType(currentJob.IacType())
-		batchResult, err := backendApi.ReportProjectJobStatus(repoNameForBackendReporting, projectNameForBackendReporting, jobId, "succeeded", time.Now(), &summary, "", jobPrCommentUrl, terraformOutput, iacUtils)
+		batchResult, err := backendApi.ReportProjectJobStatus(currentJob.Namespace, projectNameForBackendReporting, jobId, "succeeded", time.Now(), &summary, "", jobPrCommentUrl, terraformOutput, iacUtils)
 		if err != nil {
 			log.Printf("error reporting Job status: %v.\n", err)
 			return false, false, fmt.Errorf("error while running command: %v", err)

--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -12,12 +12,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
 func reportError(spec spec.Spec, backendApi backend2.Api, message string, err error) {
 	log.Printf(message)
-	_, reportingError := backendApi.ReportProjectJobStatus(spec.VCS.RepoName, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
+	repoNameForBackendReporting := strings.ReplaceAll(spec.VCS.RepoName, "/", "-")
+	_, reportingError := backendApi.ReportProjectJobStatus(repoNameForBackendReporting, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
 	if reportingError != nil {
 		usage.ReportErrorAndExit(spec.VCS.RepoOwner, fmt.Sprintf("Failed to run commands. %v", err), 5)
 	}
@@ -137,8 +139,8 @@ func RunSpec(
 
 	jobs := []scheduler.Job{job}
 
-	fullRepoName := fmt.Sprintf("%v-%v", spec.VCS.RepoOwner, spec.VCS.RepoName)
-	_, err = backendApi.ReportProjectJobStatus(fullRepoName, spec.Job.ProjectName, spec.JobId, "started", time.Now(), nil, "", "", "", nil)
+	repoNameForBackendReporting := strings.ReplaceAll(spec.VCS.RepoName, "/", "-")
+	_, err = backendApi.ReportProjectJobStatus(repoNameForBackendReporting, spec.Job.ProjectName, spec.JobId, "started", time.Now(), nil, "", "", "", nil)
 	if err != nil {
 		message := fmt.Sprintf("Failed to report jobSpec status to backend. Exiting. %v", err)
 		reportError(spec, backendApi, message, err)
@@ -159,7 +161,7 @@ func RunSpec(
 	reportTerraformOutput := spec.Reporter.ReportTerraformOutput
 	allAppliesSuccess, _, err := digger.RunJobs(jobs, prService, orgService, lock, reporter, planStorage, policyChecker, commentUpdater, backendApi, spec.JobId, true, reportTerraformOutput, commentId, currentDir)
 	if !allAppliesSuccess || err != nil {
-		serializedBatch, reportingError := backendApi.ReportProjectJobStatus(spec.VCS.RepoName, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
+		serializedBatch, reportingError := backendApi.ReportProjectJobStatus(repoNameForBackendReporting, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
 		if reportingError != nil {
 			message := fmt.Sprintf("Failed run commands. %v", err)
 			reportError(spec, backendApi, message, err)

--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -12,14 +12,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 )
 
 func reportError(spec spec.Spec, backendApi backend2.Api, message string, err error) {
 	log.Printf(message)
-	repoNameForBackendReporting := strings.ReplaceAll(spec.VCS.RepoName, "/", "-")
-	_, reportingError := backendApi.ReportProjectJobStatus(repoNameForBackendReporting, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
+	_, reportingError := backendApi.ReportProjectJobStatus(spec.VCS.RepoName, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
 	if reportingError != nil {
 		usage.ReportErrorAndExit(spec.VCS.RepoOwner, fmt.Sprintf("Failed to run commands. %v", err), 5)
 	}
@@ -139,8 +137,7 @@ func RunSpec(
 
 	jobs := []scheduler.Job{job}
 
-	repoNameForBackendReporting := strings.ReplaceAll(spec.VCS.RepoName, "/", "-")
-	_, err = backendApi.ReportProjectJobStatus(repoNameForBackendReporting, spec.Job.ProjectName, spec.JobId, "started", time.Now(), nil, "", "", "", nil)
+	_, err = backendApi.ReportProjectJobStatus(spec.VCS.RepoName, spec.Job.ProjectName, spec.JobId, "started", time.Now(), nil, "", "", "", nil)
 	if err != nil {
 		message := fmt.Sprintf("Failed to report jobSpec status to backend. Exiting. %v", err)
 		reportError(spec, backendApi, message, err)
@@ -161,7 +158,7 @@ func RunSpec(
 	reportTerraformOutput := spec.Reporter.ReportTerraformOutput
 	allAppliesSuccess, _, err := digger.RunJobs(jobs, prService, orgService, lock, reporter, planStorage, policyChecker, commentUpdater, backendApi, spec.JobId, true, reportTerraformOutput, commentId, currentDir)
 	if !allAppliesSuccess || err != nil {
-		serializedBatch, reportingError := backendApi.ReportProjectJobStatus(repoNameForBackendReporting, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
+		serializedBatch, reportingError := backendApi.ReportProjectJobStatus(spec.VCS.RepoName, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", nil)
 		if reportingError != nil {
 			message := fmt.Sprintf("Failed run commands. %v", err)
 			reportError(spec, backendApi, message, err)

--- a/libs/backendapi/diggerapi.go
+++ b/libs/backendapi/diggerapi.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -129,7 +130,8 @@ func (d DiggerApi) ReportProjectRun(namespace string, projectName string, starte
 	return nil
 }
 
-func (d DiggerApi) ReportProjectJobStatus(repo string, projectName string, jobId string, status string, timestamp time.Time, summary *iac_utils.IacSummary, planJson string, PrCommentUrl string, terraformOutput string, iacUtils iac_utils.IacUtils) (*scheduler.SerializedBatch, error) {
+func (d DiggerApi) ReportProjectJobStatus(repoFullName string, projectName string, jobId string, status string, timestamp time.Time, summary *iac_utils.IacSummary, planJson string, PrCommentUrl string, terraformOutput string, iacUtils iac_utils.IacUtils) (*scheduler.SerializedBatch, error) {
+	repoNameForBackendReporting := strings.ReplaceAll(repoFullName, "/", "-")
 	u, err := url.Parse(d.DiggerHost)
 	if err != nil {
 		log.Fatalf("Not able to parse digger cloud url: %v", err)
@@ -152,7 +154,7 @@ func (d DiggerApi) ReportProjectJobStatus(repo string, projectName string, jobId
 		}
 	}
 
-	u.Path = filepath.Join(u.Path, "repos", repo, "projects", projectName, "jobs", jobId, "set-status")
+	u.Path = filepath.Join(u.Path, "repos", repoNameForBackendReporting, "projects", projectName, "jobs", jobId, "set-status")
 	request := map[string]interface{}{
 		"status":             status,
 		"timestamp":          timestamp,


### PR DESCRIPTION
- **set correct status when sending repo in set-status endpoint**
- **set common logic in func**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Code Improvements**
	- Updated repository name handling in backend reporting
	- Renamed method parameter for improved clarity
	- Simplified repository name construction for API requests

- **Technical Updates**
	- Modified how repository names are processed and reported
	- Streamlined backend API interaction logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->