### PR TITLE
change e2b template version

### DIFF
--- a/sandbox-sidecar/src/templateRegistry.ts
+++ b/sandbox-sidecar/src/templateRegistry.ts
@@ -8,7 +8,7 @@ export interface TemplateInfo {
 }
 
 // Template version - bump this when the build recipe changes
-const TEMPLATE_VERSION = "0.1.1";
+const TEMPLATE_VERSION = "0.1.2";
 
 // Generate alias matching the build system
 function aliasFor(engine: string, version: string, tplVersion: string): string {


### PR DESCRIPTION
Basically E2B templates were set to the version in my e2b account not the company one. 

### 🧠 AI Assistance Disclosure Policy

> [!IMPORTANT]  
> Inspired by [ghostty](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md#ai-assistance-notice).  
> If you used **any AI assistance** while contributing to Digger, you must disclose it in this PR.

---

#### ✅ AI Disclosure Checklist

- [ ] I understand that all AI assistance must be disclosed.
- [x] I did **not** use AI tools in this contribution.
- [ ] I used AI tools and have disclosed details below.

**Details (if applicable):**
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

---

#### 💡 Notes

- Trivial auto-completions (single words, short phrases) don’t need disclosure.
- Contributors must understand and take responsibility for any AI-assisted code.
- Failure to disclose is considered disrespectful to maintainers and may delay review.
