### PR TITLE
fix: Syntax of the TF_PLUGIN_CACHE_DIR env for cache-dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -278,7 +278,7 @@ runs:
       id: restore_cache
       name: restore_cache
       with:
-        path: $TF_PLUGIN_CACHE_DIR
+        path: ${{ env.TF_PLUGIN_CACHE_DIR }}
         key: digger-cache
         restore-keys: |
           digger-cache
@@ -458,7 +458,7 @@ runs:
       name: cache-save
       if: ${{ always() && inputs.cache-dependencies == 'true' && steps.restore_cache.outputs.cache-hit != 'true' }}
       with:
-        path: $TF_PLUGIN_CACHE_DIR
+        path: ${{ env.TF_PLUGIN_CACHE_DIR }}
         key: digger-cache-${{ hashFiles('**/cache') }}
         
 branding:


### PR DESCRIPTION
Hello😀

# Issue

I noticed that using `cache-dependencies: true` in `digger_workflow.yml` causes the cache to fail.
- https://docs.digger.dev/ce/reference/action-inputs

## [v0.6.83](https://github.com/diggerhq/digger/releases/tag/v0.6.83)

```
Run actions/cache/save@v4
Cache saved with key: digger-cache-ea298c145783ed443510838d08d9a3c3f8fe31e25dafd6026e629439b9c74c7c
```

## [v0.6.84](https://github.com/diggerhq/digger/releases/tag/v0.6.84)

The error occurs starting from version v0.6.84. It is related to the following pull request:
- https://github.com/diggerhq/digger/pull/1873

```
Run actions/cache/save@v4
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
Warning: Cache save failed.
```

👇️image 1
![image](https://github.com/user-attachments/assets/16b9c47f-d844-4549-a36b-f54ff843e039)

👇️image 2
![image](https://github.com/user-attachments/assets/6cc16bf5-0ada-41eb-81fd-a2e3dd5b036a)

# Cause

The `$xxx` syntax cannot be used in the `path` parameter of [actions/cache](https://github.com/actions/cache). This syntax is meant for shell execution within a `run:` command. Instead, GitHub Actions requires the `${{ env.VARIABLE_NAME }}` syntax.

In my sandbox repository, the `$TF_PLUGIN_CACHE_DIR` environment variable was not expanded properly.

👇️image 3
![image](https://github.com/user-attachments/assets/8f2252b5-3c89-4c8d-882b-cbd97182b719)

# Check

I confirmed that the fix works correctly in my sandbox repository.

👇️image 4
![image](https://github.com/user-attachments/assets/acad131e-204f-4c45-b043-6d88302d87be)

👇️image 5
![image](https://github.com/user-attachments/assets/a81cac53-6c94-4967-8049-07ecf82d389e)

Could you please review? Thanks a lot 👍

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the caching configuration to reference environment variables for directory paths during cache restore and save steps, ensuring consistency while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->