### PR TITLE
overide get_env function to avoid generation errors

### DIFF
--- a/libs/digger_config/terragrunt/tac/base_blocks.go
+++ b/libs/digger_config/terragrunt/tac/base_blocks.go
@@ -2,6 +2,9 @@ package tac
 
 import (
 	"fmt"
+	"log/slog"
+	"strings"
+
 	"github.com/gruntwork-io/go-commons/errors"
 	"github.com/gruntwork-io/terragrunt/config"
 	"github.com/gruntwork-io/terragrunt/options"
@@ -11,8 +14,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
-	"log/slog"
-	"strings"
 )
 
 const (
@@ -184,6 +185,7 @@ func attemptEvaluateLocals(
 	}
 
 	evalCtx.Functions[config.FuncNameSopsDecryptFile] = wrapStringSliceToStringAsFuncImpl(NoopSopsDecryptFile, contextExtensions.TrackInclude, terragruntOptions)
+	evalCtx.Functions[config.FuncNameGetEnv] = wrapStringSliceToStringAsFuncImpl(NoopGetEnv, contextExtensions.TrackInclude, terragruntOptions)
 
 	// Track the locals that were evaluated for logging purposes
 	newlyEvaluatedLocalNames := []string{}

--- a/libs/digger_config/terragrunt/tac/context.go
+++ b/libs/digger_config/terragrunt/tac/context.go
@@ -15,5 +15,7 @@ func CreateTerragruntEvalContext(extensions config.EvalContextExtensions, filena
 
 	// override sops_decrypt_file function
 	ctx.Functions[config.FuncNameSopsDecryptFile] = wrapStringSliceToStringAsFuncImpl(NoopSopsDecryptFile, extensions.TrackInclude, terragruntOptions)
+	ctx.Functions[config.FuncNameSopsDecryptFile] = wrapStringSliceToStringAsFuncImpl(NoopGetEnv, extensions.TrackInclude, terragruntOptions)
+
 	return ctx, nil
 }

--- a/libs/digger_config/terragrunt/tac/sops_custom_fn.go
+++ b/libs/digger_config/terragrunt/tac/sops_custom_fn.go
@@ -45,3 +45,8 @@ func NoopSopsDecryptFile(params []string, trackInclude *config.TrackInclude, ter
 	terragruntOptions.Logger.Debugf("SOPS decryption function has been replaced with a no-op version. This is to ensure that generation of projects is successful.")
 	return "{}", nil
 }
+
+func NoopGetEnv(params []string, trackInclude *config.TrackInclude, terragruntOptions *options.TerragruntOptions) (string, error) {
+	terragruntOptions.Logger.Debugf("get_env function has been replaced with a no-op version. This is to ensure that generation of projects is successful.")
+	return "", nil
+}


### PR DESCRIPTION
Since terragrunt generation and parsing happens on the backend, the function get_env('XYZ") in any terragrunt module would throw an exception:

<img width="1972" height="604" alt="Screenshot 2025-12-09 at 11 32 39" src="https://github.com/user-attachments/assets/1960d878-548a-4877-b466-81468a80721c" />



This is solved by overriding that function during generation as well

* No ai used