### PR TITLE
feat/disable apply comment

### DIFF
--- a/docs/ce/howto/apply-on-merge.mdx
+++ b/docs/ce/howto/apply-on-merge.mdx
@@ -7,6 +7,8 @@ By default, Digger does not run apply on merge. This is a safer way to resolve t
 You can configure Digger to run apply on merge with the following entries in `digger.yml`
 
 ```
+disable_digger_apply_comment: true
+
 projects:
  ...
 workflows:
@@ -17,9 +19,5 @@ workflows:
          on_commit_to_default: [digger apply]
 ```
 
-<Note>
-   **Limitation**
 
-   right now there is no way to prevent running `apply` via comment, even if apply on merge is configured. Tracked in [#272](https://github.com/diggerhq/digger/issues/272)
-</Note>
 The tradeoff then of course shifts to handling flaky applies. You'll need to raise a new PR for every change. But that might be preferable in some cases, for example for highly sensitive parts of production environments that are rarely changed. (eg the "foundation infra" layer with VPC definitions etc).

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -15,6 +15,7 @@ type DiggerConfig struct {
 	CommentRenderMode          string
 	DependencyConfiguration    DependencyConfiguration
 	DeletePriorComments        bool
+	DisableDiggerApplyComment  bool
 	RespectLayers              bool
 	PrLocks                    bool
 	Projects                   []Project

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -205,6 +205,12 @@ func ConvertDiggerYamlToConfig(diggerYaml *DiggerConfigYaml) (*DiggerConfig, gra
 		}
 	}
 
+	if diggerYaml.DisableDiggerApplyComment != nil {
+		diggerConfig.DisableDiggerApplyComment = *diggerYaml.DisableDiggerApplyComment
+	} else {
+		diggerConfig.DisableDiggerApplyComment = false
+	}
+
 	if diggerYaml.ReportTerraformOutputs != nil {
 		diggerConfig.ReportTerraformOutputs = *diggerYaml.ReportTerraformOutputs
 	} else {

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -13,6 +13,7 @@ type DiggerConfigYaml struct {
 	AllowDraftPRs              *bool                        `yaml:"allow_draft_prs"`
 	DependencyConfiguration    *DependencyConfigurationYaml `yaml:"dependency_configuration"`
 	DeletePriorComments        *bool                        `yaml:"delete_prior_comments"`
+	DisableDiggerApplyComment  *bool                        `yaml:"disable_digger_apply_comment"`
 	PrLocks                    *bool                        `yaml:"pr_locks"`
 	Projects                   []*ProjectYaml               `yaml:"projects"`
 	AutoMerge                  *bool                        `yaml:"auto_merge"`


### PR DESCRIPTION
- **support disabling of digger apply comment**

User can now add a config to digger yaml `disable_digger_apply_comment: true` which makes digger ignore digger apply comments on any PR, useful in scenarios where users are trying to set digger up for "apply on merge"

closes #272
