### PR TITLE
fix environment interpolation during comment ops

### DIFF
--- a/backend/controllers/github_comment.go
+++ b/backend/controllers/github_comment.go
@@ -255,7 +255,7 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		"allImpactedProjectsCount", len(allImpactedProjects),
 	)
 
-	jobs, coverAllImpactedProjects, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjectsForComment, allImpactedProjects, config.Workflows, prBranchName, defaultBranch)
+	jobs, coverAllImpactedProjects, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjectsForComment, allImpactedProjects, config.Workflows, prBranchName, defaultBranch, false)
 	if err != nil {
 		slog.Error("Error converting event to jobs",
 			"issueNumber", issueNumber,

--- a/cli/cmd/digger/main_test.go
+++ b/cli/cmd/digger/main_test.go
@@ -930,7 +930,7 @@ func TestGitHubNewCommentContext(t *testing.T) {
 	policyChecker := policy.MockPolicyChecker{}
 	backendApi := backendapi.MockBackendApi{}
 
-	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, map[string]configuration.Workflow{}, "prbranch", "")
+	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, map[string]configuration.Workflow{}, "prbranch", "", false)
 	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "")
 	assert.NoError(t, err)
 	if err != nil {
@@ -1022,7 +1022,7 @@ func TestGitHubTestPRCommandCaseInsensitivity(t *testing.T) {
 	impactedProjects[0] = project
 	workflows := make(map[string]configuration.Workflow, 1)
 	workflows["default"] = configuration.Workflow{}
-	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "digger plan", impactedProjects, impactedProjects, workflows, "prbranch", "main")
+	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "digger plan", impactedProjects, impactedProjects, workflows, "prbranch", "main", false)
 
 	assert.Equal(t, 1, len(jobs))
 	assert.Equal(t, "digger plan", jobs[0].Commands[0])

--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -316,7 +316,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			} else {
 				impactedProjectsForEvent = impactedProjects
 			}
-			jobs, coversAllImpactedProjects, err = generic.ConvertIssueCommentEventToJobs(repoFullName, requestedBy, prNumber, commentBody, impactedProjectsForEvent, impactedProjects, diggerConfig.Workflows, prBranchName, defaultBranch)
+			jobs, coversAllImpactedProjects, err = generic.ConvertIssueCommentEventToJobs(repoFullName, requestedBy, prNumber, commentBody, impactedProjectsForEvent, impactedProjects, diggerConfig.Workflows, prBranchName, defaultBranch, true)
 		} else {
 			usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Unsupported GitHub event type. %s", err), 6)
 		}

--- a/cli/pkg/integration/integration_test.go
+++ b/cli/pkg/integration/integration_test.go
@@ -453,7 +453,7 @@ func TestHappyPath(t *testing.T) {
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
 
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -476,7 +476,7 @@ func TestHappyPath(t *testing.T) {
 
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -590,7 +590,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	// 'digger plan' comment should trigger terraform execution
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -603,7 +603,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	// 'digger apply' comment should trigger terraform execution and unlock the project
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -626,7 +626,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -809,7 +809,7 @@ workflows:
 	// 'digger plan' comment should trigger terraform execution
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -822,7 +822,7 @@ workflows:
 	// 'digger apply' comment should trigger terraform execution and unlock the project
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
@@ -844,7 +844,7 @@ workflows:
 
 	impactedProjects, requestedProject, prNumber, err = dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 	assert.NoError(t, err)
-	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main")
+	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)

--- a/ee/backend/controllers/bitbucket.go
+++ b/ee/backend/controllers/bitbucket.go
@@ -261,7 +261,7 @@ func handleIssueCommentEventBB(bitbucketProvider utils.BitbucketProvider, payloa
 		return nil
 	}
 
-	jobs, _, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjectsForComment, allImpactedProjects, config.Workflows, prBranchName, defaultBranch)
+	jobs, _, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjectsForComment, allImpactedProjects, config.Workflows, prBranchName, defaultBranch, false)
 	if err != nil {
 		log.Printf("Error converting event to jobs: %v", err)
 		utils.InitCommentReporter(bbService, issueNumber, fmt.Sprintf(":x: Error converting event to jobs: %v", err))

--- a/ee/backend/controllers/gitlab.go
+++ b/ee/backend/controllers/gitlab.go
@@ -446,7 +446,7 @@ func handleIssueCommentEvent(gitlabProvider utils.GitlabProvider, payload *gitla
 		return nil
 	}
 
-	jobs, coverAllImpactedProjects, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjectsForComment, allImpactedProjects, config.Workflows, prBranchName, defaultBranch)
+	jobs, coverAllImpactedProjects, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjectsForComment, allImpactedProjects, config.Workflows, prBranchName, defaultBranch, false)
 	if err != nil {
 		log.Printf("Error converting event to jobs: %v", err)
 		utils.InitCommentReporter(glService, issueNumber, fmt.Sprintf(":x: Error converting event to jobs: %v", err))

--- a/ee/backend/hooks/github.go
+++ b/ee/backend/hooks/github.go
@@ -121,7 +121,7 @@ var DriftReconcilliationHook ce_controllers.IssueCommentHook = func(gh utils.Git
 	}
 
 	impactedProjects := config.GetProjects(projectName)
-	jobs, coverAllImpactedProjects, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjects, nil, config.Workflows, defaultBranch, defaultBranch)
+	jobs, coverAllImpactedProjects, err := generic.ConvertIssueCommentEventToJobs(repoFullName, actor, issueNumber, commentBody, impactedProjects, nil, config.Workflows, defaultBranch, defaultBranch, false)
 	if err != nil {
 		log.Printf("Error converting event to jobs: %v", err)
 		utils.InitCommentReporter(ghService, issueNumber, fmt.Sprintf(":x: Error converting event to jobs: %v", err))

--- a/ee/cli/cmd/digger/main_test.go
+++ b/ee/cli/cmd/digger/main_test.go
@@ -935,7 +935,7 @@ func TestGitHubNewCommentContext(t *testing.T) {
 	policyChecker := policy.MockPolicyChecker{}
 	backendApi := backendapi.MockBackendApi{}
 
-	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "digger plan", impactedProjects, impactedProjects, map[string]configuration.Workflow{}, "prbranch", "main")
+	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "digger plan", impactedProjects, impactedProjects, map[string]configuration.Workflow{}, "prbranch", "main", false)
 	assert.NoError(t, err)
 	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "")
 	assert.NoError(t, err)
@@ -1031,7 +1031,7 @@ func TestGitHubTestPRCommandCaseInsensitivity(t *testing.T) {
 	impactedProjects[0] = project
 	workflows := make(map[string]configuration.Workflow, 1)
 	workflows["default"] = configuration.Workflow{}
-	jobs, _, err := generic.ConvertIssueCommentEventToJobs(*repo.FullName, *user.Login, *issue.Number, "digger plan", impactedProjects, impactedProjects, workflows, "prbranch", "main")
+	jobs, _, err := generic.ConvertIssueCommentEventToJobs(*repo.FullName, *user.Login, *issue.Number, "digger plan", impactedProjects, impactedProjects, workflows, "prbranch", "main", false)
 
 	assert.Equal(t, 1, len(jobs))
 	assert.Equal(t, "digger plan", jobs[0].Commands[0])

--- a/libs/ci/generic/events.go
+++ b/libs/ci/generic/events.go
@@ -99,7 +99,7 @@ func FindAllProjectsDependantOnImpactedProjects(impactedProjects []digger_config
 	return impactedProjectsWithDependantProjects, nil
 }
 
-func ConvertIssueCommentEventToJobs(repoFullName string, requestedBy string, prNumber int, commentBody string, impactedProjectsForComment []digger_config.Project, allImpactedProjects []digger_config.Project, workflows map[string]digger_config.Workflow, prBranchName string, defaultBranch string) ([]scheduler.Job, bool, error) {
+func ConvertIssueCommentEventToJobs(repoFullName string, requestedBy string, prNumber int, commentBody string, impactedProjectsForComment []digger_config.Project, allImpactedProjects []digger_config.Project, workflows map[string]digger_config.Workflow, prBranchName string, defaultBranch string, performEnvVarInterpolation bool) ([]scheduler.Job, bool, error) {
 	jobs := make([]scheduler.Job, 0)
 	prBranch := prBranchName
 
@@ -125,7 +125,7 @@ func ConvertIssueCommentEventToJobs(repoFullName string, requestedBy string, prN
 		return nil, false, fmt.Errorf("command is not supported: %v", diggerCommand)
 	}
 
-	jobs, err := CreateJobsForProjects(runForProjects, commandToRun, "issue_comment", repoFullName, requestedBy, workflows, &prNumber, nil, defaultBranch, prBranch, true)
+	jobs, err := CreateJobsForProjects(runForProjects, commandToRun, "issue_comment", repoFullName, requestedBy, workflows, &prNumber, nil, defaultBranch, prBranch, performEnvVarInterpolation)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
the env variables that are specified in digger.yml workflow were being interpolated on the backend during a comment event

example workflow:

```
workflows:
  default:
    env_vars:
      state:
        - name: TF_TOKEN_mo__opentaco__test_ngrok_app
          value_from: TF_TOKEN_MO_OPENTACO_TEST_NGROK_APP
```

It works correctly when there is a commit pushed to the PR. The value is passed down in the spec correctly:

```
{"DEFAULT_BRANCH":"main","PROJECT_DIR":"dev","PROJECT_NAME":"dev","PR_BRANCH":"motatoes-patch-5"},"stateEnvVars":{"TF_TOKEN_mo__opentaco__test_ngrok_app":"$DIGGER_TF_TOKEN_MO_OPENTACO_TEST_NGROK_APP"},"commandEnvVars":{},"aws_role_region":"","state_role_name":"","command_role_name":"","backend_hostname":"https://ui-backend.digger.dev/","backend_organisation_hostname":"digger","backend_job_token":"cli:0b4b778d-207a-4ef7-a6d7-d5c718a6571a","skip_merge_check":false,"command_role_arn":"","state_role_arn":"","aws_cognito_oidc":null},"reporter":
```


However and after specifying "digger plan" as a comment an empty string was passed back in the spec

```
,"variables":[{"name":"TF_TOKEN_mo__opentaco__test_ngrok_app","value":"","is_secret":false,"is_interpolated":false},{"name":"DEFAULT_BRANCH","value":"main","is_secret":false,"is_interpolated":false},{"name":"PROJECT_DIR","value":"dev","is_secret":false,"is_interpolated":false},{"name":"PROJECT_NAME","value":"dev","is_secret":false,"is_interpolated":false},{"name":"PR_BRANCH","value":"motatoes-patch-5","is_secret":false,"is_interpolated":false}]}
    setup-aws: true

```

Turns out we were doing interpolation on the backend. We change that behaviour in this PR to fix it 