### PR TITLE
support encrypted s3 bucket for plan uploads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,18 @@ inputs:
   upload-plan-destination-s3-bucket:
     description: Name of the destination bucket for AWS S3. Should be provided if destination == aws
     required: false
+  upload-plan-destination-s3-encryption-enabled:
+    description: If encryption is to be enabled for s3 bucket
+    required: false
+    default: "false"
+  upload-plan-destination-s3-encryption-type:
+    description: the type of encryption to use for the S3 bucket, either AES256 or KMS
+    required: false
+    default: "AES256"
+  upload-plan-destination-s3-encryption-kms-key-id:
+    description: for encryption of type KMS you need to specify the KMS key ID to use
+    required: false
+
   upload-plan-destination-gcp-bucket:
     description: Name of the destination bucket for a GCP bucket. Should be provided if destination == gcp
     required: false
@@ -367,6 +379,9 @@ runs:
       shell: bash
       env:
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        PLAN_UPLOAD_S3_ENCRYPTION_ENABLED: ${{ inputs.upload-plan-destination-s3-encryption-enabled }}
+        PLAN_UPLOAD_S3_ENCRYPTION_TYPE: ${{ inputs.upload-plan-destination-s3-encryption-type }}
+        PLAN_UPLOAD_S3_ENCRYPTION_KMS_ID: ${{ inputs.upload-plan-destination-s3-encryption-kms-key-id }}
         GOOGLE_STORAGE_LOCK_BUCKET: ${{ inputs.google-lock-bucket }}
         GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET: ${{ inputs.upload-plan-destination-gcp-bucket }}
         AWS_S3_BUCKET: ${{ inputs.upload-plan-destination-s3-bucket }}
@@ -404,6 +419,9 @@ runs:
       env:
         actionref: ${{ github.action_ref }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        PLAN_UPLOAD_S3_ENCRYPTION_ENABLED: ${{ inputs.upload-plan-destination-s3-encryption-enabled }}
+        PLAN_UPLOAD_S3_ENCRYPTION_TYPE: ${{ inputs.upload-plan-destination-s3-encryption-type }}
+        PLAN_UPLOAD_S3_ENCRYPTION_KMS_ID: ${{ inputs.upload-plan-destination-s3-encryption-kms-key-id }}
         GOOGLE_STORAGE_LOCK_BUCKET: ${{ inputs.google-lock-bucket }}
         GOOGLE_STORAGE_PLAN_ARTEFACT_BUCKET: ${{ inputs.upload-plan-destination-gcp-bucket }}
         AWS_S3_BUCKET: ${{ inputs.upload-plan-destination-s3-bucket }}

--- a/libs/storage/plan_storage.go
+++ b/libs/storage/plan_storage.go
@@ -235,18 +235,14 @@ func NewPlanStorage(ghToken string, ghRepoOwner string, ghRepositoryName string,
 			Context: ctx,
 		}
 	case uploadDestination == "aws":
-		ctx, client, err := GetAWSStorageClient()
-		if err != nil {
-			return nil, fmt.Errorf(fmt.Sprintf("Failed to create AWS storage client: %s", err))
-		}
 		bucketName := strings.ToLower(os.Getenv("AWS_S3_BUCKET"))
-		if bucketName == "" {
-			return nil, fmt.Errorf("AWS_S3_BUCKET is not defined")
-		}
-		planStorage = &PlanStorageAWS{
-			Context: ctx,
-			Client:  client,
-			Bucket:  bucketName,
+		encryptionEnabled := os.Getenv("PLAN_UPLOAD_S3_ENCRYPTION_ENABLED") == "true"
+		encryptionType := os.Getenv("PLAN_UPLOAD_S3_ENCRYPTION_TYPE")
+		encryptionKmsId := os.Getenv("PLAN_UPLOAD_S3_ENCRYPTION_KMS_ID")
+		var err error
+		planStorage, err = NewAWSPlanStorage(bucketName, encryptionEnabled, encryptionType, encryptionKmsId)
+		if err != nil {
+			return nil, fmt.Errorf("error while creating AWS plan storage: %v", err)
 		}
 	case uploadDestination == "gitlab":
 	//TODO implement me


### PR DESCRIPTION
Add support for S3 bucket encryption when performing plan uploads, addressing #1783

The additional arguments introduced are:

  upload-plan-destination-s3-encryption-enabled: true/false to specify if you want to enable s3 bucket encryption support
  upload-plan-destination-s3-encryption-type: AES256 is default, allowed values is AES256 or KMS
  upload-plan-destination-s3-encryption-kms-key-id: if encryption is KMS then you need to specify KMS ID or ARN of KMS bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional configuration settings to enable encryption for S3 uploads.
  - Now supports selection between standard server-side encryption and key-management encryption, with an option to provide a key when needed.
  - Improved handling and reporting of encryption setup during file storage, enhancing overall upload security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->