### PR TITLE
add page on spec signatures

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -121,7 +121,8 @@
         "ce/reference/digger.yml",
         "ce/reference/action-inputs",
         "ce/reference/api",
-        "ce/reference/terraform.lock"
+        "ce/reference/terraform.lock",
+        "ce/securing-digger/spec-signing"
       ]
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new documentation page, "ce/securing-digger/spec-signing," to the navigation under the "Reference" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->