### PR TITLE
add pod annotations to digger-backend helm chart

### DIFF
--- a/helm-charts/digger-backend/templates/backend-deployment.yaml
+++ b/helm-charts/digger-backend/templates/backend-deployment.yaml
@@ -11,6 +11,12 @@ spec:
     metadata:
       labels:
         app: {{ include "digger-backend.name" . }}-web
+      {{- if .Values.digger.podAnnotations }}
+      annotations:
+        {{- with .Values.digger.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       {{- if $.Values.digger.nodeSelector }}
       nodeSelector:

--- a/helm-charts/digger-backend/values.yaml
+++ b/helm-charts/digger-backend/values.yaml
@@ -17,6 +17,9 @@ digger:
   #     value: "another-value"
   customEnv: []
 
+  # Custom pod annotations to be added to the backend pod
+  podAnnotations: {}
+
   # Set the log level for the backend
   # DEBUG will enable the debug logs, any other value will set it to INFO
   logLevel: "INFO"


### PR DESCRIPTION
This PR will add the possibility to set pod annotations in the backend deployment.

#### ✅ AI Disclosure Checklist

- [x] I understand that all AI assistance must be disclosed.
- [ ] I did **not** use AI tools in this contribution.
- [x] I used AI tools and have disclosed details below.

**Details:**
Github copilot gpt-4.1 used for autocompletion
I know that doesn't require disclosure but with such a small PR i figure I might as well.

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
