### PR TITLE
feat/plan policies extra data

### DIFF
--- a/backend/controllers/github_comment.go
+++ b/backend/controllers/github_comment.go
@@ -522,6 +522,17 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		impactedProjectsMap[p.Name] = p
 	}
 
+	// Compute teams, approvals, and approval_teams for policy evaluation
+	err = populatePolicyFieldsForJobs(ghService, ghService, jobs, repoOwner, issueNumber)
+	if err != nil {
+		slog.Error("Error populating policy fields for jobs",
+			"issueNumber", issueNumber,
+			"error", err,
+		)
+		// Don't fail the entire process, just log the error
+		// The CLI will use empty values if these aren't populated
+	}
+
 	impactedProjectsJobMap := make(map[string]scheduler.Job)
 	for _, j := range jobs {
 		impactedProjectsJobMap[j.ProjectName] = j

--- a/backend/controllers/github_helpers.go
+++ b/backend/controllers/github_helpers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/diggerhq/digger/libs/digger_config"
 	"github.com/diggerhq/digger/libs/digger_config/terragrunt/tac"
 	"github.com/diggerhq/digger/libs/git_utils"
+	"github.com/diggerhq/digger/libs/scheduler"
 	"github.com/dominikbraun/graph"
 	"github.com/google/go-github/v61/github"
 	"github.com/google/uuid"
@@ -972,4 +973,82 @@ generate_projects:
 
 	slog.Info("Created Digger repo", "repoId", repo.ID, "diggerRepoName", diggerRepoName)
 	return repo, org, nil
+}
+
+// populatePolicyFieldsForJobs computes teams, approvals, and approval_teams for all jobs
+// These values are computed on the backend/webhook side and passed through to the CLI
+func populatePolicyFieldsForJobs(ghService *github2.GithubService, orgService ci.OrgService, jobs []scheduler.Job, repoOwner string, prNumber int) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+
+	// All jobs are from the same user and PR, so compute once
+	firstJob := jobs[0]
+	requestedBy := firstJob.RequestedBy
+
+	slog.Debug("Computing policy fields for jobs",
+		"requestedBy", requestedBy,
+		"prNumber", prNumber,
+		"jobCount", len(jobs),
+	)
+
+	// Compute user teams
+	teams, err := orgService.GetUserTeams(repoOwner, requestedBy)
+	if err != nil {
+		slog.Warn("Failed to get user teams, using empty list",
+			"requestedBy", requestedBy,
+			"repoOwner", repoOwner,
+			"error", err,
+		)
+		teams = []string{}
+	}
+
+	// Compute PR approvals
+	approvals, err := ghService.GetApprovals(prNumber)
+	if err != nil {
+		slog.Warn("Failed to get PR approvals, using empty list",
+			"prNumber", prNumber,
+			"error", err,
+		)
+		approvals = []string{}
+	}
+
+	// Compute approval teams (teams that approvers belong to)
+	approvalTeamsSet := make(map[string]bool)
+	for _, approver := range approvals {
+		approverTeams, err := orgService.GetUserTeams(repoOwner, approver)
+		if err != nil {
+			slog.Warn("Failed to get teams for approver",
+				"approver", approver,
+				"error", err,
+			)
+			continue
+		}
+		for _, team := range approverTeams {
+			approvalTeamsSet[team] = true
+		}
+	}
+
+	// Convert set to slice
+	approvalTeams := make([]string, 0, len(approvalTeamsSet))
+	for team := range approvalTeamsSet {
+		approvalTeams = append(approvalTeams, team)
+	}
+
+	slog.Info("Computed policy fields for jobs",
+		"requestedBy", requestedBy,
+		"prNumber", prNumber,
+		"teamsCount", len(teams),
+		"approvalsCount", len(approvals),
+		"approvalTeamsCount", len(approvalTeams),
+	)
+
+	// Populate all jobs with the same values
+	for i := range jobs {
+		jobs[i].Teams = teams
+		jobs[i].Approvals = approvals
+		jobs[i].ApprovalTeams = approvalTeams
+	}
+
+	return nil
 }

--- a/backend/controllers/github_pull_request.go
+++ b/backend/controllers/github_pull_request.go
@@ -500,6 +500,25 @@ func handlePullRequestEvent(gh utils.GithubClientProvider, payload *github.PullR
 
 	}
 
+	// Compute teams, approvals, and approval_teams for policy evaluation
+	jobsSlice := make([]scheduler.Job, 0, len(impactedJobsMap))
+	for _, job := range impactedJobsMap {
+		jobsSlice = append(jobsSlice, job)
+	}
+	err = populatePolicyFieldsForJobs(ghService, ghService, jobsSlice, repoOwner, prNumber)
+	if err != nil {
+		slog.Error("Error populating policy fields for jobs",
+			"prNumber", prNumber,
+			"error", err,
+		)
+		// Don't fail the entire process, just log the error
+		// The CLI will use empty values if these aren't populated
+	}
+	// Update the map with populated jobs
+	for i, job := range jobsSlice {
+		impactedJobsMap[job.ProjectName] = jobsSlice[i]
+	}
+
 	batchId, _, err := utils.ConvertJobsToDiggerJobs(*diggerCommand, reporterType, models.DiggerVCSGithub, organisationId, impactedJobsMap, impactedProjectsMap, projectsGraph, installationId, branch, prNumber, repoOwner, repoName, repoFullName, commitSha, &commentId, diggerYmlStr, 0, aiSummaryCommentId, config.ReportTerraformOutputs, coverAllImpactedProjects, nil, batchCheckRunData, jobsCheckRunIdsMap)
 	if err != nil {
 		slog.Error("Error converting jobs to Digger jobs",

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -335,7 +335,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			if isNonEmptyPlan {
 				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
 
-				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, planJsonOutput)
+				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, planJsonOutput)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to validate plan. %v", err)
 					slog.Error("Failed to validate plan.", "error", err)
@@ -431,7 +431,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					return nil, msg, fmt.Errorf("%s", msg)
 				}
 
-				_, violations, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, terraformPlanJsonStr)
+				_, violations, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, terraformPlanJsonStr)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to check plan policy. %v", err)
 					slog.Error("Failed to check plan policy.", "error", err)
@@ -711,7 +711,7 @@ func RunJob(
 				slog.Error(msg)
 				return fmt.Errorf("%s", msg)
 			}
-			planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, planJsonOutput)
+			planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, planJsonOutput)
 			slog.Info(strings.Join(messages, "\n"))
 			if err != nil {
 				msg := fmt.Sprintf("Failed to validate plan %v", err)

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -75,50 +75,29 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 	exectorResults := make([]execution.DiggerExecutorResult, len(jobs))
 	appliesPerProject := make(map[string]bool)
 
-	// Compute teams and approvals once for all jobs (assumes all jobs are from the same user and PR)
-	var teams []string
-	var approvals []string
-	var requestedBy string
-	var prNumber *int
-	var SCMOrganisation string
-
-	if len(jobs) > 0 {
-		firstJob := jobs[0]
-		splits := strings.Split(firstJob.Namespace, "/")
-		SCMOrganisation = splits[0]
-		requestedBy = firstJob.RequestedBy
-		prNumber = firstJob.PullRequestNumber
-
-		var err error
-		teams, err = orgService.GetUserTeams(SCMOrganisation, requestedBy)
-		if err != nil {
-			slog.Error("Error fetching user teams",
-				"organisation", SCMOrganisation,
-				"user", requestedBy,
-				"error", err)
-			slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
-			teams = []string{}
-		}
-
-		// Compute approvals for the PR (if applicable)
-		approvals = make([]string, 0)
-		if prNumber != nil {
-			approvals, err = prService.GetApprovals(*prNumber)
-			if err != nil {
-				slog.Warn("Failed to get PR approvals",
-					"prNumber", *prNumber,
-					"error", err)
-			}
-		}
-	}
-
 	for i, job := range jobs {
 		splits := strings.Split(job.Namespace, "/")
 		SCMOrganisation := splits[0]
 		SCMrepository := splits[1]
 
+		// Use teams, approvals, and approval_teams from the job (computed on backend/webhook side)
+		teams := job.Teams
+		approvals := job.Approvals
+		approvalTeams := job.ApprovalTeams
+
+		// Initialize as empty slices if nil to avoid nil pointer issues
+		if teams == nil {
+			teams = []string{}
+		}
+		if approvals == nil {
+			approvals = []string{}
+		}
+		if approvalTeams == nil {
+			approvalTeams = []string{}
+		}
+
 		for _, command := range job.Commands {
-			allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, job.RequestedBy, teams, approvals, []string{})
+			allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, job.RequestedBy, teams, approvals, approvalTeams, []string{})
 
 			if err != nil {
 				return false, false, fmt.Errorf("error checking policy: %v", err)
@@ -222,29 +201,23 @@ func reportPolicyError(projectName string, command string, requestedBy string, r
 func run(command string, job orchestrator.Job, policyChecker policy.Checker, orgService ci.OrgService, SCMOrganisation string, SCMrepository string, PRNumber *int, requestedBy string, reporter reporting.Reporter, lock locking2.Lock, prService ci.PullRequestService, projectNamespace string, workingDir string, planStorage storage.PlanStorage, appliesPerProject map[string]bool) (*execution.DiggerExecutorResult, string, error) {
 	slog.Info("Running command for project", "command", command, "project name", job.ProjectName, "project workflow", job.ProjectWorkflow)
 
-	// Compute teams for the user
-	teams, err := orgService.GetUserTeams(SCMOrganisation, requestedBy)
-	if err != nil {
-		slog.Error("Error fetching user teams",
-			"organisation", SCMOrganisation,
-			"user", requestedBy,
-			"error", err)
-		slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
+	// Use teams, approvals, and approval_teams from the job (computed on backend/webhook side)
+	teams := job.Teams
+	approvals := job.Approvals
+	approvalTeams := job.ApprovalTeams
+
+	// Initialize as empty slices if nil to avoid nil pointer issues
+	if teams == nil {
 		teams = []string{}
 	}
-
-	// Compute approvals for the PR (if applicable)
-	var approvals = make([]string, 0)
-	if job.PullRequestNumber != nil {
-		approvals, err = prService.GetApprovals(*job.PullRequestNumber)
-		if err != nil {
-			slog.Warn("Failed to get PR approvals",
-				"prNumber", *job.PullRequestNumber,
-				"error", err)
-		}
+	if approvals == nil {
+		approvals = []string{}
+	}
+	if approvalTeams == nil {
+		approvalTeams = []string{}
 	}
 
-	allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, []string{})
+	allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, []string{})
 
 	if err != nil {
 		return nil, "error checking policy", fmt.Errorf("error checking policy: %v", err)
@@ -335,7 +308,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			if isNonEmptyPlan {
 				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
 
-				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, planJsonOutput)
+				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, approvalTeams, planJsonOutput)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to validate plan. %v", err)
 					slog.Error("Failed to validate plan.", "error", err)
@@ -431,7 +404,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					return nil, msg, fmt.Errorf("%s", msg)
 				}
 
-				_, violations, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, terraformPlanJsonStr)
+				_, violations, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, approvalTeams, terraformPlanJsonStr)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to check plan policy. %v", err)
 					slog.Error("Failed to check plan policy.", "error", err)
@@ -443,28 +416,8 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 				planPolicyViolations = []string{}
 			}
 
-			// Re-compute teams and approvals for apply command
-			teams, err := orgService.GetUserTeams(SCMOrganisation, requestedBy)
-			if err != nil {
-				slog.Error("Error fetching user teams",
-					"organisation", SCMOrganisation,
-					"user", requestedBy,
-					"error", err)
-				slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
-				teams = []string{}
-			}
-
-			var approvals = make([]string, 0)
-			if job.PullRequestNumber != nil {
-				approvals, err = prService.GetApprovals(*job.PullRequestNumber)
-				if err != nil {
-					slog.Warn("Failed to get PR approvals",
-						"prNumber", *job.PullRequestNumber,
-						"error", err)
-				}
-			}
-
-			allowedToApply, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, planPolicyViolations)
+			// Check access policy before apply (teams, approvals, approval_teams are already loaded from job)
+			allowedToApply, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations)
 			if err != nil {
 				msg := fmt.Sprintf("Failed to run plan policy check before apply. %v", err)
 				slog.Error("Failed to run plan policy check before apply", "error", err)
@@ -621,22 +574,24 @@ func RunJob(
 	SCMOrganisation, SCMrepository := utils.ParseRepoNamespace(repo)
 	slog.Info("Running commands for project", "commands", job.Commands, "project name", job.ProjectName)
 
-	// Compute teams once for all commands (all commands are for the same user)
-	teams, err := orgService.GetUserTeams(SCMOrganisation, requestedBy)
-	if err != nil {
-		slog.Error("Error fetching user teams",
-			"organisation", SCMOrganisation,
-			"user", requestedBy,
-			"error", err)
-		slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
+	// Use teams, approvals, and approval_teams from the job (computed on backend/webhook side)
+	teams := job.Teams
+	approvals := job.Approvals
+	approvalTeams := job.ApprovalTeams
+
+	// Initialize as empty slices if nil to avoid nil pointer issues
+	if teams == nil {
 		teams = []string{}
 	}
-
-	// No PR approvals in RunJob context (prService is nil)
-	var approvals = make([]string, 0)
+	if approvals == nil {
+		approvals = []string{}
+	}
+	if approvalTeams == nil {
+		approvalTeams = []string{}
+	}
 
 	for _, command := range job.Commands {
-		allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, nil, requestedBy, teams, approvals, []string{})
+		allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, nil, requestedBy, teams, approvals, approvalTeams, []string{})
 
 		if err != nil {
 			return fmt.Errorf("error checking policy: %v", err)
@@ -711,7 +666,7 @@ func RunJob(
 				slog.Error(msg)
 				return fmt.Errorf("%s", msg)
 			}
-			planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, planJsonOutput)
+			planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, approvalTeams, planJsonOutput)
 			slog.Info(strings.Join(messages, "\n"))
 			if err != nil {
 				msg := fmt.Sprintf("Failed to validate plan %v", err)

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -75,13 +75,50 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 	exectorResults := make([]execution.DiggerExecutorResult, len(jobs))
 	appliesPerProject := make(map[string]bool)
 
+	// Compute teams and approvals once for all jobs (assumes all jobs are from the same user and PR)
+	var teams []string
+	var approvals []string
+	var requestedBy string
+	var prNumber *int
+	var SCMOrganisation string
+
+	if len(jobs) > 0 {
+		firstJob := jobs[0]
+		splits := strings.Split(firstJob.Namespace, "/")
+		SCMOrganisation = splits[0]
+		requestedBy = firstJob.RequestedBy
+		prNumber = firstJob.PullRequestNumber
+
+		var err error
+		teams, err = orgService.GetUserTeams(SCMOrganisation, requestedBy)
+		if err != nil {
+			slog.Error("Error fetching user teams",
+				"organisation", SCMOrganisation,
+				"user", requestedBy,
+				"error", err)
+			slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
+			teams = []string{}
+		}
+
+		// Compute approvals for the PR (if applicable)
+		approvals = make([]string, 0)
+		if prNumber != nil {
+			approvals, err = prService.GetApprovals(*prNumber)
+			if err != nil {
+				slog.Warn("Failed to get PR approvals",
+					"prNumber", *prNumber,
+					"error", err)
+			}
+		}
+	}
+
 	for i, job := range jobs {
 		splits := strings.Split(job.Namespace, "/")
 		SCMOrganisation := splits[0]
 		SCMrepository := splits[1]
 
 		for _, command := range job.Commands {
-			allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(orgService, &prService, SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, job.RequestedBy, []string{})
+			allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, job.RequestedBy, teams, approvals, []string{})
 
 			if err != nil {
 				return false, false, fmt.Errorf("error checking policy: %v", err)
@@ -185,7 +222,29 @@ func reportPolicyError(projectName string, command string, requestedBy string, r
 func run(command string, job orchestrator.Job, policyChecker policy.Checker, orgService ci.OrgService, SCMOrganisation string, SCMrepository string, PRNumber *int, requestedBy string, reporter reporting.Reporter, lock locking2.Lock, prService ci.PullRequestService, projectNamespace string, workingDir string, planStorage storage.PlanStorage, appliesPerProject map[string]bool) (*execution.DiggerExecutorResult, string, error) {
 	slog.Info("Running command for project", "command", command, "project name", job.ProjectName, "project workflow", job.ProjectWorkflow)
 
-	allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(orgService, &prService, SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, []string{})
+	// Compute teams for the user
+	teams, err := orgService.GetUserTeams(SCMOrganisation, requestedBy)
+	if err != nil {
+		slog.Error("Error fetching user teams",
+			"organisation", SCMOrganisation,
+			"user", requestedBy,
+			"error", err)
+		slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
+		teams = []string{}
+	}
+
+	// Compute approvals for the PR (if applicable)
+	var approvals = make([]string, 0)
+	if job.PullRequestNumber != nil {
+		approvals, err = prService.GetApprovals(*job.PullRequestNumber)
+		if err != nil {
+			slog.Warn("Failed to get PR approvals",
+				"prNumber", *job.PullRequestNumber,
+				"error", err)
+		}
+	}
+
+	allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, []string{})
 
 	if err != nil {
 		return nil, "error checking policy", fmt.Errorf("error checking policy: %v", err)
@@ -275,6 +334,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		} else if planPerformed {
 			if isNonEmptyPlan {
 				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
+
 				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, planJsonOutput)
 				if err != nil {
 					msg := fmt.Sprintf("Failed to validate plan. %v", err)
@@ -383,7 +443,28 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 				planPolicyViolations = []string{}
 			}
 
-			allowedToApply, err := policyChecker.CheckAccessPolicy(orgService, &prService, SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, planPolicyViolations)
+			// Re-compute teams and approvals for apply command
+			teams, err := orgService.GetUserTeams(SCMOrganisation, requestedBy)
+			if err != nil {
+				slog.Error("Error fetching user teams",
+					"organisation", SCMOrganisation,
+					"user", requestedBy,
+					"error", err)
+				slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
+				teams = []string{}
+			}
+
+			var approvals = make([]string, 0)
+			if job.PullRequestNumber != nil {
+				approvals, err = prService.GetApprovals(*job.PullRequestNumber)
+				if err != nil {
+					slog.Warn("Failed to get PR approvals",
+						"prNumber", *job.PullRequestNumber,
+						"error", err)
+				}
+			}
+
+			allowedToApply, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, planPolicyViolations)
 			if err != nil {
 				msg := fmt.Sprintf("Failed to run plan policy check before apply. %v", err)
 				slog.Error("Failed to run plan policy check before apply", "error", err)
@@ -540,9 +621,22 @@ func RunJob(
 	SCMOrganisation, SCMrepository := utils.ParseRepoNamespace(repo)
 	slog.Info("Running commands for project", "commands", job.Commands, "project name", job.ProjectName)
 
-	for _, command := range job.Commands {
+	// Compute teams once for all commands (all commands are for the same user)
+	teams, err := orgService.GetUserTeams(SCMOrganisation, requestedBy)
+	if err != nil {
+		slog.Error("Error fetching user teams",
+			"organisation", SCMOrganisation,
+			"user", requestedBy,
+			"error", err)
+		slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
+		teams = []string{}
+	}
 
-		allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(orgService, nil, SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, nil, requestedBy, []string{})
+	// No PR approvals in RunJob context (prService is nil)
+	var approvals = make([]string, 0)
+
+	for _, command := range job.Commands {
+		allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, nil, requestedBy, teams, approvals, []string{})
 
 		if err != nil {
 			return fmt.Errorf("error checking policy: %v", err)

--- a/libs/policy/core.go
+++ b/libs/policy/core.go
@@ -9,8 +9,8 @@ type Provider interface {
 
 type Checker interface {
 	// TODO refactor arguments - use AccessPolicyContext
-	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error)
-	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error)
+	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error)
+	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
 }
 

--- a/libs/policy/core.go
+++ b/libs/policy/core.go
@@ -10,7 +10,7 @@ type Provider interface {
 type Checker interface {
 	// TODO refactor arguments - use AccessPolicyContext
 	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error)
-	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error)
+	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
 }
 

--- a/libs/policy/core.go
+++ b/libs/policy/core.go
@@ -1,9 +1,5 @@
 package policy
 
-import (
-	"github.com/diggerhq/digger/libs/ci"
-)
-
 type Provider interface {
 	GetAccessPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
 	GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
@@ -13,7 +9,7 @@ type Provider interface {
 
 type Checker interface {
 	// TODO refactor arguments - use AccessPolicyContext
-	CheckAccessPolicy(ciService ci.OrgService, prService *ci.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error)
+	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error)
 	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
 }

--- a/libs/policy/mocks.go
+++ b/libs/policy/mocks.go
@@ -1,11 +1,9 @@
 package policy
 
-import "github.com/diggerhq/digger/libs/ci"
-
 type MockPolicyChecker struct {
 }
 
-func (t MockPolicyChecker) CheckAccessPolicy(ciService ci.OrgService, prService *ci.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error) {
+func (t MockPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error) {
 	return false, nil
 }
 

--- a/libs/policy/mocks.go
+++ b/libs/policy/mocks.go
@@ -3,11 +3,11 @@ package policy
 type MockPolicyChecker struct {
 }
 
-func (t MockPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error) {
+func (t MockPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
 	return false, nil
 }
 
-func (t MockPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error) {
+func (t MockPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error) {
 	return false, nil, nil
 }
 

--- a/libs/policy/mocks.go
+++ b/libs/policy/mocks.go
@@ -7,7 +7,7 @@ func (t MockPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMreposito
 	return false, nil
 }
 
-func (t MockPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error) {
+func (t MockPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error) {
 	return false, nil, nil
 }
 

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -30,11 +30,11 @@ type DiggerHttpPolicyProvider struct {
 type NoOpPolicyChecker struct {
 }
 
-func (p NoOpPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error) {
+func (p NoOpPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
 	return true, nil
 }
 
-func (p NoOpPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error) {
+func (p NoOpPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error) {
 	return true, nil, nil
 }
 
@@ -343,7 +343,7 @@ type DiggerPolicyChecker struct {
 }
 
 // TODO refactor to use AccessPolicyContext - too many arguments
-func (p DiggerPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error) {
+func (p DiggerPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
 	slog.Debug("Checking access policy",
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
@@ -363,6 +363,7 @@ func (p DiggerPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMreposi
 		"organisation":         SCMOrganisation,
 		"teams":                teams,
 		"approvals":            approvals,
+		"approval_teams":       approvalTeams,
 		"planPolicyViolations": planPolicyViolations,
 		"action":               command,
 		"project":              projectName,
@@ -418,7 +419,7 @@ func (p DiggerPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMreposi
 	return true, nil
 }
 
-func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error) {
+func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error) {
 	slog.Debug("Checking plan policy",
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
@@ -426,6 +427,7 @@ func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisati
 		"requestedBy", requestedBy,
 		"teams", teams,
 		"approvals", approvals,
+		"approvalTeams", approvalTeams,
 	)
 
 	policy, err := p.PolicyProvider.GetPlanPolicy(SCMOrganisation, SCMrepository, projectname, projectDir)
@@ -442,12 +444,13 @@ func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisati
 	}
 
 	input := map[string]interface{}{
-		"terraform":    parsedPlanOutput,
-		"user":         requestedBy,
-		"organisation": SCMOrganisation,
-		"project":      projectname,
-		"teams":        teams,
-		"approvals":    approvals,
+		"terraform":      parsedPlanOutput,
+		"user":           requestedBy,
+		"organisation":   SCMOrganisation,
+		"project":        projectname,
+		"teams":          teams,
+		"approvals":      approvals,
+		"approval_teams": approvalTeams,
 	}
 
 	if policy == "" {

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -423,7 +423,10 @@ func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisati
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
 		"project", projectname,
-		"requestedBy", requestedBy)
+		"requestedBy", requestedBy,
+		"teams", teams,
+		"approvals", approvals,
+	)
 
 	policy, err := p.PolicyProvider.GetPlanPolicy(SCMOrganisation, SCMrepository, projectname, projectDir)
 	if err != nil {

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -34,7 +34,7 @@ func (p NoOpPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMreposito
 	return true, nil
 }
 
-func (p NoOpPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error) {
+func (p NoOpPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error) {
 	return true, nil, nil
 }
 
@@ -418,11 +418,12 @@ func (p DiggerPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMreposi
 	return true, nil
 }
 
-func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, planOutput string) (bool, []string, error) {
+func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, planOutput string) (bool, []string, error) {
 	slog.Debug("Checking plan policy",
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
-		"project", projectname)
+		"project", projectname,
+		"requestedBy", requestedBy)
 
 	policy, err := p.PolicyProvider.GetPlanPolicy(SCMOrganisation, SCMrepository, projectname, projectDir)
 	if err != nil {
@@ -438,7 +439,12 @@ func (p DiggerPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisati
 	}
 
 	input := map[string]interface{}{
-		"terraform": parsedPlanOutput,
+		"terraform":    parsedPlanOutput,
+		"user":         requestedBy,
+		"organisation": SCMOrganisation,
+		"project":      projectname,
+		"teams":        teams,
+		"approvals":    approvals,
 	}
 
 	if policy == "" {

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/diggerhq/digger/libs/ci"
 	"github.com/open-policy-agent/opa/rego"
 )
 
@@ -31,7 +30,7 @@ type DiggerHttpPolicyProvider struct {
 type NoOpPolicyChecker struct {
 }
 
-func (p NoOpPolicyChecker) CheckAccessPolicy(ciService ci.OrgService, prService *ci.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error) {
+func (p NoOpPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error) {
 	return true, nil
 }
 
@@ -344,7 +343,7 @@ type DiggerPolicyChecker struct {
 }
 
 // TODO refactor to use AccessPolicyContext - too many arguments
-func (p DiggerPolicyChecker) CheckAccessPolicy(ciService ci.OrgService, prService *ci.PullRequestService, SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, planPolicyViolations []string) (bool, error) {
+func (p DiggerPolicyChecker) CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, planPolicyViolations []string) (bool, error) {
 	slog.Debug("Checking access policy",
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
@@ -357,27 +356,6 @@ func (p DiggerPolicyChecker) CheckAccessPolicy(ciService ci.OrgService, prServic
 	if err != nil {
 		slog.Error("Error fetching policy", "error", err)
 		return false, err
-	}
-
-	teams, err := ciService.GetUserTeams(SCMOrganisation, requestedBy)
-	if err != nil {
-		slog.Error("Error fetching user teams",
-			"organisation", SCMOrganisation,
-			"user", requestedBy,
-			"error", err)
-		slog.Warn("Teams failed to be fetched, using empty list for access policy checks")
-		teams = []string{}
-	}
-
-	// list of pull request approvals (if applicable)
-	var approvals = make([]string, 0)
-	if prService != nil && prNumber != nil {
-		approvals, err = (*prService).GetApprovals(*prNumber)
-		if err != nil {
-			slog.Warn("Failed to get PR approvals",
-				"prNumber", *prNumber,
-				"error", err)
-		}
 	}
 
 	input := map[string]interface{}{

--- a/libs/policy/policy_test.go
+++ b/libs/policy/policy_test.go
@@ -221,7 +221,8 @@ func TestDiggerAccessPolicyChecker_Check(t *testing.T) {
 			}
 			teams := []string{"engineering"}
 			approvals := []string{}
-			got, err := p.CheckAccessPolicy(tt.organisation, tt.name, tt.name, "", tt.command, nil, tt.requestedBy, teams, approvals, tt.planPolicyViolations)
+			approvalTeams := []string{}
+			got, err := p.CheckAccessPolicy(tt.organisation, tt.name, tt.name, "", tt.command, nil, tt.requestedBy, teams, approvals, approvalTeams, tt.planPolicyViolations)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiggerPolicyChecker.CheckAccessPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -276,7 +277,8 @@ func TestDiggerPlanPolicyChecker_Check(t *testing.T) {
 			requestedBy := "test-user"
 			teams := []string{"engineering"}
 			approvals := []string{}
-			got, _, err := p.CheckPlanPolicy("", "", "", "", requestedBy, teams, approvals, tt.planJsonOutput)
+			approvalTeams := []string{"platform"}
+			got, _, err := p.CheckPlanPolicy("", "", "", "", requestedBy, teams, approvals, approvalTeams, tt.planJsonOutput)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiggerPolicyChecker.CheckPlanPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/libs/policy/policy_test.go
+++ b/libs/policy/policy_test.go
@@ -273,7 +273,10 @@ func TestDiggerPlanPolicyChecker_Check(t *testing.T) {
 			var p = &DiggerPolicyChecker{
 				PolicyProvider: tt.fields.PolicyProvider,
 			}
-			got, _, err := p.CheckPlanPolicy("", "", "", "", tt.planJsonOutput)
+			requestedBy := "test-user"
+			teams := []string{"engineering"}
+			approvals := []string{}
+			got, _, err := p.CheckPlanPolicy("", "", "", "", requestedBy, teams, approvals, tt.planJsonOutput)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiggerPolicyChecker.CheckPlanPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/libs/policy/policy_test.go
+++ b/libs/policy/policy_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"github.com/diggerhq/digger/libs/ci"
 	"testing"
 )
 
@@ -220,8 +219,9 @@ func TestDiggerAccessPolicyChecker_Check(t *testing.T) {
 			var p = &DiggerPolicyChecker{
 				PolicyProvider: tt.fields.PolicyProvider,
 			}
-			ciService := ci.MockPullRequestManager{Teams: []string{"engineering"}}
-			got, err := p.CheckAccessPolicy(ciService, nil, tt.organisation, tt.name, tt.name, "", tt.command, nil, tt.requestedBy, tt.planPolicyViolations)
+			teams := []string{"engineering"}
+			approvals := []string{}
+			got, err := p.CheckAccessPolicy(tt.organisation, tt.name, tt.name, "", tt.command, nil, tt.requestedBy, teams, approvals, tt.planPolicyViolations)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiggerPolicyChecker.CheckAccessPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/libs/scheduler/jobs.go
+++ b/libs/scheduler/jobs.go
@@ -40,6 +40,10 @@ type Job struct {
 	CommandRoleArn     string
 	CognitoOidcConfig  *configuration.AwsCognitoOidcConfig
 	SkipMergeCheck     bool
+	// Policy-related fields computed on backend/webhook side
+	Teams         []string
+	Approvals     []string
+	ApprovalTeams []string
 }
 
 type Step struct {

--- a/libs/scheduler/json_models.go
+++ b/libs/scheduler/json_models.go
@@ -51,6 +51,10 @@ type JobJson struct {
 	CommandRoleArn          string            `json:"command_role_arn"`
 	StateRoleArn            string            `json:"state_role_arn"`
 	CognitoOidcConfig       *cognitoConfig    `json:"aws_cognito_oidc"`
+	// Policy-related fields computed on backend/webhook side
+	Teams         []string `json:"teams"`
+	Approvals     []string `json:"approvals"`
+	ApprovalTeams []string `json:"approval_teams"`
 }
 
 func (j *JobJson) IsPlan() bool {
@@ -107,6 +111,9 @@ func JobToJson(job Job, jobType DiggerCommand, organisationName string, branch s
 		CommandRoleArn:          job.CommandRoleArn,
 		StateRoleArn:            job.StateRoleArn,
 		CognitoOidcConfig:       job.CognitoOidcConfig,
+		Teams:                   job.Teams,
+		Approvals:               job.Approvals,
+		ApprovalTeams:           job.ApprovalTeams,
 	}
 }
 
@@ -135,6 +142,9 @@ func JsonToJob(jobJson JobJson) Job {
 		StateRoleArn:       jobJson.StateRoleArn,
 		SkipMergeCheck:     jobJson.SkipMergeCheck,
 		CognitoOidcConfig:  jobJson.CognitoOidcConfig,
+		Teams:              jobJson.Teams,
+		Approvals:          jobJson.Approvals,
+		ApprovalTeams:      jobJson.ApprovalTeams,
 	}
 }
 


### PR DESCRIPTION
Additional fields passed on to plan policy as mentioned in #2453 

- **refactor access policies to not recieve prService,orgService**
- **add extra data to plan policy**
- **add more teams**
- **pass values from backend**

<img width="733" height="370" alt="Screenshot 2025-12-18 at 17 11 29" src="https://github.com/user-attachments/assets/4b39d1c5-374c-4a3a-9de7-e3067710c7f3" />

-- used claude code in a directed manner