### PR TITLE
Support relative paths in include_patterns and exclude_patterns

### DIFF
--- a/docs/ce/howto/include-exclude-patterns.mdx
+++ b/docs/ce/howto/include-exclude-patterns.mdx
@@ -15,19 +15,35 @@ modules/
 ```
 
 <Note>
-    The path of include / exclude patterns is relative to the digger.yml location - NOT the project location
+    Patterns starting with `.` (e.g., `./modules/**` or `../modules/**`) are resolved relative to the **project directory**. All other patterns are resolved relative to the **digger.yml location**.
 </Note>
 
 If you wanted to trigger plans for all `modules/` folder in both dev and prod projects you would include them in the `include_patterns` key. Similarly you put anything which you want to ignore in the `exclude_patterns` key ( exclude takes precedence over includes).
+
+Example using patterns relative to project directory:
 
 ```yml
 projects:
   - name: dev
     dir: ./development
-    include_patterns: ["./modules/**"]
+    include_patterns: ["../modules/**"]  # Resolved from ./development/
     workflow: default_workflow
   - name: prod
     dir: ./production
-    include_patterns: ["./modules/**"]
-    exclude_patterns: ["./modules/dev_only_module/**"]
+    include_patterns: ["../modules/**"]  # Resolved from ./production/
+    exclude_patterns: ["../modules/dev_only_module/**"]
+```
+
+Example using patterns relative to digger.yml location:
+
+```yml
+projects:
+  - name: dev
+    dir: ./development
+    include_patterns: ["modules/**"]  # Resolved from digger.yml location
+    workflow: default_workflow
+  - name: prod
+    dir: ./production
+    include_patterns: ["modules/**"]
+    exclude_patterns: ["modules/dev_only_module/**"]
 ```

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -68,7 +68,6 @@ func TestDiggerConfigWhenCustomFileName(t *testing.T) {
 	assert.Equal(t, configPath, path.Join(tempDir, "digger-custom.yml"))
 
 	os.Unsetenv("DIGGER_FILENAME")
-
 }
 
 func TestDiggerConfigWhenOnlyYamlExists(t *testing.T) {
@@ -579,7 +578,6 @@ workflows:
 	assert.NotNil(t, workflow)
 	assert.NotNil(t, workflow.Plan)
 	assert.NotNil(t, workflow.Apply)
-
 }
 
 func TestDiggerConfigMissingProjectsWorkflow(t *testing.T) {
@@ -603,7 +601,6 @@ workflows:
 
 	_, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
 	assert.Equal(t, "failed to find workflow digger_config 'my_custom_workflow' for project 'my-first-app'", err.Error())
-
 }
 
 func TestDiggerConfigWithEmptyInitBlock(t *testing.T) {
@@ -1309,7 +1306,7 @@ projects:
 func TestGetModifiedProjectsReturnsCorrectSourceMappingWithDotFile(t *testing.T) {
 	changedFiles := []string{"prod/main.tf", "dev/test/main.tf"}
 	projects := []Project{
-		Project{
+		{
 			Name: "dev",
 			Dir:  ".",
 		},
@@ -1317,7 +1314,7 @@ func TestGetModifiedProjectsReturnsCorrectSourceMappingWithDotFile(t *testing.T)
 	c := DiggerConfig{
 		Projects: projects,
 	}
-	//expectedImpactingLocations := map[string]ProjectToSourceMapping{}
+	// expectedImpactingLocations := map[string]ProjectToSourceMapping{}
 	// TODO: this behaviour doesn't make much sense, we should re-evaluate when we make it configurable
 	impactedProjects, _ := c.GetModifiedProjects(changedFiles)
 	assert.Equal(t, 1, len(impactedProjects))
@@ -1326,7 +1323,7 @@ func TestGetModifiedProjectsReturnsCorrectSourceMappingWithDotFile(t *testing.T)
 func TestShouldDetectNestedFilesAsImpacted(t *testing.T) {
 	changedFiles := []string{"services/backend/files/config.json"}
 	projects := []Project{
-		Project{
+		{
 			Name: "services_backend",
 			Dir:  "services/backend",
 		},
@@ -1341,12 +1338,12 @@ func TestShouldDetectNestedFilesAsImpacted(t *testing.T) {
 func TestGetModifiedProjectsReturnsCorrectSourceMapping(t *testing.T) {
 	changedFiles := []string{"modules/bucket/main.tf", "dev/main.tf"}
 	projects := []Project{
-		Project{
+		{
 			Name:            "dev",
 			Dir:             "dev",
 			IncludePatterns: []string{"modules/**"},
 		},
-		Project{
+		{
 			Name:            "prod",
 			Dir:             "prod",
 			IncludePatterns: []string{"modules/**"},
@@ -1367,7 +1364,37 @@ func TestGetModifiedProjectsReturnsCorrectSourceMapping(t *testing.T) {
 	assert.Equal(t, 1, len(projectSourceMapping["prod"].ImpactingLocations))
 	assert.Equal(t, expectedImpactingLocations["dev"].ImpactingLocations, projectSourceMapping["dev"].ImpactingLocations)
 	assert.Equal(t, expectedImpactingLocations["prod"].ImpactingLocations, projectSourceMapping["prod"].ImpactingLocations)
+}
 
+func TestGetModifiedProjectsReturnsCorrectSourceMappingWithRelativePaths(t *testing.T) {
+	changedFiles := []string{"terraform/modules/bucket/main.tf", "terraform/dev/main.tf"}
+	projects := []Project{
+		{
+			Name:            "dev",
+			Dir:             "terraform/dev",
+			IncludePatterns: []string{"../modules/**"},
+		},
+		{
+			Name:            "prod",
+			Dir:             "terraform/prod",
+			IncludePatterns: []string{"../modules/**"},
+		},
+	}
+	c := DiggerConfig{
+		Projects: projects,
+	}
+	expectedImpactingLocations := map[string]ProjectToSourceMapping{
+		"dev":  {ImpactingLocations: []string{"terraform/modules/bucket", "terraform/dev"}},
+		"prod": {ImpactingLocations: []string{"terraform/modules/bucket"}},
+	}
+
+	impactedProjects, projectSourceMapping := c.GetModifiedProjects(changedFiles)
+	assert.Equal(t, 2, len(impactedProjects))
+	assert.Equal(t, 2, len(projectSourceMapping))
+	assert.Equal(t, 2, len(projectSourceMapping["dev"].ImpactingLocations))
+	assert.Equal(t, 1, len(projectSourceMapping["prod"].ImpactingLocations))
+	assert.Equal(t, expectedImpactingLocations["dev"].ImpactingLocations, projectSourceMapping["dev"].ImpactingLocations)
+	assert.Equal(t, expectedImpactingLocations["prod"].ImpactingLocations, projectSourceMapping["prod"].ImpactingLocations)
 }
 
 func TestCognitoTokenSetFromMinConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR enables the use of relative paths for `include_patterns` and `exclude_patterns`.

## Changes
- Updated pattern matching logic to support relative paths

## Motivation
Previously, `include_patterns` and `exclude_patterns` only worked with absolute paths, which made configurations less flexible. Supporting relative paths improves usability and aligns with common developer expectations.

## Testing
- Verified that relative paths are correctly resolved during matching
- Confirmed existing absolute path functionality remains unaffected
- Added unit tests covering the cases