### PR TITLE
Add changelog for November 14th, 2025

### DIFF
--- a/changelogs/November_14th_2025.md
+++ b/changelogs/November_14th_2025.md
@@ -1,0 +1,18 @@
+# 11/14
+
+We’ve been having a ton of sign ups on [otaco.app](http://otaco.app) after the launch, and also went live at our first conference earlier this week, we were diamond sponsors at OpenTofu day at Kubecon in Atlanta. It was quite an experience speaking to folks who had used OpenTaco already and was also interesting to learn about painpoints folks see in existing tooling. Below is an image of the booth!
+
+<img width="1600" height="1200" alt="Image" src="https://github.com/user-attachments/assets/fa07118b-ae9c-48f4-bd41-e599cf9277b8" />
+
+Now to move onto what we shipped this week:
+
+# **Remote runs POC (backend)  #2451**
+
+This PR implements the backend foundation for "Remote Runs," allowing OpenTaco to manage Terraform plan and apply executions directly. It introduces new database structures and TFE-compatible API endpoints to track runs, plans, and configuration versions, alongside dedicated executors that handle Terraform operations with automatic state locking. The update also adds secure log streaming, extends unit configuration with TFE-specific settings like execution mode and auto-apply, and includes the necessary database migrations and feature flags to support the rollout of managed remote execution.
+
+# Support caching of impacted projects #2452
+
+#2452 introduces a database-backed caching system to track "impacted projects" for each commit, improving the reliability of CI/CD workflows. It adds a new ImpactedProject model and corresponding database tables to persist which projects are affected and their execution status (planned vs. applied), replacing ephemeral in-memory checks. The update modifies PR and comment event handlers to populate this cache automatically and updates the auto-merge logic to verify project status directly from the database, ensuring more accurate validation before merging.
+
+We also had a whole host of fixes, something we’d expected after a blockbuster launch week!
+Full commit history is [here](https://github.com/diggerhq/digger/commits/develop/). If you do end up trying out OpenTaco v0.2, please do share your thoughts, we’re very hungry for feedback!


### PR DESCRIPTION
Added a detailed changelog for November 14th, 2025, highlighting new features, including Remote Runs POC and caching of impacted projects, along with a summary of the conference experience.

### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [x] I understand that all AI assistance must be disclosed.
- [ ] I did **not** use AI tools in this contribution.
- [x] I used AI tools and have disclosed details below.

**Details (if applicable):**
> used mintlify agent and chatgpt
---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
