### PR TITLE
use goroutines during checks to fix the latency issue

### DIFF
--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -22,9 +22,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test that the docker image still builds successfully
-        run: |
-          export COMMIT_SHA=$(git rev-parse --short HEAD)
-          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
+        uses: depot/setup-action@v1
+      
+      - name: Build Docker image with Depot
+        uses: depot/build-push-action@v1
+        with:
+          project: f11hp4hlmg
+          token: ${{ secrets.DEPOT_TOKEN }}
+          context: .
+          file: ./Dockerfile_backend
+          push: false
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
 
       - name: Deps
         run: go get -v ./...

--- a/.github/workflows/ee_backend_test.yml
+++ b/.github/workflows/ee_backend_test.yml
@@ -22,9 +22,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test that the docker image still builds successfully
-        run: |
-          export COMMIT_SHA=$(git rev-parse --short HEAD)
-          docker build -t testingbuild:latest --build-arg COMMIT_SHA=${COMMIT_SHA} . -f Dockerfile_backend
+        uses: depot/setup-action@v1
+      
+      - name: Build Docker image with Depot
+        uses: depot/build-push-action@v1
+        with:
+          project: kcld4zgwzx
+          token: ${{ secrets.DEPOT_TOKEN }}
+          context: .
+          file: ./Dockerfile_backend_ee
+          push: false
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
 
       - name: Deps
         run: go get -v ./...

--- a/.github/workflows/update-helm-on-release.yml
+++ b/.github/workflows/update-helm-on-release.yml
@@ -32,8 +32,6 @@ jobs:
             SERVICE="backend-ee"
             VERSION="${TAG_NAME##backend-ee/}"
             YAML_PATH=".taco-orchestrator.digger.image.tag"
-            echo "Backend EE detected - skipping helm update (disabled for manual control)"
-            exit 0
           elif [[ $TAG_NAME == drift/v* ]]; then
             SERVICE="drift"
             VERSION="${TAG_NAME##drift/}"

--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -1031,18 +1031,22 @@ func (d DiggerController) SetJobStatusForProject(c *gin.Context) {
 		"checkRunId", refreshedBatch.CheckRunId,
 		"vcs", refreshedBatch.VCS,
 		"jobId", jobId)
-	err = UpdateCheckRunForBatch(d.GithubClientProvider, refreshedBatch)
-	if err != nil {
-		slog.Warn("DIAGNOSTIC #7: Failed to update GitHub Check Run for batch (non-fatal)",
-			"batchId", batch.ID,
-			"checkRunId", refreshedBatch.CheckRunId,
-			"vcs", refreshedBatch.VCS,
-			"error", err,
-			"errorType", fmt.Sprintf("%T", err))
-				// Continue processing - Check Run update is best-effort, not critical
-	} else {
-		slog.Debug("Successfully updated GitHub Check Run for batch", "batchId", batch.ID)
-	}
+
+	// performing this in a goroutine to avoid huge latencies (added by ai summary gen)
+	go func() {
+		err = UpdateCheckRunForBatch(d.GithubClientProvider, refreshedBatch)
+		if err != nil {
+			slog.Warn("DIAGNOSTIC #7: Failed to update GitHub Check Run for batch (non-fatal)",
+				"batchId", batch.ID,
+				"checkRunId", refreshedBatch.CheckRunId,
+				"vcs", refreshedBatch.VCS,
+				"error", err,
+				"errorType", fmt.Sprintf("%T", err))
+			// Continue processing - Check Run update is best-effort, not critical
+		} else {
+			slog.Debug("Successfully updated GitHub Check Run for batch", "batchId", batch.ID)
+		}
+	}()
 
 	slog.Debug("Fetching refreshed job", "jobId", jobId, "batchId", batch.ID)
 	refreshedJob, err := models.DB.GetDiggerJob(jobId)
@@ -1060,19 +1064,24 @@ func (d DiggerController) SetJobStatusForProject(c *gin.Context) {
 		"checkRunId", refreshedJob.CheckRunId,
 		"vcs", refreshedJob.Batch.VCS,
 		"batchId", batch.ID)
-	err = UpdateCheckRunForJob(d.GithubClientProvider, refreshedJob)
-	if err != nil {
-		slog.Warn("DIAGNOSTIC #9: Failed to update GitHub Check Run for job (non-fatal)",
-			"jobId", jobId,
-			"checkRunId", refreshedJob.CheckRunId,
-			"batchId", batch.ID,
-			"vcs", refreshedJob.Batch.VCS,
-			"error", err,
-			"errorType", fmt.Sprintf("%T", err))
-		// Continue processing - Check Run update is best-effort, not critical
-	} else {
-		slog.Debug("Successfully updated GitHub Check Run for job", "jobId", jobId)
-	}
+
+	// performing this in a goroutine to avoid huge latencies (added by ai summary gen)
+	go func() {
+		err = UpdateCheckRunForJob(d.GithubClientProvider, refreshedJob)
+		if err != nil {
+			slog.Warn("DIAGNOSTIC #9: Failed to update GitHub Check Run for job (non-fatal)",
+				"jobId", jobId,
+				"checkRunId", refreshedJob.CheckRunId,
+				"batchId", batch.ID,
+				"vcs", refreshedJob.Batch.VCS,
+				"error", err,
+				"errorType", fmt.Sprintf("%T", err))
+			// Continue processing - Check Run update is best-effort, not critical
+		} else {
+			slog.Debug("Successfully updated GitHub Check Run for job", "jobId", jobId)
+		}
+	}()
+
 
 	if batch.ReportTerraformOutputs {
 		slog.Info("Generating Terraform outputs summary", "batchId", batch.ID)


### PR DESCRIPTION
we have spiky latencies in the "set-status" endpoint. On inspection of logs I found that the biggest factor is the summary generator service. To avoid huge latency in response and http timeout instead 