### PR TITLE
remove deprecated --terragrunt-non-interactive flag

### DIFF
--- a/libs/execution/terragrunt.go
+++ b/libs/execution/terragrunt.go
@@ -26,7 +26,6 @@ func (terragrunt Terragrunt) Init(params []string, envs map[string]string) (stri
 func (terragrunt Terragrunt) Apply(params []string, plan *string, envs map[string]string) (string, string, error) {
 	params = append(params, []string{"-lock-timeout=3m"}...)
 	params = append(params, "--auto-approve")
-	params = append(params, "--terragrunt-non-interactive")
 	if plan != nil {
 		params = append(params, *plan)
 	}
@@ -40,7 +39,6 @@ func (terragrunt Terragrunt) Apply(params []string, plan *string, envs map[strin
 
 func (terragrunt Terragrunt) Destroy(params []string, envs map[string]string) (string, string, error) {
 	params = append(params, "--auto-approve")
-	params = append(params, "--terragrunt-non-interactive")
 	stdout, stderr, exitCode, err := terragrunt.runTerragruntCommand("destroy", true, envs, nil, params...)
 	if exitCode != 0 {
 		logCommandFail(exitCode, err)


### PR DESCRIPTION
### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [x] I understand that all AI assistance must be disclosed.
- [ ] I did **not** use AI tools in this contribution.
- [x] I used AI tools and have disclosed details below.

**Details (if applicable):**
Used ChatGPT to understand how Terragrunt flags work. All code changes were made manually.

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
