### PR TITLE
disable linkered for jobs so projects-refresh doesn't hang

### DIFF
--- a/backend/service_clients/k8s.go
+++ b/backend/service_clients/k8s.go
@@ -219,6 +219,9 @@ func (k K8sJobClient) TriggerProjectsRefreshService(
 			"repoFullName":  repoFullName,
 			"triggerSource": "orchestrator-api",
 		},
+		Annotations: map[string]string{
+			"linkerd.io/inject": "disabled",
+		},
 		Env: map[string]string{
 			"DIGGER_GITHUB_REPO_CLONE_URL":     cloneUrl,
 			"DIGGER_GITHUB_REPO_CLONE_BRANCH":       branch,


### PR DESCRIPTION
Linkered basically keeps the ephemeral jobs from terminating, need to disable linkered inject when creating them 

### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
Sonnet-4.5 for discussion 

