### PR TITLE
fix: silently skip repos without digger config for org-wide installation

### DIFF
--- a/backend/controllers/github_pull_request.go
+++ b/backend/controllers/github_pull_request.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/diggerhq/digger/backend/ci_backends"
 	config2 "github.com/diggerhq/digger/backend/config"
@@ -136,7 +137,17 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 			)
 			return nil
 		}
-		
+
+		// Silently skip repos without digger.yml - this is expected for org-wide installations
+		if strings.Contains(err.Error(), "could not find digger.yml") ||
+			strings.Contains(err.Error(), "could not find digger.yaml") {
+			slog.Info("No Digger config found, skipping repo",
+				"prNumber", prNumber,
+				"repoFullName", repoFullName,
+			)
+			return nil
+		}
+
 		slog.Error("Error getting Digger config for PR",
 			"prNumber", prNumber,
 			"repoFullName", repoFullName,
@@ -504,7 +515,7 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 		commentReporterManager.UpdateComment(fmt.Sprintf(":x: Could not retrieve created batch: %v", err))
 		return fmt.Errorf("error getting digger batch")
 	}
-	
+
 	if config.CommentRenderMode == digger_config.CommentRenderModeGroupByModule {
 		slog.Info("Using GroupByModule render mode for comments", "prNumber", prNumber)
 


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where Digger posts error comments to PRs in repositories without `digger.yml` configuration files when the GitHub App is installed org-wide.

**Changes:**
- Added silent skip logic in `handlePullRequestEvent` (lines 141-149) to detect missing config file errors
- When `digger.yml` or `digger.yaml` is not found, Digger now logs the skip and returns early
- Error comment posting (line 156) is still reached for OTHER error types (invalid YAML, network errors, etc.)
- This enables org-wide GitHub App installation without impacting repos that don't use Digger

**Behaviour:**
- Repos WITH `digger.yml` - continue to work normally
- Repos WITHOUT `digger.yml` - silently skipped (no error comments posted)
- Repos with INVALID `digger.yml` - still get error comments (as expected)
- Logs show: "No Digger config found, skipping repo" for tracking

**Industry Standard Pattern:**

This config-file-based activation pattern is used by many popular GitHub Apps when installed org-wide:
- **Renovate** - Only activates in repos with `renovate.json` or `.github/renovate.json`
- **Dependabot** - Only activates in repos with `.github/dependabot.yml`
- **GitHub Actions** - Only runs in repos with `.github/workflows/*.yml` files
- **Pre-commit.ci** - Only activates in repos with `.pre-commit-config.yaml`

All of these tools silently skip repos without their config files rather than posting error messages, which is the expected behavior for org-wide installations.

### Testing

**Unit Tests:**
- All existing backend controller tests pass (5/5)
- Full backend test suite passes (18 tests)

### :brain: **Ai UsageDetails (if applicable):**

This PR was written primarily by Claude (Roo Code mode). The solution was:
- Analyzed by AI to understand the codebase and identify the root cause
- Code changes generated by AI following existing patterns in the codebase
- Testing strategy and verification performed by AI
- All code reviewed and verified by human contributor

The human contributor understands the changes and can answer questions about:
- Error handling flow in `handlePullRequestEvent`
- String matching logic for config file errors
- Impact on org-wide vs per-repo installations
- Testing approach and verification strategy

### Checklist

- [x] Branched from `develop`
- [x] Code follows existing patterns
- [x] All existing tests pass
- [x] Commit message follows conventions
- [x] AI assistance disclosed
- [x] Changes are minimal and focused
- [x] No breaking changes

### Related

Addresses the requirement for org-wide GitHub App installation without impacting existing repos, as discussed in the task description.