### PR TITLE
doc: fix minor typo

### DIFF
--- a/docs/ce/state-management/digger-integration.mdx
+++ b/docs/ce/state-management/digger-integration.mdx
@@ -15,7 +15,7 @@ terraform login <hostname> # (OPENTACO_PUBLIC_BASE_URL)
 cat ~/.terraform.d/credentials.tfrc.json
 ```
 
-And copy the value of the token from the JSON file of your terraform credentials file. Store the token as a secret STATESMANE_TOKEN in your CI system.
+And copy the value of the token from the JSON file of your terraform credentials file. Store the token as a secret STATESMAN_TOKEN in your CI system.
 From there you would need to make some small tweaks to your digger workflow:
 
 ```


### PR DESCRIPTION
Variable name had an extra char. And I guess the GitHub web editor wanted to add a newline at the end of the file.

### :brain: **Ai UsageDetails (if applicable):**

NA; I deleted that "E" all by myself. ;)

