### PR TITLE
Skip locks on push into a draft PR

### DIFF
--- a/backend/controllers/github_pull_request.go
+++ b/backend/controllers/github_pull_request.go
@@ -251,8 +251,8 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 		return nil
 	}
 
-	// special case for when a draft pull request is opened and ignore PRs is set to true we DO NOT want to lock the projects
-	if !config.AllowDraftPRs && isDraft && action == "opened" {
+	// don't lock when a draft pull request is opened, or a commit to it is pushed
+	if !config.AllowDraftPRs && isDraft && (action == "opened" || action == "synchronize") {
 		slog.Info("Draft PRs are disabled, skipping PR",
 			"prNumber", prNumber,
 			"isDraft", isDraft,


### PR DESCRIPTION
### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [x] I understand that all AI assistance must be disclosed.
- [ ] I did **not** use AI tools in this contribution.
- [x] I used AI tools and have disclosed details below.

**Details (if applicable):**
> codex to locate the issue and propose a fix. the code it proposed was dirty; had to rewrite

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
