### PR TITLE
Respect skip_merge_check during apply requirements check on backend 

### DIFF
--- a/backend/controllers/github_comment.go
+++ b/backend/controllers/github_comment.go
@@ -376,7 +376,7 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 
 	// Check for apply requirements
 	if *diggerCommand == scheduler.DiggerCommandApply {
-		err = apply_requirements.CheckApplyRequirements(ghService, impactedProjectsForComment, issueNumber, *prSourceBranch, targetBranch)
+		err = apply_requirements.CheckApplyRequirements(ghService, impactedProjectsForComment, jobs, issueNumber, *prSourceBranch, targetBranch)
 		if err != nil {
 			commentReporterManager.UpdateComment(fmt.Sprintf(":x: Could not proceed with apply since apply requirements checks have failed: %v", err))
 			return nil

--- a/libs/apply_requirements/apply_requirements.go
+++ b/libs/apply_requirements/apply_requirements.go
@@ -4,10 +4,21 @@ import (
 	"fmt"
 	"github.com/diggerhq/digger/libs/ci"
 	"github.com/diggerhq/digger/libs/digger_config"
+	"github.com/diggerhq/digger/libs/scheduler"
 	"log/slog"
 )
 
-func CheckApplyRequirements(ghService ci.PullRequestService, impactedProjects []digger_config.Project, prNumber int, sourceBranch string, targetBranch string) error {
+// IgnoreMergeabilityForProject will strip out the 'mergeability' requirement if
+// the project's workflow has specified skip_merge_check: true
+func IgnoreMergeabilityForProject(project digger_config.Project, jobs []scheduler.Job) bool {
+	job, err := scheduler.JobForProjectName(jobs, project.Name)
+	if err != nil {
+		slog.Warn("could not find job for mergeability ignore check, skipping this check and returning false")
+		return false
+	}
+	return job.SkipMergeCheck
+}
+func CheckApplyRequirements(ghService ci.PullRequestService, impactedProjects []digger_config.Project, jobs []scheduler.Job, prNumber int, sourceBranch string, targetBranch string) error {
 	isMergeable, err := ghService.IsMergeable(prNumber)
 	if err != nil {
 		slog.Error("Error checking if PR is mergeable", "prNumber", prNumber)
@@ -26,11 +37,12 @@ func CheckApplyRequirements(ghService ci.PullRequestService, impactedProjects []
 	}
 	for _, proj := range impactedProjects {
 		for _, req := range proj.ApplyRequirements {
+			ignoreMergeability := IgnoreMergeabilityForProject(proj, jobs)
 			if req == digger_config.ApplyRequirementsApproved && isApproved == false {
 				return fmt.Errorf("PR fails apply requirements for project %v, Expected PR to be approved, a minimum of one approval is required before proceeding", proj.Name)
 			} else if req == digger_config.ApplyRequirementsUndiverged && isDiverged == true {
 				return fmt.Errorf("PR fails apply requirements for project %v, Expected PR to be undiverged from target branch. Merge main into the PR branch or rebase the PR branch on top of main", proj.Name)
-			} else if req == digger_config.ApplyRequirementsMergeable && isMergeable == false {
+			} else if req == digger_config.ApplyRequirementsMergeable && isMergeable == false && !ignoreMergeability {
 				return fmt.Errorf("PR fails apply requirements for project %v, Expected PR to be mergable. Ensure all status checks are successful in order to proceed", proj.Name)
 			} else {
 				slog.Warn("unknown apply requirements found", "project", proj.Name, "requirement", req)

--- a/libs/scheduler/jobs.go
+++ b/libs/scheduler/jobs.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"github.com/samber/lo"
 	"slices"
 
@@ -82,6 +83,19 @@ func (j *Job) GetProjectAlias() string {
 		return j.ProjectAlias
 	}
 	return j.ProjectName
+}
+
+func JobForProjectName(jobs []Job, projectName string) (*Job, error) {
+	filteredJobs := lo.Filter(jobs, func(item Job, index int) bool {
+		return item.ProjectName == projectName
+	})
+	if len(filteredJobs) == 0 {
+		return nil, fmt.Errorf("job not found for project name %v", projectName)
+	}
+	if len(filteredJobs) > 1 {
+		return nil, fmt.Errorf("more than one job found for project name, duplicate? %v", projectName)
+	}
+	return &filteredJobs[0], nil
 }
 
 func (j *Job) IsPlan() bool {


### PR DESCRIPTION
we were not properly skipping the merge check in the backend after adding apply_requirements. This adds an additional ignoreMergability flag which takes into account the skip_merge_check of the project's workflow configuration