### PR TITLE
fix(auth): set organisation from job token when present

### DIFF
--- a/backend/middleware/basic.go
+++ b/backend/middleware/basic.go
@@ -72,6 +72,7 @@ func HttpBasicApiAuth() gin.HandlerFunc {
 				c.Set(ACCESS_LEVEL_KEY, jobToken.Type)
 				c.Set(JOB_TOKEN_KEY, jobToken.Value)
 				slog.Debug("Job token verified", "organisationId", jobToken.OrganisationID, "accessLevel", jobToken.Type)
+				c.Next()
 			}
 		} else if token == os.Getenv("BEARER_AUTH_TOKEN") {
 			slog.Debug("Using admin bearer token")

--- a/backend/middleware/basic.go
+++ b/backend/middleware/basic.go
@@ -68,9 +68,10 @@ func HttpBasicApiAuth() gin.HandlerFunc {
 				c.Abort()
 				return
 			} else {
-				setDefaultOrganisationId(c)
+				c.Set(ORGANISATION_ID_KEY, jobToken.OrganisationID)
 				c.Set(ACCESS_LEVEL_KEY, jobToken.Type)
 				c.Set(JOB_TOKEN_KEY, jobToken.Value)
+				slog.Debug("Job token verified", "organisationId", jobToken.OrganisationID, "accessLevel", jobToken.Type)
 			}
 		} else if token == os.Getenv("BEARER_AUTH_TOKEN") {
 			slog.Debug("Using admin bearer token")


### PR DESCRIPTION
I discovered this bug while trying to use the access policy feature on the community edition.

When setting the policy through the api, all goes fine, but there is a mismatch between logged in org id and passed org when the github action is trying to retrieve the policy via its job-token.
The problem comes from this condition: https://github.com/diggerhq/digger/blob/71aee6455a7db791f1452adacbf705f5d54d5a68/backend/controllers/policies.go#L107

This PR fixes it by making sure ORGANISATION_ID_KEY get set to the org id coming from the token, rather than the default org id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Modified the job token verification flow to assign organization data directly from the token.
	- Enhanced the logging to improve traceability during token verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->