### PR TITLE
docs: replace old digger GH app with otaco

### DIFF
--- a/docs/ce/getting-started/github-actions-+-aws.mdx
+++ b/docs/ce/getting-started/github-actions-+-aws.mdx
@@ -17,7 +17,7 @@ You should see onboarding screen after you sign up, which guides you to install 
 
 # Step 2: install the Digger GitHub App
 
-Install the Digger [GitHub App](https://github.com/apps/digger-pro) into your repository.
+Install the Digger [GitHub App](https://github.com/apps/opentaco-cloud/installations/select_target) into your repository.
 
 <Note>
 Digger GitHub App does not need access to your cloud account, it just starts jobs in your CI. All sensitive data stays in your CI job.

--- a/docs/ce/getting-started/github-actions-and-gcp.mdx
+++ b/docs/ce/getting-started/github-actions-and-gcp.mdx
@@ -17,7 +17,7 @@ You should see onboarding screen after you sign up, which guides you to install 
 
 # Step 2: install the Digger GitHub App
 
-Install the Digger [GitHub App](https://github.com/apps/digger-pro) into your repository.
+Install the Digger [GitHub App](https://github.com/apps/opentaco-cloud/installations/select_target) into your repository.
 
 <Note>
 Digger GitHub App does not need access to your cloud account, it just starts jobs in your CI. All sensitive data stays in your CI job.

--- a/docs/ce/getting-started/with-opentofu.mdx
+++ b/docs/ce/getting-started/with-opentofu.mdx
@@ -21,7 +21,7 @@ You should see an empty dashboard after you sign up.
 
   <Step title="Install the Digger GitHub App">
 
-Install the Digger [GitHub App](https://github.com/apps/digger-pro/installations/select_target) into your repository.
+Install the Digger [GitHub App](https://github.com/apps/opentaco-cloud/installations/select_target) into your repository.
 
 <Note>
 Digger GitHub App does not need access to your cloud account, it just starts jobs in your CI. All sensitive data stays in your CI job.

--- a/docs/ce/getting-started/with-terragrunt.mdx
+++ b/docs/ce/getting-started/with-terragrunt.mdx
@@ -21,7 +21,7 @@ You should see an empty dashboard after you sign up.
 
   <Step title="Install the Digger GitHub App">
 
-Install the Digger [GitHub App](https://github.com/apps/digger-pro/installations/select_target) into your repository.
+Install the Digger [GitHub App](https://github.com/apps/opentaco-cloud/installations/select_target) into your repository.
 
 <Note>
 Digger GitHub App does not need access to your cloud account, it just starts jobs in your CI. All sensitive data stays in your CI job.


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**
NA

This PR updates links to the GitHub app, which was previously Digger Pro, with the move to Otaco; some of the existing links broke. 

This should also fix #2464 