### PR TITLE
Upgrade Node.js version to 22-alpine in Dockerfile

### DIFF
--- a/Dockerfile_ui
+++ b/Dockerfile_ui
@@ -1,50 +1,44 @@
-# Multi-stage build for Taco UI
+# syntax=docker/dockerfile:1.7
+
+########### Builder: compile Vite/TypeScript/etc. ###########
 FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Install ALL dependencies (including devDeps) — required for Vite, tsc, plugins, etc.
 COPY ui/package.json ui/package-lock.json ./
 
-# Install dependencies first
-# npm will automatically install correct platform-specific binaries (amd64 or arm64)
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci && \
-    npm cache clean --force
+    npm ci
 
-# Copy source code (node_modules excluded via .dockerignore)
+# Copy source (node_modules should be excluded via .dockerignore)
 COPY ui/ ./
 
-# Build the application (with node adapter)
+# Build the app
 RUN --mount=type=cache,target=/root/.npm \
     npm run build
 
-# Production stage
-FROM node:22-alpine
+
+########### Runtime: minimal production image ###########
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 
-# Copy package file
-COPY ui/package.json ui/package-lock.json ./
-
-# Install production dependencies only
-# npm will automatically install correct platform-specific binaries (amd64 or arm64)
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev && \
-    npm cache clean --force
-
-# Copy built application and server entry from builder
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/server-start.js ./
-
-# Expose port
-EXPOSE 3030
-
-# Set environment variables
+# Set env before install so some libs can optimize for production
 ENV NODE_ENV=production
 ENV PORT=3030
 ENV HOST=0.0.0.0
 
-# Start the Node.js production server
-CMD ["node", "server-start.js"]
+# Install only production deps
+COPY ui/package.json ui/package-lock.json ./
 
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
+
+# Bring in built assets and server entry from builder
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/server-start.js ./
+
+EXPOSE 3030
+
+CMD ["node", "server-start.js"]


### PR DESCRIPTION
### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [ ] I understand that all AI assistance must be disclosed.
- [ ] I did **not** use AI tools in this contribution.
- [x] I used AI tools and have disclosed details below.

**Details (if applicable):**
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

Used gpt to help fix the errors in the build after version upgrade. The change involves not running clean cache on the stage 1 of the build 


---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
