### PR TITLE
manual release for backend-ee

### DIFF
--- a/.github/workflows/auto-tag-and-release.yml
+++ b/.github/workflows/auto-tag-and-release.yml
@@ -143,7 +143,7 @@ jobs:
 
   tag-backend-ee:
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend_ee_changed == 'true'
+    if: false  # Disabled - manual tagging only
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/auto-tag-and-release.yml
+++ b/.github/workflows/auto-tag-and-release.yml
@@ -143,7 +143,7 @@ jobs:
 
   tag-backend-ee:
     needs: detect-changes
-    if: false  # Disabled - manual tagging only
+    if: needs.detect-changes.outputs.backend_ee_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-helm-on-release.yml
+++ b/.github/workflows/update-helm-on-release.yml
@@ -32,6 +32,8 @@ jobs:
             SERVICE="backend-ee"
             VERSION="${TAG_NAME##backend-ee/}"
             YAML_PATH=".taco-orchestrator.digger.image.tag"
+            echo "Backend EE detected - skipping helm update (disabled for manual control)"
+            exit 0
           elif [[ $TAG_NAME == drift/v* ]]; then
             SERVICE="drift"
             VERSION="${TAG_NAME##drift/}"


### PR DESCRIPTION
Remove backend-ee from auto release so we can deploy to staging or merge changes until it is ready

### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
N/a 

