### PR TITLE
projects build on every pr

### DIFF
--- a/.github/workflows/projects_refresh_image_build.yml
+++ b/.github/workflows/projects_refresh_image_build.yml
@@ -1,0 +1,37 @@
+name: projects-refresh-image-build
+
+on:
+  pull_request:
+    paths:
+      - background/projects-refresh-service/**
+      - Dockerfile_bg_projects_refresh
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build projects-refresh image (no push)
+        uses: depot/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile_bg_projects_refresh
+          platforms: linux/amd64
+          push: false
+          tags: ghcr.io/diggerhq/digger/projects-refresh-service:ci-test
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+


### PR DESCRIPTION
adding this  to be sure that changes to that service are tested for build success on every pr to avoid discovering after the merge happens