### PR TITLE
fix for long status names

### DIFF
--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -251,12 +251,18 @@ func (svc GithubService) SetStatus(prNumber int, status string, statusContext st
 	if err != nil {
 		log.Printf("error getting pull request : %v", err)
 		return fmt.Errorf("error getting pull request : %v", err)
-
 	}
+
+	// previously was setting description as "statusContext" but
+	// faced some issues with too long strings of > 140 chars:
+	// 422 Validation Failed [{Resource:Status Field:description Code:custom Message:description is too long (maximum is 140 characters)}]
+	// since description isn't shown in ui setting to blank for now
+	description := ""
+
 	_, _, err = svc.Client.Repositories.CreateStatus(context.Background(), svc.Owner, svc.RepoName, *pr.Head.SHA, &github.RepoStatus{
 		State:       &status,
 		Context:     &statusContext,
-		Description: &statusContext,
+		Description: &description,
 	})
 	return err
 }
@@ -490,9 +496,9 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				CommandRoleArn:     cmdRole,
-				StateRoleArn: 	 	stateRole,	
+				StateRoleArn:       stateRole,
 				StateEnvProvider:   StateEnvProvider,
-			    CognitoOidcConfig: 	project.AwsCognitoOidcConfig,
+				CognitoOidcConfig:  project.AwsCognitoOidcConfig,
 				SkipMergeCheck:     skipMerge,
 			})
 		} else if *payload.Action == "opened" || *payload.Action == "reopened" || *payload.Action == "synchronize" {
@@ -516,9 +522,9 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				CommandRoleArn:     cmdRole,
-				StateRoleArn: 	 	stateRole,	
+				StateRoleArn:       stateRole,
 				StateEnvProvider:   StateEnvProvider,
-				CognitoOidcConfig: 	project.AwsCognitoOidcConfig,
+				CognitoOidcConfig:  project.AwsCognitoOidcConfig,
 				SkipMergeCheck:     skipMerge,
 			})
 		} else if *payload.Action == "closed" {
@@ -542,9 +548,9 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				CommandRoleArn:     cmdRole,
-				StateRoleArn: 	 	stateRole,	
+				StateRoleArn:       stateRole,
 				StateEnvProvider:   StateEnvProvider,
-				CognitoOidcConfig: 	project.AwsCognitoOidcConfig,
+				CognitoOidcConfig:  project.AwsCognitoOidcConfig,
 				SkipMergeCheck:     skipMerge,
 			})
 		} else if *payload.Action == "converted_to_draft" {
@@ -575,9 +581,9 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				RequestedBy:        *payload.Sender.Login,
 				CommandEnvProvider: CommandEnvProvider,
 				CommandRoleArn:     cmdRole,
-				StateRoleArn: 	 	stateRole,	
+				StateRoleArn:       stateRole,
 				StateEnvProvider:   StateEnvProvider,
-				CognitoOidcConfig: 	project.AwsCognitoOidcConfig,
+				CognitoOidcConfig:  project.AwsCognitoOidcConfig,
 				SkipMergeCheck:     skipMerge,
 			})
 		}


### PR DESCRIPTION
when projects are being generated and the directory structure is too deep there is an error while setting status name as follows:

```
422 Validation Failed [{Resource:Status Field:description Code:custom Message:description is too long (maximum is 140 characters)}]
```

seems that there is an undocumented validation in github api to validate this description. Since the description isn't shown much in the ui (context is displayed first), we set the description to "" to avoid this validation error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Revised pull request status handling to prevent validation errors from overly long descriptions.
  
- **Style**
  - Implemented formatting improvements for enhanced readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->