### PR TITLE
Fix nil pointer dereference in GetGithubAppInstallationLink calls

### DIFF
--- a/backend/controllers/cache.go
+++ b/backend/controllers/cache.go
@@ -47,6 +47,11 @@ func (d DiggerController) UpdateRepoCache(c *gin.Context) {
 		c.String(http.StatusInternalServerError, fmt.Sprintf("could not find installation link %v %v", repoFullName, installationId))
 		return
 	}
+	if link == nil {
+		slog.Error("GitHub app installation link not found", "repoFullName", repoFullName, "installationId", installationId)
+		c.String(http.StatusInternalServerError, fmt.Sprintf("could not find installation link %v %v", repoFullName, installationId))
+		return
+	}
 	orgId := link.OrganisationId
 
 	slog.Info("Processing repo cache update", "orgId", orgId)

--- a/backend/controllers/github_comment.go
+++ b/backend/controllers/github_comment.go
@@ -78,6 +78,12 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		)
 		return fmt.Errorf("error getting github app link")
 	}
+	if link == nil {
+		slog.Error("GitHub app installation link not found",
+			"installationId", installationId,
+		)
+		return fmt.Errorf("github app installation link not found")
+	}
 	orgId := link.OrganisationId
 
 	if *payload.Action != "created" {

--- a/backend/controllers/github_pull_request.go
+++ b/backend/controllers/github_pull_request.go
@@ -76,6 +76,12 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 		)
 		return fmt.Errorf("error getting github app link")
 	}
+	if link == nil {
+		slog.Error("GitHub app installation link not found",
+			"installationId", installationId,
+		)
+		return fmt.Errorf("github app installation link not found")
+	}
 	organisationId := link.OrganisationId
 
 	ghService, _, ghServiceErr := utils.GetGithubService(gh, installationId, repoFullName, repoOwner, repoName)


### PR DESCRIPTION
**Description:**
The GetGithubAppInstallationLink function in digger/backend/models/storage.go returns nil, nil when no record is found, which is a valid scenario when a GitHub app installation hasn't been linked to an organization yet.

**Reference:** #2108 