### PR TITLE
enable fips140 builds

### DIFF
--- a/.github/workflows/ee_backend_docker_release_fips.yml
+++ b/.github/workflows/ee_backend_docker_release_fips.yml
@@ -8,7 +8,7 @@ name: EE Backend Publish docker image
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}_backend_ee
+  IMAGE_NAME: ${{ github.repository }}_backend_ee_fips
 
 jobs:
   build-and-push-image:
@@ -45,5 +45,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
-
+          build-args: |
+            GODEBUG_VALUE=fips140=only
+            GOFIPS140_VALUE=v1.0.0            
             

--- a/.github/workflows/ee_cli_release_fips.yml
+++ b/.github/workflows/ee_cli_release_fips.yml
@@ -33,7 +33,6 @@ jobs:
           project_path: ./ee/cli/cmd/digger
           binary_name: digger
           pre_command: export CGO_ENABLED=0
-          ldflags: ${{ matrix.ldflags }}
           sha256sum: true
           md5sum: false
           asset_name: "digger-ee-cli-Linux-X64-fips"

--- a/.github/workflows/ee_cli_release_fips.yml
+++ b/.github/workflows/ee_cli_release_fips.yml
@@ -1,0 +1,44 @@
+---
+name: release ee cli
+
+"on":
+  release:
+    branches:
+      - 'go'
+    types:
+      - 'released'
+
+jobs:
+  binary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.0
+        id: go
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Publish linux-x64 exec to github
+        id: build-and-release-binary
+        uses: wangyoucao577/go-release-action@8fa1e8368c8465264d64e0198208e10f71474c87  # v1.50
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: linux
+          goarch: amd64
+          goversion: 1.24.0
+          project_path: ./ee/cli/cmd/digger
+          binary_name: digger
+          pre_command: export CGO_ENABLED=0
+          ldflags: ${{ matrix.ldflags }}
+          sha256sum: true
+          md5sum: false
+          asset_name: "digger-ee-cli-Linux-X64-fips"
+          compress_assets: "OFF"
+        env:
+          GODEBUG: fips140=only
+          GOFIPS140: v1.0.0
+

--- a/Dockerfile_backend_ee
+++ b/Dockerfile_backend_ee
@@ -20,8 +20,16 @@ RUN go build -ldflags="-X 'main.Version=${COMMIT_SHA}'" -o backend_exe ./ee/back
 
 # Multi-stage build will just copy the binary to an alpine image.
 FROM ubuntu:24.04 as runner
-ENV ATLAS_VERSION v0.31.0
+
 ARG COMMIT_SHA
+ARG GODEBUG_VALUE=off
+ARG GOFIPS140_VALUE=off
+
+# Set environment variables using the build arguments
+ENV GODEBUG=$GODEBUG_VALUE
+ENV GOFIPS140=$GOFIPS140_VALUE
+ENV ATLAS_VERSION v0.31.0
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y ca-certificates curl && apt-get install -y git && apt-get clean all

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: use ee cli?
     required: false
     default: 'false'
+  fips:
+    description: build with fips140 standard?
+    required: false
+    default: 'false'
   setup-aws:
     description: Setup AWS
     required: false
@@ -358,6 +362,10 @@ runs:
     - name: Copy Digger CLI go.sum for cache key
       run: |
         if [[ ${{ inputs.ee }} == "true" ]]; then
+          if [[ ${{ inputs.fips }} == "true" ]]; then
+            export GODEBUG=fips140=only
+            export GOFIPS140=v1.0.0
+          fi
           cp "$GITHUB_ACTION_PATH/ee/cli/go.sum" "$GITHUB_WORKSPACE/.digger.go.sum"
         else
           cp "$GITHUB_ACTION_PATH/cli/go.sum" "$GITHUB_WORKSPACE/.digger.go.sum"
@@ -467,7 +475,11 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.ee }} == "true" ]]; then
-          curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-ee-cli-${{ runner.os }}-${{ runner.arch }} -o digger
+          if [[ ${{ inputs.fips }} == "true" ]]; then
+            curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-ee-cli-${{ runner.os }}-${{ runner.arch }}-fips -o digger
+          else
+            curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-ee-cli-${{ runner.os }}-${{ runner.arch }} -o digger
+          fi
         else
           curl -sL https://github.com/diggerhq/digger/releases/download/${actionref}/digger-cli-${{ runner.os }}-${{ runner.arch }} -o digger
         fi

--- a/action.yml
+++ b/action.yml
@@ -362,10 +362,6 @@ runs:
     - name: Copy Digger CLI go.sum for cache key
       run: |
         if [[ ${{ inputs.ee }} == "true" ]]; then
-          if [[ ${{ inputs.fips }} == "true" ]]; then
-            export GODEBUG=fips140=only
-            export GOFIPS140=v1.0.0
-          fi
           cp "$GITHUB_ACTION_PATH/ee/cli/go.sum" "$GITHUB_WORKSPACE/.digger.go.sum"
         else
           cp "$GITHUB_ACTION_PATH/cli/go.sum" "$GITHUB_WORKSPACE/.digger.go.sum"
@@ -435,6 +431,10 @@ runs:
           else
             cd $GITHUB_ACTION_PATH/cli
           fi
+          if [[ ${{ inputs.fips }} == "true" ]]; then
+            export GODEBUG=fips140=only
+            export GOFIPS140=v1.0.0
+          fi        
           go build -o digger ./cmd/digger
           chmod +x digger
           PATH=$PATH:$(pwd)

--- a/cli/cmd/digger/default.go
+++ b/cli/cmd/digger/default.go
@@ -19,6 +19,7 @@ import (
 )
 
 func initLogger() {
+
 	logLevel := os.Getenv("DIGGER_LOG_LEVEL")
 	var level slog.Leveler
 	if logLevel == "DEBUG" {

--- a/docs/ee/fips-140.mdx
+++ b/docs/ee/fips-140.mdx
@@ -1,0 +1,19 @@
+---
+title: "FIPS 140 build"
+---
+
+You can use digger binary with FIPS140 standard. FIPS 140 (Federal Information Processing Standard Publication 140) is a U.S. government standard that specifies security requirements for cryptographic modules protecting sensitive information.
+
+as of version v0.6.101 digger backend and cli are both compiled seperately with FIPS140 enabled. In order to enable it for github follow these steps:
+
+- For the backend you need to ensure you use the right docker image: `_backend_ee_fips` during the pull
+- For the cli you need to add the following argument in addition to `ee: true` :
+
+```
+    - diggerhq/digger@vLatest
+      with:
+         ee: 'true'
+         fips: 'true'
+```
+
+If you are using gitlab or other VCS then just ensure that you are downloading the fips enabled binary which is suffixed with '_fips'

--- a/ee/backend/main.go
+++ b/ee/backend/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/fips140"
 	"embed"
 	"fmt"
 	"github.com/diggerhq/digger/backend/bootstrap"
@@ -31,6 +32,8 @@ func main() {
 		log.Printf("error checking license %v", err)
 		os.Exit(1)
 	}
+
+	log.Printf("fips140 enabled: %v", fips140.Enabled())
 	githubProvider := github.DiggerGithubEEClientProvider{}
 	diggerController := ce_controllers.DiggerController{
 		CiBackendProvider:                  ci_backends2.EEBackendProvider{},

--- a/ee/cli/cmd/digger/default.go
+++ b/ee/cli/cmd/digger/default.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/fips140"
 	"encoding/json"
 	"fmt"
 	"github.com/diggerhq/digger/cli/pkg/digger"
@@ -24,8 +25,8 @@ import (
 var defaultCmd = &cobra.Command{
 	Use: "default",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		specStr := os.Getenv("DIGGER_RUN_SPEC")
+		log.Printf("Fips140 enabled in build: %v", fips140.Enabled())
 		if specStr != "" {
 			var spec lib_spec.Spec
 			err := json.Unmarshal([]byte(specStr), &spec)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated workflows to build and publish FIPS-compliant Docker images and CLI binaries for the enterprise edition on release events.
  - The CLI and backend now log whether FIPS 140 mode is enabled at runtime.
  - Added support in the release action to conditionally build and download FIPS-compliant enterprise CLI binaries.
  - Added documentation detailing how to enable and use FIPS 140 compliant binaries and workflows.

- **Chores**
  - Updated Docker image build process to support FIPS mode via new build arguments and environment variables.
  - Minor formatting and structural improvements to workflow and code files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->