### PR TITLE
patch error while posting comment too large

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -131,7 +131,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 		_, jobPrCommentUrl, err := reporter.Flush()
 		if err != nil {
 			log.Printf("error while sending job comments %v", err)
-			cmt, cmt_err := prService.PublishComment(*currentJob.PullRequestNumber, fmt.Sprintf(":yellow_circle: Warning: failed to post comment for project %v, recieved error: %v.\n\n you may review details in the job logs", currentJob.ProjectName, err))
+			cmt, cmt_err := prService.PublishComment(*currentJob.PullRequestNumber, fmt.Sprintf(":yellow_circle: Warning: failed to post report for project %v, recieved error: %v.\n\n you may review details in the job logs", currentJob.ProjectName, err))
 			if cmt_err != nil {
 				log.Printf("Error while posting error comment: %v", err)
 				return false, false, fmt.Errorf("failed to post reporter error comment, aborting. Error: %v", err)

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -126,13 +126,19 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 	}
 
 	if allAppliesSuccess == true && reportFinalStatusToBackend == true {
+		currentJob := jobs[0]
+
 		_, jobPrCommentUrl, err := reporter.Flush()
 		if err != nil {
 			log.Printf("error while sending job comments %v", err)
-			return false, false, fmt.Errorf("error while sending job comments %v", err)
+			cmt, cmt_err := prService.PublishComment(*currentJob.PullRequestNumber, fmt.Sprintf(":yellow_circle: Warning: failed to post comment for project %v, recieved error: %v.\n\n you may review details in the job logs", currentJob.ProjectName, err))
+			if cmt_err != nil {
+				log.Printf("Error while posting error comment: %v", err)
+				return false, false, fmt.Errorf("failed to post reporter error comment, aborting. Error: %v", err)
+			}
+			jobPrCommentUrl = cmt.Url
 		}
 
-		currentJob := jobs[0]
 		projectNameForBackendReporting := currentJob.ProjectName
 		// TODO: handle the apply result summary as well to report it to backend. Possibly reporting changed resources as well
 		// Some kind of generic terraform operation summary might need to be introduced

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -131,7 +131,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 		_, jobPrCommentUrl, err := reporter.Flush()
 		if err != nil {
 			log.Printf("error while sending job comments %v", err)
-			cmt, cmt_err := prService.PublishComment(*currentJob.PullRequestNumber, fmt.Sprintf(":yellow_circle: Warning: failed to post report for project %v, recieved error: %v.\n\n you may review details in the job logs", currentJob.ProjectName, err))
+			cmt, cmt_err := prService.PublishComment(*currentJob.PullRequestNumber, fmt.Sprintf(":yellow_circle: Warning: failed to post report for project %v, received error: %v.\n\n you may review details in the job logs", currentJob.ProjectName, err))
 			if cmt_err != nil {
 				log.Printf("Error while posting error comment: %v", err)
 				return false, false, fmt.Errorf("failed to post reporter error comment, aborting. Error: %v", err)


### PR DESCRIPTION
When a plan is too large it could be larger than the allowed size allowed by github (66535 chars). Current behaviour was that digger would make the job fail and not post a comment to the PR causing confusion to the user especially in the apply phase. In this PR we catch error posting report and post a warning comment as below then proceed so the job would succeed despite this publishing failure

<img width="820" alt="Screenshot 2025-03-24 at 18 49 57" src="https://github.com/user-attachments/assets/abd41a61-036f-4c3c-86bf-f7af55798d4f" />

-----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling during job processing by posting a warning message on the pull request when issues occur, providing clear feedback for users and encouraging review of job logs for further details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->