### PR TITLE
add x permissions to providers after download

### DIFF
--- a/scripts/s3-cache-download.bash
+++ b/scripts/s3-cache-download.bash
@@ -34,11 +34,15 @@ echo "Restoring cache from S3 bucket: $BUCKET (prefix: $PREFIX, region: $REGION)
 if aws s3 sync "s3://$BUCKET/$PREFIX" "$CACHE_DIR" --region "$REGION"; then
   CACHED_FILES=$(find "$CACHE_DIR" -type f 2>/dev/null | wc -l)
   echo "Cache restored successfully ($CACHED_FILES files)"
-  
+
   if [ "$CACHED_FILES" -gt 0 ]; then
     echo "Sample cached artifacts:"
     find "$CACHE_DIR" -type f 2>/dev/null | head -3
   fi
+
+  echo "Setting permissions for cached artifacts (provider files)"
+  find "$CACHE_DIR" -type f -name 'terraform-provider-*' -exec chmod +x {} \;
+
 else
   echo "No existing cache found or failed to restore (this is normal for first run)"
 fi

--- a/scripts/s3-cache-download.bash
+++ b/scripts/s3-cache-download.bash
@@ -31,7 +31,7 @@ echo "Ensuring cache directory exists: $CACHE_DIR"
 
 # Download cache from S3
 echo "Restoring cache from S3 bucket: $BUCKET (prefix: $PREFIX, region: $REGION)"
-if aws s3 sync "s3://$BUCKET/$PREFIX" "$CACHE_DIR" --region "$REGION"; then
+if aws s3 sync "s3://$BUCKET/$PREFIX" "$CACHE_DIR" --region "$REGION" --only-show-errors; then
   CACHED_FILES=$(find "$CACHE_DIR" -type f 2>/dev/null | wc -l)
   echo "Cache restored successfully ($CACHED_FILES files)"
 
@@ -40,8 +40,14 @@ if aws s3 sync "s3://$BUCKET/$PREFIX" "$CACHE_DIR" --region "$REGION"; then
     find "$CACHE_DIR" -type f 2>/dev/null | head -3
   fi
 
+  # This step is necessary for filesystems where noexec is enabled
   echo "Setting permissions for cached artifacts (provider files)"
-  find "$CACHE_DIR" -type f -name 'terraform-provider-*' -exec chmod +x {} \;
+  if find "$CACHE_DIR" -type f -name 'terraform-provider-*' \
+      -exec chmod +x {} \; ; then
+    echo "✅ All provider binaries marked executable."
+  else
+    echo "❌ Failed to set exec bit on one or more providers." >&2
+  fi
 
 else
   echo "No existing cache found or failed to restore (this is normal for first run)"

--- a/scripts/s3-cache-upload.bash
+++ b/scripts/s3-cache-upload.bash
@@ -67,7 +67,7 @@ fi
 echo "Saving cache to S3 bucket: $BUCKET (prefix: $PREFIX, region: $REGION)"
 echo "Uploading $ARTIFACT_COUNT files"
 
-if aws s3 sync "$CACHE_DIR" "s3://$BUCKET/$PREFIX" --region "$REGION"; then
+if aws s3 sync "$CACHE_DIR" "s3://$BUCKET/$PREFIX" --region "$REGION" --only-show-errors; then
   echo "Cache saved successfully"
 else
   echo "Warning: Failed to save cache (this won't fail the build)"


### PR DESCRIPTION
an improvement to ensure when s3 provider cache is downloaded the providers have the right executable permissions. Since s3 is object store it does not store permissions during upload so they are not preserved during downloads. This can cause issues when the filesystem defaults to noexec mode.