### PR TITLE
Remove outdated demo repos

### DIFF
--- a/docs/ce/getting-started/with-terraform.mdx
+++ b/docs/ce/getting-started/with-terraform.mdx
@@ -5,7 +5,7 @@ title: "With Terraform"
 In this tutorial, you will set up Digger to automate terraform pull requests using Github Actions
 
 **Prerequisites**
-- A GitHub repository with valid terraform code, don't have one? see [here](#demo-repositories)
+- A GitHub repository with valid terraform code. Don't have one? see [Example repo](https://github.com/diggerhq/quickstart-actions-aws)
 - Your cloud provider credentials:
   - For AWS: [Hashicorp's AWS tutorial](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build)
   - For GCP: [Hashicorp's GCP tutorial](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/google-cloud-platform-build)
@@ -283,11 +283,5 @@ Then you can add a comment like `digger apply` and shortly after apply output wi
 ></video>
 </Step>
 </Steps>
-
-## Demo repositories
-
-- [AWS demo repo](https://github.com/diggerhq/quickstart-actions-aws)
-- [GCP demo repo](https://github.com/diggerhq/demo-conftest-gcp/)
-- [Azure demo repo](https://github.com/diggerhq/azure-onboarding-test)
 
 


### PR DESCRIPTION
Removed outdated example repos except for one (aws). It's better to have one well-maintained example repo than multiple but under-maintained. A user issue was caused by it being out of date (missing spec; now updated)

### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [ ] I understand that all AI assistance must be disclosed.
- [x] I did **not** use AI tools in this contribution.
- [ ] I used AI tools and have disclosed details below.

**Details (if applicable):**
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
