### PR TITLE
fix: fix terragrunt non-interactive flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ inputs:
   terragrunt-version:
     description: Terragrunt version
     required: false
-    default: v0.90.0
+    default: v0.73.7
   opentofu-version:
     description: OpenTofu version
     required: false

--- a/libs/execution/terragrunt.go
+++ b/libs/execution/terragrunt.go
@@ -26,7 +26,6 @@ func (terragrunt Terragrunt) Init(params []string, envs map[string]string) (stri
 func (terragrunt Terragrunt) Apply(params []string, plan *string, envs map[string]string) (string, string, error) {
 	params = append(params, []string{"-lock-timeout=3m"}...)
 	params = append(params, "--auto-approve")
-	params = append(params, "--non-interactive")
 	if plan != nil {
 		params = append(params, *plan)
 	}
@@ -40,7 +39,6 @@ func (terragrunt Terragrunt) Apply(params []string, plan *string, envs map[strin
 
 func (terragrunt Terragrunt) Destroy(params []string, envs map[string]string) (string, string, error) {
 	params = append(params, "--auto-approve")
-	params = append(params, "--non-interactive")
 	stdout, stderr, exitCode, err := terragrunt.runTerragruntCommand("destroy", true, envs, nil, params...)
 	if exitCode != 0 {
 		logCommandFail(exitCode, err)


### PR DESCRIPTION
Terragrunt redesigned their CLI (released in [v0.77.22](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.77.22), see [GH issue comment](https://github.com/gruntwork-io/terragrunt/issues/3445#issuecomment-2819076926)) to remove the `terragrunt` prefix.

This PR removes the `--terragrunt-non-interactive` for `apply` and `destroy` commands. This flag is not valid for newer versions of Terragrunt and was duplicative with ENV vars set here: https://github.com/diggerhq/digger/blob/53173e54b1e4e1638faad6f421e808c05490b2d5/libs/execution/terragrunt.go#L123-L125

By removing the CLI flag but setting both `TERRAGRUNT_NON_INTERACTIVE=true` AND `TG_NON_INTERACTIVE=true`, digger remains compatible with versions before and after the CLI redesign https://terragrunt.gruntwork.io/docs/migrate/cli-redesign/

---

### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [x] I understand that all AI assistance must be disclosed.
- [x] I did **not** use AI tools in this contribution.
- [ ] I used AI tools and have disclosed details below.

**Details (if applicable):**
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
