### PR TITLE
fix bug in depends_on traversal

### DIFF
--- a/libs/ci/generic/events.go
+++ b/libs/ci/generic/events.go
@@ -87,7 +87,7 @@ func FindAllProjectsDependantOnImpactedProjects(impactedProjects []digger_config
 						}
 					}
 				}
-				return true
+				return false
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Our BFS traversal during depends on was returning "true" as a default value in the algorithm and when this happens the traversal of BFS stops, this caused some nodes to be never explored. Bug description:

In a digger.yml as follows:

```
projects:
  - name: core
    dir: ./core
  - name: platform
    dir: ./platform
    depends_on: ["core"]
    # include_patterns: ["./core/**"]
  - name: services
    dir: ./services
    depends_on: ["platform"]
    # include_patterns: ["core/**", "platform/**"]

workflows:
  default:
    plan:
      steps:
        - init
        - plan
        - run: echo "running the custom command!"
```

Which has the following dependency graph:

![image](https://github.com/user-attachments/assets/02f47685-9026-480e-a48d-c04da3f76ca5)

creating a PR which changes "platform" causes "no projects impacted". Turns out we are not properly traversing all nodes since we return true in the BFS function and terminate early