### PR TITLE
support depends_on in terragrunt generation

### DIFF
--- a/backend/middleware/noop.go
+++ b/backend/middleware/noop.go
@@ -3,6 +3,9 @@ package middleware
 import (
 	"github.com/diggerhq/digger/backend/models"
 	"github.com/gin-gonic/gin"
+	"log/slog"
+	"net/http"
+	"strings"
 )
 
 func NoopWebAuth() gin.HandlerFunc {
@@ -15,6 +18,25 @@ func NoopWebAuth() gin.HandlerFunc {
 
 func NoopApiAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		authHeader := c.Request.Header.Get("Authorization")
+
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+
+		if strings.HasPrefix(token, "cli:") {
+			slog.Debug("Processing CLI token")
+			if jobToken, err := CheckJobToken(c, token); err != nil {
+				slog.Warn("Invalid job token", "error", err)
+				c.String(http.StatusForbidden, err.Error())
+				c.Abort()
+				return
+			} else {
+				c.Set(ORGANISATION_ID_KEY, jobToken.OrganisationID)
+				c.Set(ACCESS_LEVEL_KEY, jobToken.Type)
+				c.Set(JOB_TOKEN_KEY, jobToken.Value)
+				slog.Debug("Job token verified", "organisationId", jobToken.OrganisationID, "accessLevel", jobToken.Type)
+				c.Next()
+			}
+		}
 		setDefaultOrganisationId(c)
 		c.Set(ACCESS_LEVEL_KEY, models.AdminPolicyType)
 		c.Next()

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -742,7 +742,7 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 		"defaultWorkflow", parsingConfig.DefaultWorkflow,
 		"filterPath", parsingConfig.FilterPath)
 
-	atlantisConfig, _, err := atlantis.Parse(
+	atlantisConfig, projectDependsOnMap, err := atlantis.Parse(
 		root,
 		parsingConfig.ProjectHclFiles,
 		projectExternalChilds,
@@ -802,7 +802,7 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 			"projectDir", projectDir,
 			"workspace", atlantisProject.Workspace)
 
-		configYaml.Projects = append(configYaml.Projects, &ProjectYaml{
+		diggerProject := &ProjectYaml{
 			Name:                 atlantisProject.Name,
 			Dir:                  projectDir,
 			Workspace:            atlantisProject.Workspace,
@@ -813,7 +813,13 @@ func hydrateDiggerConfigYamlWithTerragrunt(configYaml *DiggerConfigYaml, parsing
 			Generated:            true,
 			AwsRoleToAssume:      parsingConfig.AwsRoleToAssume,
 			AwsCognitoOidcConfig: parsingConfig.AwsCognitoOidcConfig,
-		})
+		}
+
+		if parsingConfig.DependsOnOrdering != nil && *parsingConfig.DependsOnOrdering {
+			diggerProject.DependencyProjects = projectDependsOnMap[atlantisProject.Name]
+		}
+
+		configYaml.Projects = append(configYaml.Projects, diggerProject)
 	}
 
 	slog.Info("completed hydrating config with terragrunt projects",

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -174,6 +174,7 @@ type TerragruntParsingConfig struct {
 	WorkflowFile                   string                      `yaml:"workflow_file"`
 	AwsRoleToAssume                *AssumeRoleForProjectConfig `yaml:"aws_role_to_assume,omitempty"`
 	AwsCognitoOidcConfig           *AwsCognitoOidcConfig       `yaml:"aws_cognito_oidc,omitempty"`
+	DependsOnOrdering              *bool                       `yaml:"dependsOnOrdering,omitempty"`
 }
 
 func (p *ProjectYaml) UnmarshalYAML(unmarshal func(interface{}) error) error {


### PR DESCRIPTION
support for depends_on during terragrunt genration and also fixed bug with NOOP auth not picking the right org when cli token is sent 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for capturing and assigning project dependency ordering information when parsing Terragrunt configurations.
  - Introduced an optional setting to enable or disable dependency ordering in configuration files.

- **Bug Fixes**
  - Improved API authentication handling for CLI tokens, providing clearer error responses and logging for invalid tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->