### PR TITLE
Fix: include_patterns ignored for terragrunt blocks without direct changes

### DIFF
--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -419,57 +419,55 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string, 
 			// if blocks of include/exclude patterns defined
 			for _, b := range config.GenerateProjectsConfig.Blocks {
 				if b.Terragrunt == true {
-					if checkBlockInChangedFiles(*b.RootDir, changedFiles) {
-						slog.Info("generating terragrunt projects for block",
-							"blockName", b.BlockName,
-							"rootDir", *b.RootDir)
+					slog.Info("generating terragrunt projects for block",
+						"blockName", b.BlockName,
+						"rootDir", *b.RootDir)
 
-						workflow := "default"
-						if b.Workflow != "" {
-							workflow = b.Workflow
-						}
+					workflow := "default"
+					if b.Workflow != "" {
+						workflow = b.Workflow
+					}
 
-						// load the parsing config and override the block values
-						tgParsingConfig := b.TerragruntParsingConfig
-						if tgParsingConfig == nil {
-							tgParsingConfig = &TerragruntParsingConfig{}
-						}
-						tgParsingConfig.CreateProjectName = true
-						tgParsingConfig.DefaultWorkflow = workflow
-						tgParsingConfig.WorkflowFile = b.WorkflowFile
-						tgParsingConfig.FilterPaths = []string{path.Join(terraformDir, *b.RootDir)}
-						tgParsingConfig.AwsRoleToAssume = b.AwsRoleToAssume
-						tgParsingConfig.AwsCognitoOidcConfig = b.AwsCognitoOidcConfig
+					// load the parsing config and override the block values
+					tgParsingConfig := b.TerragruntParsingConfig
+					if tgParsingConfig == nil {
+						tgParsingConfig = &TerragruntParsingConfig{}
+					}
+					tgParsingConfig.CreateProjectName = true
+					tgParsingConfig.DefaultWorkflow = workflow
+					tgParsingConfig.WorkflowFile = b.WorkflowFile
+					tgParsingConfig.FilterPaths = []string{path.Join(terraformDir, *b.RootDir)}
+					tgParsingConfig.AwsRoleToAssume = b.AwsRoleToAssume
+					tgParsingConfig.AwsCognitoOidcConfig = b.AwsCognitoOidcConfig
 
-						_, err := hydrateDiggerConfigYamlWithTerragrunt(config, *tgParsingConfig, terraformDir, b.BlockName, nil)
-						if err != nil {
-							slog.Error("failed to hydrate config with terragrunt",
-								"error", err,
-								"blockName", b.BlockName)
-							return nil, err
-						}
-						if len(b.IncludePatterns) > 0 || len(b.ExcludePatterns) > 0 {
-							for _, project := range config.Projects {
-								if project.BlockName == b.BlockName && project.Terragrunt {
-									if len(b.IncludePatterns) > 0 {
-										project.IncludePatterns = append(project.IncludePatterns, b.IncludePatterns...)
-										slog.Debug("merged include_patterns for terragrunt project",
-											"projectName", project.Name,
-											"blockName", b.BlockName,
-											"includePatterns", project.IncludePatterns)
-									}
-									if len(b.ExcludePatterns) > 0 {
-										project.ExcludePatterns = append(project.ExcludePatterns, b.ExcludePatterns...)
-										slog.Debug("merged exclude_patterns for terragrunt project",
-											"projectName", project.Name,
-											"blockName", b.BlockName,
-											"excludePatterns", project.ExcludePatterns)
-									}
+					_, err := hydrateDiggerConfigYamlWithTerragrunt(config, *tgParsingConfig, terraformDir, b.BlockName, nil)
+					if err != nil {
+						slog.Error("failed to hydrate config with terragrunt",
+							"error", err,
+							"blockName", b.BlockName)
+						return nil, err
+					}
+					// Always merge include_patterns and exclude_patterns, regardless of direct changes
+					// This ensures patterns are evaluated even when only files matching include_patterns change
+					if len(b.IncludePatterns) > 0 || len(b.ExcludePatterns) > 0 {
+						for _, project := range config.Projects {
+							if project.BlockName == b.BlockName && project.Terragrunt {
+								if len(b.IncludePatterns) > 0 {
+									project.IncludePatterns = append(project.IncludePatterns, b.IncludePatterns...)
+									slog.Debug("merged include_patterns for terragrunt project",
+										"projectName", project.Name,
+										"blockName", b.BlockName,
+										"includePatterns", project.IncludePatterns)
+								}
+								if len(b.ExcludePatterns) > 0 {
+									project.ExcludePatterns = append(project.ExcludePatterns, b.ExcludePatterns...)
+									slog.Debug("merged exclude_patterns for terragrunt project",
+										"projectName", project.Name,
+										"blockName", b.BlockName,
+										"excludePatterns", project.ExcludePatterns)
 								}
 							}
 						}
-					} else {
-						slog.Debug("skipping block due to no changed files", "blockName", b.BlockName)
 					}
 				} else {
 					includePatterns = []string{b.Include}


### PR DESCRIPTION
## Summary

This PR fixes issue #2485 where `include_patterns` were only evaluated when at least one project had direct file changes in its root directory.

## Problem

The bug was in the `HandleYamlProjectGeneration` function where the entire terragrunt block processing (including the merging of `include_patterns` and `exclude_patterns`) was wrapped in a `checkBlockInChangedFiles()` conditional at line 422.

This caused three different behaviors:

**Case 1 (Working):** Modifying files within a project → Project is planned ✅
**Case 2 (Working):** Modifying both project files AND files matching `include_patterns` → All projects are planned ✅  
**Case 3 (Broken):** Modifying only files matching `include_patterns` → No projects are planned ❌

## Solution

Removed the `checkBlockInChangedFiles()` conditional wrapper that was preventing pattern evaluation. Now:

- Terragrunt projects are always generated for blocks
- `include_patterns` and `exclude_patterns` are always merged into projects
- Pattern matching occurs in `GetModifiedProjects()` regardless of direct project changes
- Behavior is now consistent with non-terragrunt blocks

## Changes

- **File modified:** `libs/digger_config/digger_config.go`
- **Lines affected:** 419-473
- Removed conditional check that wrapped terragrunt block processing
- Added clarifying comment explaining the fix

## Test plan

- [ ] Verify that projects are detected when only `include_patterns` files change
- [ ] Verify that projects are still detected when direct project files change
- [ ] Verify that projects are detected when both direct and `include_patterns` files change
- [ ] Run existing tests to ensure no regressions

Fixes #2485

🤖 Generated with [Claude Code](https://claude.com/claude-code)