### PR TITLE
docs: describe a safer approach to using pinned version

### DIFF
--- a/docs/ce/howto/versioning.mdx
+++ b/docs/ce/howto/versioning.mdx
@@ -4,9 +4,7 @@ description: "For serious usecases always use a pinned version which is of the f
 ---
 
 <Warning>
-  For serious usecases always use a pinned version which is of the form @vX.Y.Z
-  since this will download a compiled binary. In addition to being faster to run, it
-  is also more secure than using a commit from a branch
+  For serious usecases always use a commit SHA reference for the digger action, of the format `@<40-character-commit-SHA>`. We recommend using a commit SHA from one of [our releases](https://github.com/diggerhq/digger/releases), since this will download a compiled binary. In addition to being faster to run, it is also more secure than using a commit from a branch or tag.
 </Warning>
 
 ## Use vLatest tag
@@ -15,18 +13,18 @@ The default and recommended way of versioning Digger is to use the vLatest tag, 
 
 ```
 - name: digger
-  uses: diggerhq/digger@vX.Y.Z
+  uses: diggerhq/digger@vLatest
   env:
     ...
 ```
 
 ## Use a pinned version
 
-To pin a specific release of Digger, you can use `@vX.Y.Z` tag in your workflow file:
+To pin a specific release of Digger, look up the release in [our releases](https://github.com/diggerhq/digger/releases). Copy the full commit SHA from the release and use it in your workflow file:
 
 ```
 - name: digger
-  uses: diggerhq/digger@vX.Y.Z
+  uses: diggerhq/digger@28a8ecd4ccb31f9196b1cbc9ceb14025059f97dc # v0.6.93
   env:
     ...
 ```

--- a/docs/ce/howto/versioning.mdx
+++ b/docs/ce/howto/versioning.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Specifying version"
-description: "For serious usecases always use a pinned version which is of the form @vX.Y.Z since this will download a compiled binary. In addition to being faster to run, it is also more secure than using a commit from a branch"
 ---
 
 <Warning>

--- a/docs/ce/howto/versioning.mdx
+++ b/docs/ce/howto/versioning.mdx
@@ -4,7 +4,7 @@ description: "For serious usecases always use a pinned version which is of the f
 ---
 
 <Warning>
-  For serious usecases always use a commit SHA reference for the digger action, of the format `@<40-character-commit-SHA>`. We recommend using a commit SHA from one of [our releases](https://github.com/diggerhq/digger/releases), since this will download a compiled binary. In addition to being faster to run, it is also more secure than using a commit from a branch or tag.
+  For serious usecases always use a commit SHA reference to the digger action, of the format `@<40-character-commit-SHA>`. We recommend using a commit SHA from one of [our releases](https://github.com/diggerhq/digger/releases), since this will download a compiled binary. In addition to being faster to run, it is also more secure than using a commit from a branch or tag.
 </Warning>
 
 ## Use vLatest tag


### PR DESCRIPTION
As exemplified by the recent [`tj-actions/changed-files` compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised#summary-of-the-incident), pinning GitHub Action references to a tag is inherently unsafe: if the referenced action is compromised, the attacker can update any tags, including old ones, to point to whatever they want.

For something as crucial as IaC management it'd probably be preferable to use _actually_ pinned versions over pinning to mutable tags. This PR updates the [_"Specifying version"_](https://docs.digger.dev/ce/howto/versioning#use-a-pinned-version) docs to describe that process instead. Might as well push people towards the safer workflow 🤷

Also includes a fix to the docs so the code example for `vLatest` actually uses `@vLatest`, and removes the `description` MDX header, since it contains text that's immediately replicated in a more-visible warning directly below it.

Feel free to make any changes you feel relevant to make the wording flow better! This PR is mostly to suggest that the pin-to-commit-SHA approach is described in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated versioning guidance for the Digger action.
	- Revised instructions now recommend using a commit SHA for pinning releases, enhancing security and performance.
	- Clarified the usage of the "vLatest" tag to denote the most recent release with pre-built binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->