### PR TITLE
Add MS Teams Webhook Support for Drift Notifications

### DIFF
--- a/backend/controllers/orgs.go
+++ b/backend/controllers/orgs.go
@@ -39,10 +39,11 @@ func GetOrgSettingsApi(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"drift_enabled":     org.DriftEnabled,
-		"drift_cron_tab":    org.DriftCronTab,
-		"drift_webhook_url": org.DriftWebhookUrl,
-		"billing_plan":      org.BillingPlan,
+		"drift_enabled":         org.DriftEnabled,
+		"drift_cron_tab":        org.DriftCronTab,
+		"drift_webhook_url":     org.DriftWebhookUrl,
+		"drift_teams_webhook_url": org.DriftTeamsWebhookUrl,
+		"billing_plan":          org.BillingPlan,
 	})
 }
 
@@ -66,6 +67,7 @@ func UpdateOrgSettingsApi(c *gin.Context) {
 		DriftEnabled                *bool   `json:"drift_enabled,omitempty"`
 		DriftCronTab                *string `json:"drift_cron_tab,omitempty"`
 		DriftWebhookUrl             *string `json:"drift_webhook_url,omitempty"`
+		DriftTeamsWebhookUrl        *string `json:"drift_teams_webhook_url,omitempty"`
 		BillingPlan                 *string `json:"billing_plan,omitempty"`
 		BillingStripeSubscriptionId *string `json:"billing_stripe_subscription_id,omitempty"`
 		SlackChannelName            *string `json:"slack_channel_name,omitempty"`
@@ -87,6 +89,10 @@ func UpdateOrgSettingsApi(c *gin.Context) {
 
 	if reqBody.DriftWebhookUrl != nil {
 		org.DriftWebhookUrl = *reqBody.DriftWebhookUrl
+	}
+
+	if reqBody.DriftTeamsWebhookUrl != nil {
+		org.DriftTeamsWebhookUrl = *reqBody.DriftTeamsWebhookUrl
 	}
 
 	if reqBody.BillingPlan != nil {

--- a/backend/models/orgs.go
+++ b/backend/models/orgs.go
@@ -23,6 +23,7 @@ type Organisation struct {
 	ExternalId                  string `gorm:"uniqueIndex:idx_external_source"`
 	DriftEnabled                bool   `gorm:"default:false"`
 	DriftWebhookUrl             string
+	DriftTeamsWebhookUrl        string
 	DriftCronTab                string      `gorm:"default:'0 0 * * *'"`
 	BillingPlan                 BillingPlan `gorm:"default:'free'"`
 	BillingStripeSubscriptionId string

--- a/drift/controllers/notifications.go
+++ b/drift/controllers/notifications.go
@@ -78,8 +78,71 @@ func sendTestSlackWebhook(webhookURL string) error {
 	return nil
 }
 
+func sendTestTeamsWebhook(webhookURL string) error {
+	messageCard := map[string]interface{}{
+		"@type":    "MessageCard",
+		"@context": "http://schema.org/extensions",
+		"themeColor": "0076D7",
+		"summary":  "Digger Drift Detection Test",
+		"sections": []map[string]interface{}{
+			{
+				"activityTitle":    "Digger Drift Detection",
+				"activitySubtitle": "Test Notification",
+				"activityText":     "This is a test notification to verify your MS Teams integration is working correctly.",
+				"facts": []map[string]string{
+					{"name": "Project", "value": "Dev environment"},
+					{"name": "Status", "value": "🟡 Drift detected"},
+				},
+			},
+			{
+				"activityTitle":    "Environment Status",
+				"activitySubtitle": "Current Status Overview",
+				"facts": []map[string]string{
+					{"name": "Dev environment", "value": "🟡 Drift detected"},
+					{"name": "Staging environment", "value": "⚪ Acknowledged drift"},
+					{"name": "Prod environment", "value": "🟢 No drift"},
+				},
+			},
+			{
+				"activityTitle": "Note",
+				"activityText":  "✅ This is a test notification",
+			},
+		},
+		"potentialAction": []map[string]interface{}{
+			{
+				"@type": "OpenUri",
+				"name":  "View Dashboard",
+				"targets": []map[string]interface{}{
+					{"os": "default", "uri": os.Getenv("DIGGER_APP_URL")},
+				},
+			},
+		},
+	}
+
+	jsonPayload, err := json.Marshal(messageCard)
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %v", err)
+	}
+
+	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("error sending POST request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK HTTP status: %s", resp.Status)
+	}
+
+	return nil
+}
+
 type TestSlackNotificationForUrl struct {
 	SlackNotificationUrl string `json:"notification_url"`
+}
+
+type TestTeamsNotificationForUrl struct {
+	TeamsNotificationUrl string `json:"notification_url"`
 }
 
 func (mc MainController) SendTestSlackNotificationForUrl(c *gin.Context) {
@@ -96,6 +159,26 @@ func (mc MainController) SendTestSlackNotificationForUrl(c *gin.Context) {
 	if err != nil {
 		log.Printf("Error sending slack notification: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error sending slack notification"})
+		return
+	}
+
+	c.String(200, "ok")
+}
+
+func (mc MainController) SendTestTeamsNotificationForUrl(c *gin.Context) {
+	var request TestTeamsNotificationForUrl
+	err := c.BindJSON(&request)
+	if err != nil {
+		log.Printf("Error binding JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error binding JSON"})
+		return
+	}
+	teamsNotificationUrl := request.TeamsNotificationUrl
+
+	err = sendTestTeamsWebhook(teamsNotificationUrl)
+	if err != nil {
+		log.Printf("Error sending teams notification: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error sending teams notification"})
 		return
 	}
 
@@ -217,6 +300,128 @@ func (mc MainController) SendRealSlackNotificationForOrg(c *gin.Context) {
 	c.String(200, "ok")
 }
 
+func createTeamsMessageCardForProjects(projects []*models.Project) map[string]interface{} {
+	facts := []map[string]string{
+		{"name": "Project", "value": "Status"},
+	}
+
+	var sections []map[string]interface{}
+
+	for _, project := range projects {
+		if project.DriftEnabled {
+			var statusValue string
+
+			switch project.DriftStatus {
+			case models.DriftStatusNoDrift:
+				statusValue = "🟢 No Drift"
+			case models.DriftStatusAcknowledgeDrift:
+				statusValue = "⚪ Acknowledged Drift"
+			case models.DriftStatusNewDrift:
+				statusValue = "🟡 Drift detected"
+			default:
+				statusValue = "❓ Unknown"
+			}
+
+			facts = append(facts, map[string]string{
+				"name":  project.Name,
+				"value": statusValue,
+			})
+		}
+	}
+
+	section := map[string]interface{}{
+		"activityTitle":    "Digger Drift Detection Report",
+		"activitySubtitle": fmt.Sprintf("Found %d projects with drift enabled", len(facts)-1),
+		"facts":           facts,
+	}
+
+	sections = append(sections, section)
+
+	messageCard := map[string]interface{}{
+		"@type":       "MessageCard",
+		"@context":    "http://schema.org/extensions",
+		"themeColor":  "0076D7",
+		"summary":     "Digger Drift Detection Report",
+		"sections":    sections,
+		"potentialAction": []map[string]interface{}{
+			{
+				"@type": "OpenUri",
+				"name":  "View Dashboard",
+				"targets": []map[string]interface{}{
+					{"os": "default", "uri": os.Getenv("DIGGER_APP_URL")},
+				},
+			},
+		},
+	}
+
+	return messageCard
+}
+
+func (mc MainController) SendRealTeamsNotificationForOrg(c *gin.Context) {
+	var request RealSlackNotificationForOrgRequest
+	err := c.BindJSON(&request)
+	if err != nil {
+		log.Printf("Error binding JSON: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error binding JSON"})
+		return
+	}
+	orgId := request.OrgId
+
+	org, err := models.DB.GetOrganisationById(orgId)
+	if err != nil {
+		log.Printf("could not get org %v err: %v", orgId, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Could not get org %v", orgId)})
+		return
+	}
+
+	teamsNotificationUrl := org.DriftTeamsWebhookUrl
+
+	projects, err := models.DB.LoadProjectsForOrg(orgId)
+	if err != nil {
+		log.Printf("could not load projects for org %v err: %v", orgId, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Could not load projects for org %v", orgId)})
+		return
+	}
+
+	numOfProjectsWithDriftEnabled := 0
+	for _, project := range projects {
+		if project.DriftEnabled {
+			numOfProjectsWithDriftEnabled++
+		}
+	}
+
+	if numOfProjectsWithDriftEnabled == 0 {
+		log.Printf("no projects with drift enabled for org: %v, succeeding", orgId)
+		c.String(200, "ok")
+		return
+	}
+
+	messageCard := createTeamsMessageCardForProjects(projects)
+
+	jsonPayload, err := json.Marshal(messageCard)
+	if err != nil {
+		log.Printf("error marshalling teams message card: %v", err)
+		c.JSON(500, gin.H{"error": "error marshalling teams message card"})
+		return
+	}
+
+	resp, err := http.Post(teamsNotificationUrl, "application/json", bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		log.Printf("error sending teams webhook: %v", err)
+		c.JSON(500, gin.H{"error": "error sending teams webhook"})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("teams webhook got unexpected status for org: %v - status: %v", org.ID, resp.StatusCode)
+		c.JSON(500, gin.H{"error": "teams webhook got unexpected status"})
+		return
+	}
+
+	c.String(200, "ok")
+}
+
 func (mc MainController) ProcessAllNotifications(c *gin.Context) {
 	diggerHostname := os.Getenv("DIGGER_HOSTNAME")
 	webhookSecret := os.Getenv("DIGGER_WEBHOOK_SECRET")
@@ -230,6 +435,13 @@ func (mc MainController) ProcessAllNotifications(c *gin.Context) {
 	if err != nil {
 		log.Printf("could not form drift url: %v", err)
 		c.JSON(500, gin.H{"error": "could not form drift url"})
+		return
+	}
+
+	sendTeamsNotificationUrl, err := url.JoinPath(diggerHostname, "_internal/send_teams_notification_for_org")
+	if err != nil {
+		log.Printf("could not form teams drift url: %v", err)
+		c.JSON(500, gin.H{"error": "could not form teams drift url"})
 		return
 	}
 
@@ -279,6 +491,45 @@ func (mc MainController) ProcessAllNotifications(c *gin.Context) {
 			statusCode := resp.StatusCode
 			if statusCode != 200 {
 				log.Printf("send slack notification got unexpected status for org: %v - status: %v", org.ID, statusCode)
+			}
+
+			// Send MS Teams notification if webhook URL is configured
+			if org.DriftTeamsWebhookUrl != "" {
+				fmt.Println("Sending teams notification for org ID: ", org.ID)
+				teamsPayload := RealSlackNotificationForOrgRequest{OrgId: org.ID}
+
+				// Convert payload to JSON
+				teamsJsonPayload, err := json.Marshal(teamsPayload)
+				if err != nil {
+					fmt.Println("Process Teams notification: error marshaling JSON:", err)
+					continue
+				}
+
+				// Create a new request for MS Teams
+				teamsReq, err := http.NewRequest("POST", sendTeamsNotificationUrl, bytes.NewBuffer(teamsJsonPayload))
+				if err != nil {
+					fmt.Println("Process teams notification: Error creating request:", err)
+					continue
+				}
+
+				// Set headers
+				teamsReq.Header.Set("Content-Type", "application/json")
+				teamsReq.Header.Set("Authorization", fmt.Sprintf("Bearer %v", webhookSecret))
+
+				// Send the request
+				teamsClient := &http.Client{}
+				teamsResp, err := teamsClient.Do(teamsReq)
+				if err != nil {
+					fmt.Println("Error sending teams request:", err)
+					continue
+				}
+				teamsResp.Body.Close()
+
+				// Get the status code
+				teamsStatusCode := teamsResp.StatusCode
+				if teamsStatusCode != 200 {
+					log.Printf("send teams notification got unexpected status for org: %v - status: %v", org.ID, teamsStatusCode)
+				}
 			}
 		}
 	}

--- a/ee/drift/main.go
+++ b/ee/drift/main.go
@@ -87,6 +87,8 @@ func main() {
     r.POST("/_internal/process_notifications", middleware.WebhookAuth(), controller.ProcessAllNotifications)
     r.POST("/_internal/send_slack_notification_for_org", middleware.WebhookAuth(), controller.SendRealSlackNotificationForOrg)
     r.POST("/_internal/send_test_slack_notification_for_url", middleware.WebhookAuth(), controller.SendTestSlackNotificationForUrl)
+    r.POST("/_internal/send_teams_notification_for_org", middleware.WebhookAuth(), controller.SendRealTeamsNotificationForOrg)
+    r.POST("/_internal/send_test_teams_notification_for_url", middleware.WebhookAuth(), controller.SendTestTeamsNotificationForUrl)
 
     r.POST("/_internal/process_drift", middleware.WebhookAuth(), controller.ProcessAllDrift)
     r.POST("/_internal/process_drift_for_org", middleware.WebhookAuth(), controller.ProcessDriftForOrg)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1397,6 +1397,8 @@ github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5 h1:+CpLbZIeUn94m02
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4 h1:itqmmf1PFpC4n5JW+j4BU7X4MTfVurhYRTjODoPb2Y8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:1iy2qD6JEhHKKhUOA9IWs7mjco7lnw2qx8FsRI2wirE=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
@@ -1632,6 +1634,7 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAx
 github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/cloud-bigtable-clients-test v0.0.2 h1:S+sCHWAiAc+urcEnvg5JYJUOdlQEm/SEzQ/c/IdAH5M=
 github.com/googleapis/cloud-bigtable-clients-test v0.0.2/go.mod h1:mk3CrkrouRgtnhID6UZQDK3DrFFa7cYCAJcEmNsHYrY=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
@@ -2209,6 +2212,9 @@ github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec h1:2ZXvIUGghLpdTVHR1UfvfrzoVlZaE/yOWC5LueIHZig=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=


### PR DESCRIPTION
**Description**
This PR adds Microsoft Teams webhook support for drift detection notifications, providing an alternative to Slack notifications for organizations that use MS Teams for communication.

**Changes Made**
- Database: Added DriftTeamsWebhookUrl field to Organisation model
- API: Updated organization settings endpoints to handle MS Teams webhook URLs
- Notifications: Implemented MS Teams MessageCard format for rich notifications
- Processing: Added MS Teams notification processing to drift detection workflow
- Routes: Added endpoints for testing and sending MS Teams notifications

**API Endpoints Added**
- `POST /_internal/send_teams_notification_for_org` - Send drift notifications to MS Teams
- `POST /_internal/send_test_teams_notification_for_url` - Test MS Teams webhook URLs

**Referenced Issue:** #2276