### PR TITLE
fix glob pattern for impacted projects

### DIFF
--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -866,11 +866,7 @@ func (c *DiggerConfig) GetModifiedProjects(changedFiles []string) ([]Project, ma
 			includePatterns := project.IncludePatterns
 			excludePatterns := project.ExcludePatterns
 
-			if !project.Terragrunt {
-				includePatterns = append(includePatterns, filepath.Join(project.Dir, "**", "*"))
-			} else {
-				includePatterns = append(includePatterns, filepath.Join(project.Dir, "*"))
-			}
+			includePatterns = append(includePatterns, filepath.Join(project.Dir, "*"))
 
 			// all our patterns are the globale dir pattern + the include patterns specified by user
 			if MatchIncludeExcludePatternsToFile(changedFile, includePatterns, excludePatterns) {

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -1267,6 +1267,23 @@ projects:
 	assert.Equal(t, false, dg.AllowDraftPRs)
 }
 
+func TestGetModifiedProjectsReturnsCorrectSourceMappingWithDotFile(t *testing.T) {
+	changedFiles := []string{"prod/main.tf", "dev/test/main.tf"}
+	projects := []Project{
+		Project{
+			Name: "dev",
+			Dir:  ".",
+		},
+	}
+	c := DiggerConfig{
+		Projects: projects,
+	}
+	//expectedImpactingLocations := map[string]ProjectToSourceMapping{}
+
+	impactedProjects, _ := c.GetModifiedProjects(changedFiles)
+	assert.Equal(t, 0, len(impactedProjects))
+}
+
 func TestGetModifiedProjectsReturnsCorrectSourceMapping(t *testing.T) {
 	changedFiles := []string{"modules/bucket/main.tf", "dev/main.tf"}
 	projects := []Project{


### PR DESCRIPTION
fix for https://github.com/diggerhq/digger/issues/1988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated how modified projects are detected to improve accuracy when project directories are set to the current directory (".").
- **Tests**
  - Added a new test to ensure projects with the current directory as their path are correctly handled when identifying impacted projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->