### PR TITLE
Remove cache options from Docker build

### DIFF
--- a/.github/workflows/drift-release.yml
+++ b/.github/workflows/drift-release.yml
@@ -59,8 +59,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             VERSION=${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Removed caching options from Docker build step.

### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [ ] I understand that all AI assistance must be disclosed.
- [ ] I did **not** use AI tools in this contribution.
- [ ] I used AI tools and have disclosed details below.

**Details (if applicable):**
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
