### PR TITLE
Update GCP link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Digger runs Terraform natively in your CI. This is:
 ## Getting Started
 
 - [GitHub Actions + AWS](https://docs.digger.dev/getting-started/github-actions-+-aws)
-- [GitHub Actions + GCP](https://docs.digger.dev/getting-started/github-actions-and-gcp)
+- [GitHub Actions + GCP](https://docs.opentaco.dev/ce/gcp/setting-up-gcp-+-gh-actions)
 
 ## How it works
 


### PR DESCRIPTION
The current GCP + Github Actions link is dead, fixed with the new link. Couldn't find an equivalent for AWS, best to maybe just drop the link? That link is also dead


### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

N/A

