### PR TITLE
Fix nil pointer panic in comment updater when backend API returns nil

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -148,10 +148,15 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 			return false, false, fmt.Errorf("error while running command: %v", err)
 		}
 
-		err = commentUpdater.UpdateComment(batchResult.Jobs, prNumber, prService, prCommentId)
-		if err != nil {
-			slog.Error("error Updating status comment", "error", err)
-			return false, false, err
+		// Check if batchResult is nil (can happen with mock backend or when backend is not configured)
+		if batchResult == nil {
+			slog.Warn("batchResult is nil, skipping comment update", "jobId", jobId, "prNumber", prNumber)
+		} else {
+			err = commentUpdater.UpdateComment(batchResult.Jobs, prNumber, prService, prCommentId)
+			if err != nil {
+				slog.Error("error Updating status comment", "error", err, "prNumber", prNumber, "jobId", jobId)
+				return false, false, err
+			}
 		}
 
 	}

--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -163,7 +163,12 @@ func RunSpec(
 			message := fmt.Sprintf("Failed run commands. %v", err)
 			reportError(spec, backendApi, message, err)
 		}
-		commentUpdater.UpdateComment(serializedBatch.Jobs, serializedBatch.PrNumber, prService, commentId)
+		// Check if serializedBatch is nil (can happen with mock backend or when backend is not configured)
+		if serializedBatch == nil {
+			slog.Warn("serializedBatch is nil, skipping comment update", "jobId", spec.JobId)
+		} else {
+			commentUpdater.UpdateComment(serializedBatch.Jobs, serializedBatch.PrNumber, prService, commentId)
+		}
 		reportError(spec, backendApi, fmt.Sprintf("failed to run commands %v", err), err)
 	}
 	usage.ReportErrorAndExit(spec.VCS.RepoOwner, "Digger finished successfully", 0)

--- a/libs/comment_utils/summary/updater.go
+++ b/libs/comment_utils/summary/updater.go
@@ -24,6 +24,11 @@ func (b BasicCommentUpdater) UpdateComment(jobs []scheduler.SerializedJob, prNum
 		return err
 	}
 
+	if len(jobSpecs) == 0 {
+		slog.Warn("no job specs found, cannot update comment", "jobCount", len(jobs))
+		return nil
+	}
+
 	firstJobSpec := jobSpecs[0]
 	jobType := firstJobSpec.JobType
 	jobTypeTitle := cases.Title(language.AmericanEnglish).String(string(jobType))


### PR DESCRIPTION
**Description:**
Fix 1: Nil Check for batchResult
Fix 2: Nil Check for serializedBatch
Fix 3: Empty Slice Check in Comment Updater

The fixes are quite minimal, safe, and maintain backward compatibility while preventing the segmentation fault that was causing the process to exit with code 2.

**Reference:** #2022 