### PR TITLE
fix panic when digger is misconfigured

### DIFF
--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -319,6 +319,44 @@ workflows:
 	assert.Equal(t, Step{Action: "plan", ExtraArgs: []string{"-var-file=vars/dev.tfvars"}, Shell: ""}, dg.Workflows["default"].Plan.Steps[2], "parsed struct does not match expected struct")
 }
 
+func TestProjectWithMisconfiguredRunStepThrowsError(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+  - name: "dev"
+    dir: "dev"
+  - name: "staging"
+    dir: "staging"
+  - name: "prod"
+    dir: "prod"
+workflows:
+  default:
+    workflow_configuration:
+      on_pull_request_pushed: ["digger plan"]
+      on_pull_request_closed: ["digger unlock"]
+      on_commit_to_default: ["digger unlock"]
+    plan:
+      steps:
+      - init:
+          extra_args: ["-backend-config=tf_backend.tfbackend" ]
+      - run:
+          command: terragrunt plan -input=false -out=$PLANFILE
+    apply:
+      steps:
+      - init:
+          extra_args: ["-backend-config=tf_backend.tfbackend" ]
+      - apply:
+`
+	deleteFile := createFile(path.Join(tempDir, "digger.yaml"), diggerCfg)
+	defer deleteFile()
+
+	_, _, _, err := LoadDiggerConfig(tempDir, true, nil)
+	assert.Error(t, err, "expected error to be raised")
+	assert.Contains(t, err.Error(), "step.run must be a string")
+}
+
 func TestDiggerGenerateProjects(t *testing.T) {
 	tempDir, teardown := setUp()
 	defer teardown()

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -2,6 +2,7 @@ package digger_config
 
 import (
 	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -260,7 +261,11 @@ func (s *StepYaml) UnmarshalYAML(value *yaml.Node) error {
 
 	if _, ok := stepMap["run"]; ok {
 		s.Action = "run"
-		s.Value = stepMap["run"].(string)
+		v, ok := stepMap["run"].(string)
+		if !ok {
+			return fmt.Errorf("step.run must be a string, but got %T", stepMap["run"])
+		}
+		s.Value = v
 		if _, ok := stepMap["shell"]; ok {
 			s.Shell = stepMap["shell"].(string)
 		}

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -267,7 +267,11 @@ func (s *StepYaml) UnmarshalYAML(value *yaml.Node) error {
 		}
 		s.Value = v
 		if _, ok := stepMap["shell"]; ok {
-			s.Shell = stepMap["shell"].(string)
+			shell, ok := stepMap["shell"].(string)
+			if !ok {
+				return fmt.Errorf("step.run.shell must be a string, but got %T", stepMap["shell"])
+			}
+			s.Shell = shell
 		}
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for invalid types in the "run" and "shell" fields when processing YAML files, preventing potential crashes and providing clearer error messages.
- **Tests**
  - Added tests to ensure errors are raised when the "run" step or its "shell" attribute are misconfigured with incorrect types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->