### PR TITLE
fix dynamodb lock table creation

### DIFF
--- a/libs/locking/aws/dynamo_locking_test.go
+++ b/libs/locking/aws/dynamo_locking_test.go
@@ -20,10 +20,10 @@ type mockDynamoDbClient struct {
 
 func (m *mockDynamoDbClient) DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
 	if m.table == nil || m.table[aws.ToString(params.TableName)] == nil {
-		return nil, &types.TableNotFoundException{}
+		return nil, &types.ResourceNotFoundException{}
 	}
 	if m.table[aws.ToString(params.TableName)] != nil {
-		return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{TableName: params.TableName}}, nil
+		return &dynamodb.DescribeTableOutput{Table: &types.TableDescription{TableName: params.TableName, TableStatus: "ACTIVE"}}, nil
 	}
 	return nil, nil
 }
@@ -59,7 +59,6 @@ func TestDynamoDbLock_Lock(t *testing.T) {
 	dynamodbLock := DynamoDbLock{
 		DynamoDb: &client,
 	}
-	dynamodbLock.DynamoDb.CreateTable(context.Background(), &dynamodb.CreateTableInput{TableName: aws.String(TABLE_NAME)})
 
 	// Set up the input parameters for the Lock method
 	transactionId := 123
@@ -79,7 +78,6 @@ func TestDynamoDbLock_GetLock(t *testing.T) {
 	dynamodbLock := DynamoDbLock{
 		DynamoDb: &client,
 	}
-	dynamodbLock.DynamoDb.CreateTable(context.Background(), &dynamodb.CreateTableInput{TableName: aws.String(TABLE_NAME)})
 
 	id, err := dynamodbLock.GetLock("example-resource")
 	if err != nil {


### PR DESCRIPTION
When trying to set up backendless Digger in a new AWS account I was blocked by errors in locking:

> level=ERROR msg="Error describing DynamoDB table" tableName=DiggerDynamoDBLockTable error="operation error DynamoDB: DescribeTable, https response error StatusCode: 400, RequestID: D3AC..., ResourceNotFoundException: Requested resource not found: Table: DiggerDynamoDBLockTable not found"
>
> level=ERROR msg="Failed to get DynamoDB item for lock" lockId=... error="operation error DynamoDB: GetItem, https response error StatusCode: 400, RequestID: 5BQQ..., ResourceNotFoundException: Requested resource not found"

Per the AWS docs[^1], `DescribeTable` throws `ResourceNotFoundException`, not `TableNotFoundException`. Checking for the wrong type caused `createTableIfNotExists` to always fail, though nothing was checking for the error it returned.

All callers now bubble up the error returned by `createTableIfNotExists` and there's no longer a hidden `os.Exit(1)` error handler.

With these changes I was able to run Digger successfully. 

[^1]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html