### PR TITLE
Add more results to GitHub App repository listing

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -2414,7 +2414,8 @@ func (d DiggerController) GithubAppCallbackPage(c *gin.Context) {
 	// we get repos accessible to this installation
 	slog.Debug("Listing repositories for installation", "installationId", installationId64)
 
-	listRepos, _, err := client.Apps.ListRepos(context.Background(), nil)
+	opt := &github.ListOptions{Page: 1, PerPage: 100}
+	listRepos, _, err := client.Apps.ListRepos(context.Background(), opt)
 	if err != nil {
 		slog.Error("Failed to list existing repositories",
 			"installationId", installationId64,


### PR DESCRIPTION
## Problem

We noticed that when 30 repositories are registered with the GitHub App, adding a 31st repository causes one of the existing ones (often the latest) to be **removed**.

https://diggertalk.slack.com/archives/C01DVJRK6CX/p1745923260568589

## Root cause

By default, the GitHub API returns a limited number of results per request (usually 30). Since the call to `client.Apps.ListRepos` did not explicitly handle pagination, we were unintentionally working with a truncated list of repositories.

## Quick fix

We now explicitly provide pagination options using `github.ListOptions{Page: 1, PerPage: 100}` to ensure the API returns up to 100 repositories. 
This is a temporary fix, as the implementation should ideally retrieve all Git repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved repository listing to display up to 100 accessible repositories when connecting a GitHub App.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->