### PR TITLE
updated atlas versions

### DIFF
--- a/Dockerfile_drift
+++ b/Dockerfile_drift
@@ -20,7 +20,7 @@ RUN go build -ldflags="-X 'main.Version=${COMMIT_SHA}'" -o drift_exe ./ee/drift/
 
 # Multi-stage build will just copy the binary to an alpine image.
 FROM ubuntu:24.04 as runner
-ENV ATLAS_VERSION v0.28.0
+ENV ATLAS_VERSION v0.31.0
 ARG COMMIT_SHA
 WORKDIR /app
 

--- a/Dockerfile_tasks
+++ b/Dockerfile_tasks
@@ -20,7 +20,7 @@ RUN go build -ldflags="-X 'main.Version=${COMMIT_SHA}'" -o tasks_exe ./backend/t
 
 # Multi-stage build will just copy the binary to an alpine image.
 FROM ubuntu:24.04 as runner
-ENV ATLAS_VERSION v0.28.0
+ENV ATLAS_VERSION v0.31.0
 ARG COMMIT_SHA
 WORKDIR /app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the underlying Atlas version used in both the drift and tasks services to v0.31.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->