### PR TITLE
WIP: implement the current-state-version-outputs endpoint

### DIFF
--- a/taco/internal/api/internal.go
+++ b/taco/internal/api/internal.go
@@ -172,9 +172,11 @@ func RegisterInternalRoutes(e *echo.Echo, deps Dependencies) {
 	tfeInternal.POST("/workspaces/:workspace_id/actions/force-unlock", tfeHandler.ForceUnlockWorkspace)
 	tfeInternal.GET("/workspaces/:workspace_id/current-state-version", tfeHandler.GetCurrentStateVersion)
 	tfeInternal.POST("/workspaces/:workspace_id/state-versions", tfeHandler.CreateStateVersion)
+	tfeInternal.GET("/workspaces/:workspace_id/current-state-version-outputs", tfeHandler.GetCurrentStateVersionOutputs)
 	tfeInternal.GET("/state-versions/:id/download", tfeHandler.DownloadStateVersion)
 	tfeInternal.GET("/state-versions/:id", tfeHandler.ShowStateVersion)
-	
+
+
 	log.Println("TFE API endpoints registered at /internal/tfe/api/v2 with webhook auth")
 	
 	// ====================================================================================

--- a/taco/internal/api/routes.go
+++ b/taco/internal/api/routes.go
@@ -274,6 +274,7 @@ func RegisterRoutes(e *echo.Echo, deps Dependencies) {
 	tfeGroup.POST("/workspaces/:workspace_id/actions/force-unlock", tfeHandler.ForceUnlockWorkspace)
 	tfeGroup.GET("/workspaces/:workspace_id/current-state-version", tfeHandler.GetCurrentStateVersion)
 	tfeGroup.POST("/workspaces/:workspace_id/state-versions", tfeHandler.CreateStateVersion)
+	tfeGroup.GET("/workspaces/:workspace_id/current-state-version-outputs", tfeHandler.GetCurrentStateVersionOutputs)
 	tfeGroup.GET("/state-versions/:id", tfeHandler.ShowStateVersion)
 
 	// Upload/Download endpoints use signed URLs instead of auth middleware

--- a/taco/internal/domain/tfe/state.go
+++ b/taco/internal/domain/tfe/state.go
@@ -1,0 +1,23 @@
+package tfe
+
+// StateVersionOutput represents a single output value attached to a state
+// version in the Terraform Cloud / Enterprise JSON API.
+type StateVersionOutput struct {
+	// Primary identifier for this output resource.
+	ID string `jsonapi:"primary,state-version-outputs" json:"id"`
+
+	// Logical name of the output, e.g. "db_endpoint".
+	Name string `jsonapi:"attr,name" json:"name"`
+
+	// If true, the value should be treated as secret/redacted.
+	Sensitive bool `jsonapi:"attr,sensitive" json:"sensitive"`
+
+	// Terraform type string for the value, such as "string", "number", "map", etc.
+	Type string `jsonapi:"attr,type" json:"type"`
+
+	// Actual value of the output as returned by the API.
+	Value interface{} `jsonapi:"attr,value" json:"value"`
+}
+
+
+

--- a/taco/internal/tfe/state.go
+++ b/taco/internal/tfe/state.go
@@ -1,0 +1,135 @@
+package tfe
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/diggerhq/digger/opentaco/internal/domain/tfe"
+	"github.com/diggerhq/digger/opentaco/internal/logging"
+	"github.com/diggerhq/digger/opentaco/internal/storage"
+	"github.com/google/jsonapi"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+func (h *TfeHandler) GetCurrentStateVersionOutputs(c echo.Context) error {
+	logger := logging.FromContext(c)
+	c.Response().Header().Set(echo.HeaderContentType, "application/vnd.api+json")
+	c.Response().Header().Set("Tfp-Api-Version", "2.5")
+	c.Response().Header().Set("X-Terraform-Enterprise-App", "Terraform Enterprise")
+
+	// Extract workspace ID (format: ws-{workspace-name})
+	workspaceID := extractWorkspaceIDFromParam(c)
+	if workspaceID == "" {
+		logger.Warn("Missing workspace ID",
+			"operation", "tfe_get_current_state",
+		)
+		return c.JSON(400, map[string]string{"error": "workspace_id required"})
+	}
+
+	// Strip ws- prefix to get workspace name
+	workspaceName := convertWorkspaceToStateID(workspaceID)
+
+	// Get org from authentication context (JWT claim or webhook header)
+	orgIdentifier, err := getOrgFromContext(c)
+	if err != nil {
+		logger.Error("Failed to get org from context",
+			"operation", "tfe_get_current_state",
+			"workspace_id", workspaceID,
+			"error", err,
+		)
+		return c.JSON(http.StatusUnauthorized, map[string]string{
+			"error": "Organization context required",
+			"detail": err.Error(),
+		})
+	}
+
+	logger.Info("Getting current state version",
+		"operation", "tfe_get_current_state",
+		"workspace_id", workspaceID,
+		"workspace_name", workspaceName,
+		"org_identifier", orgIdentifier,
+	)
+
+	// Resolve to UUID/UUID path
+	stateID, err := h.convertWorkspaceToStateIDWithOrg(c.Request().Context(), orgIdentifier, workspaceName)
+	if err != nil {
+		return c.JSON(500, map[string]string{
+			"error": "failed to resolve workspace",
+			"detail": err.Error(),
+		})
+	}
+
+	// Extract unit UUID from state ID - repository expects just the UUID
+	unitUUID := extractUnitUUID(stateID)
+
+	// Download the state data
+	stateData, err := h.directStateStore.Download(c.Request().Context(), unitUUID)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			return c.JSON(404, map[string]string{"error": "State version not found"})
+		}
+		return c.JSON(500, map[string]string{"error": "Failed to download state"})
+	}
+
+	var st map[string]interface{}
+	var outputs []*tfe.StateVersionOutput
+	if uErr := json.Unmarshal(stateData, &st); uErr == nil {
+
+		raw, ok := st["outputs"]
+		if !ok {
+			return fmt.Errorf("state version outputs not found or failed to parse")
+		}
+
+		type TfeOutputEntry struct {
+			Value string `json:"value"`
+			Type  string `json:"type"`
+			Sensitive bool `json:"sensitive,omitempty"`
+		}
+
+		// raw is interface{} -> turn it back into JSON, then into typed map
+		b, err := json.Marshal(raw)
+		if err != nil {
+			return fmt.Errorf("failed to re-marshal outputs: %w", err)
+		}
+
+		m := map[string]TfeOutputEntry{}
+		if err := json.Unmarshal(b, &m); err != nil {
+			return fmt.Errorf("failed to unmarshal outputs as TfeOutputEntry: %w", err)
+		}
+
+		for name, v := range m {
+			// v = map[string]any for this output
+			b, _ := json.Marshal(v)
+
+			out := tfe.StateVersionOutput{
+				ID: uuid.NewString(),
+				Name: name,
+				Sensitive: v.Sensitive,
+				Type: v.Type,
+			}
+
+			if err := json.Unmarshal(b, &out); err != nil {
+				return nil // or return err
+			}
+
+			outputs = append(outputs, &out)
+		}
+
+	}
+
+	res := c.Response()
+	res.Header().Set(echo.HeaderContentType, jsonapi.MediaType)
+	res.WriteHeader(http.StatusOK)
+	
+	if err := jsonapi.MarshalPayload(res, outputs); err != nil {
+		// Response already has headers; last resort is 500 with plain text
+		slog.Error("failed to marshall json payload", "error", err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to marshal jsonapi")
+	}
+
+	return c.JSON(200, map[string]interface{}{})
+
+}


### PR DESCRIPTION
DO NOT MERGE yet

work in progress implementation for the "terraform output" endpoint support which is current-state-output-versions

Currently it pulls it from the latest statefile but we should consider having actual db entries for state versions to have them queryable by ID and so on.

### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [ ] I understand that all AI assistance must be disclosed.
- [x] I did **not** use AI tools in this contribution.
- [ ] I used AI tools and have disclosed details below.

**Details (if applicable):**
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
