### PR TITLE
docs: Fix broken links in GitHub Actions + AWS docs

### DIFF
--- a/docs/ce/getting-started/github-actions-+-aws.mdx
+++ b/docs/ce/getting-started/github-actions-+-aws.mdx
@@ -13,11 +13,11 @@ In this tutorial, you will set up Digger to automate terraform pull requests usi
 <Note>
 Digger GitHub App does not need access to your cloud account, it just starts jobs in your CI. All sensitive data stays in your CI job.
 
-You can also [self-host Digger orchestrator](/self-host/deploy-docker) with a private GiHub app and issue your own token
+You can also [self-host Digger orchestrator](/ce/self-host/deploy-docker) with a private GiHub app and issue your own token
 
 </Note>
 
-# Create Action Secrets with AWS credentials (you can also [use OIDC](https://docs.digger.dev/cloud-providers/authenticating-with-oidc-on-aws))
+# Create Action Secrets with AWS credentials (you can also [use OIDC](/ce/cloud-providers/authenticating-with-oidc-on-aws))
 
 In GitHub repository settings, go to Secrets and Variables - Actions. Create the following secrets:
 


### PR DESCRIPTION
Hello😀 

While reading the Digger documentation ([GitHub Actions + AWS](https://docs.digger.dev/ce/getting-started/github-actions-+-aws)), I found two broken links and fixed them.

- `self-host Digger orchestrator` link
    - from: https://docs.digger.dev/self-host/deploy-docker
    - to: https://docs.digger.dev/ce/self-host/deploy-docker
- `use OIDC` link
    - from: https://docs.digger.dev/cloud-providers/authenticating-with-oidc-on-aws
    - to: https://docs.digger.dev/ce/cloud-providers/authenticating-with-oidc-on-aws

Thanks.