### PR TITLE
Added handler for ready_for_review action for draft PR conversion

### DIFF
--- a/backend/controllers/github_pull_request.go
+++ b/backend/controllers/github_pull_request.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/diggerhq/digger/backend/ci_backends"
 	config2 "github.com/diggerhq/digger/backend/config"
@@ -101,7 +102,37 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 		return fmt.Errorf("error getting ghService to post error comment")
 	}
 
-	if !slices.Contains([]string{"closed", "opened", "reopened", "synchronize", "converted_to_draft"}, action) {
+	// here we check if pr was closed and automatic deletion is enabled, to avoid errors when
+	// pr is merged and the branch does not exist we handle that gracefully
+	if action == "closed" {
+		slog.Debug("Handling closed PR action", "prNumber", prNumber)
+		// we sleep for 1 second to give github time to delete the branch
+		time.Sleep(1 * time.Second)
+
+		branchName, _, _, _, err := ghService.GetBranchName(prNumber)
+		if err != nil {
+			slog.Error("Could not retrieve PR details", "prNumber", prNumber, "error", err)
+			utils.InitCommentReporter(ghService, prNumber, fmt.Sprintf(":x: Could not retrieve PR details, error: %v", err))
+			return fmt.Errorf("Could not retrieve PR details: %v", err)
+		}
+
+		branchExists, err := ghService.CheckBranchExists(branchName)
+		if err != nil {
+			slog.Error("Could not check if branch exists", "prNumber", prNumber, "branchName", branchName, "error", err)
+			utils.InitCommentReporter(ghService, prNumber, fmt.Sprintf(":x: Could not check if branch exists, error: %v", err))
+			return fmt.Errorf("Could not check if branch exists: %v", err)
+		}
+
+		if !branchExists {
+			slog.Info("Branch no longer exists, ignoring PR closed event",
+				"prNumber", prNumber,
+				"branchName", branchName,
+			)
+			return nil
+		}
+	}
+
+	if !slices.Contains([]string{"closed", "opened", "reopened", "synchronize", "converted_to_draft", "ready_for_review"}, action) {
 		slog.Info("Ignoring event with action not requiring processing", "action", action, "prNumber", prNumber)
 		return nil
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1397,6 +1397,8 @@ github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5 h1:+CpLbZIeUn94m02
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4 h1:itqmmf1PFpC4n5JW+j4BU7X4MTfVurhYRTjODoPb2Y8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:1iy2qD6JEhHKKhUOA9IWs7mjco7lnw2qx8FsRI2wirE=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
@@ -1632,6 +1634,7 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAx
 github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/cloud-bigtable-clients-test v0.0.2 h1:S+sCHWAiAc+urcEnvg5JYJUOdlQEm/SEzQ/c/IdAH5M=
 github.com/googleapis/cloud-bigtable-clients-test v0.0.2/go.mod h1:mk3CrkrouRgtnhID6UZQDK3DrFFa7cYCAJcEmNsHYrY=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
@@ -2209,6 +2212,9 @@ github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec h1:2ZXvIUGghLpdTVHR1UfvfrzoVlZaE/yOWC5LueIHZig=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -1027,6 +1027,39 @@ func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impac
 				CognitoOidcConfig:          project.AwsCognitoOidcConfig,
 				SkipMergeCheck:             skipMerge,
 			})
+		} else if action == "ready_for_review" {
+			slog.Info("processing PR ready for review",
+				"prNumber", *pullRequestNumber,
+				"project", project.Name,
+				"action", action)
+
+			jobs = append(jobs, scheduler.Job{
+				ProjectName:        project.Name,
+				ProjectAlias:       project.Alias,
+				ProjectDir:         project.Dir,
+				ProjectWorkspace:   project.Workspace,
+				ProjectWorkflow:    project.Workflow,
+				Layer:              project.Layer,
+				Terragrunt:         project.Terragrunt,
+				OpenTofu:           project.OpenTofu,
+				Pulumi:             project.Pulumi,
+				Commands:           workflow.Configuration.OnPullRequestPushed,
+				ApplyStage:         scheduler.ToConfigStage(workflow.Apply),
+				PlanStage:          scheduler.ToConfigStage(workflow.Plan),
+				RunEnvVars:         runEnvVars,
+				CommandEnvVars:     commandEnvVars,
+				StateEnvVars:       stateEnvVars,
+				PullRequestNumber:  pullRequestNumber,
+				EventName:          "pull_request",
+				Namespace:          *payload.Repo.FullName,
+				RequestedBy:        *payload.Sender.Login,
+				CommandEnvProvider: CommandEnvProvider,
+				CommandRoleArn:     cmdRole,
+				StateRoleArn:       stateRole,
+				StateEnvProvider:   StateEnvProvider,
+				CognitoOidcConfig:  project.AwsCognitoOidcConfig,
+				SkipMergeCheck:     skipMerge,
+			})
 		} else if action == "closed" {
 			slog.Info("processing PR closed",
 				"prNumber", *pullRequestNumber,


### PR DESCRIPTION
**Description**
When a GitHub draft PR is converted to "ready for review", Digger was ignoring this action and not triggering a digger plan. Users had to manually comment "digger plan" to trigger the initial plan

**Referenced Issue:** #2291
