### PR TITLE
refactor(ee/backend): replace golang.org/x/exp/maps with stdlib maps

### DIFF
--- a/ee/backend/controllers/web.go
+++ b/ee/backend/controllers/web.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"html/template"
 	"log"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/diggerhq/digger/backend/services"
 	"github.com/gin-gonic/gin"
 	"github.com/robert-nix/ansihtml"
-	"golang.org/x/exp/maps"
 )
 
 type WebController struct {

--- a/ee/backend/go.mod
+++ b/ee/backend/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/samber/lo v1.46.0
 	github.com/xanzy/go-gitlab v0.106.0
-	golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc
 )
 
 require (
@@ -282,6 +281,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect


### PR DESCRIPTION
A small cleanup that I noticed while doing https://github.com/diggerhq/digger/pull/2279. The experimental functions in `golang.org/x/exp/maps` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#maps