### PR TITLE
support for apply policies

### DIFF
--- a/backend/models/policies.go
+++ b/backend/models/policies.go
@@ -6,6 +6,7 @@ const (
 	POLICY_TYPE_ACCESS = "access"
 	POLICY_TYPE_PLAN   = "plan"
 	POLICY_TYPE_DRIFT  = "drift"
+	POLICY_TYPE_APPLY  = "apply"
 )
 
 type Policy struct {

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -476,20 +476,13 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					applyPolicyFormatter = reporting.AsComment(summary)
 				}
 
-				applyPolicyReportMessage := fmt.Sprintf("User %s is not allowed to perform action: %s. Check your policies :x:<br>", requestedBy, command)
-				slog.Debug("Base report message created", "message", applyPolicyReportMessage)
+				applyPolicyReportMessage := "Terraform apply failed validation checks :x:<br>"
 				if len(applyPolicyViolations) > 0 {
-					slog.Debug("Adding violations to report", "count", len(applyPolicyViolations))
 					preformattedMessages := make([]string, 0)
-					for i, message := range applyPolicyViolations {
-						formatted := fmt.Sprintf("    %v", message)
-						preformattedMessages = append(preformattedMessages, formatted)
-						slog.Debug("Formatted violation", "index", i, "original", message, "formatted", formatted)
+					for _, message := range applyPolicyViolations {
+						preformattedMessages = append(preformattedMessages, fmt.Sprintf("    %v", message))
 					}
 					applyPolicyReportMessage = applyPolicyReportMessage + strings.Join(preformattedMessages, "<br>")
-					slog.Debug("Final report message with violations", "message", applyPolicyReportMessage)
-				} else {
-					slog.Warn("No violations in array despite policy denial")
 				}
 				_, _, err = reporter.Report(applyPolicyReportMessage, applyPolicyFormatter)
 				if err != nil {

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -430,14 +430,30 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			}
 
 			// Check apply policy before apply
+			// Try to retrieve the terraform plan JSON if plan storage is configured
+			var terraformPlanJson string
+			if os.Getenv("PLAN_UPLOAD_DESTINATION") != "" {
+				slog.Debug("Plan storage configured, attempting to retrieve plan for apply policy check")
+				retrievedPlanJson, err := executor.RetrievePlanJson()
+				if err != nil {
+					slog.Warn("Failed to retrieve plan JSON for apply policy check, proceeding without plan data", "error", err)
+				} else {
+					terraformPlanJson = retrievedPlanJson
+					slog.Debug("Successfully retrieved plan JSON for apply policy check", "planLength", len(terraformPlanJson))
+				}
+			} else {
+				slog.Debug("Plan storage not configured, apply policy will not have terraform plan data")
+			}
+
 			slog.Debug("Calling CheckApplyPolicy",
 				"organisation", SCMOrganisation,
 				"repository", SCMrepository,
 				"projectName", job.ProjectName,
 				"projectDir", job.ProjectDir,
 				"command", command,
-				"requestedBy", requestedBy)
-			allowedToApplyByApplyPolicy, applyPolicyViolations, err := policyChecker.CheckApplyPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations)
+				"requestedBy", requestedBy,
+				"hasTerraformPlan", terraformPlanJson != "")
+			allowedToApplyByApplyPolicy, applyPolicyViolations, err := policyChecker.CheckApplyPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations, terraformPlanJson)
 			slog.Debug("CheckApplyPolicy result",
 				"allowed", allowedToApplyByApplyPolicy,
 				"violationsCount", len(applyPolicyViolations),

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -105,7 +105,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 
 			if !allowedToPerformCommand {
 				msg := reportPolicyError(job.ProjectName, command, job.RequestedBy, reporter)
-				slog.Warn("Skipping command ... %v for project %v", command, job.ProjectName)
+				slog.Warn("Skipping command ...", "command", command, "projectName", job.ProjectName)
 				slog.Warn("Received policy error", "message", msg)
 				appliesPerProject[job.ProjectName] = false
 				continue
@@ -430,14 +430,35 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			}
 
 			// Check apply policy before apply
-			allowedToApplyByApplyPolicy, err := policyChecker.CheckApplyPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations)
+			allowedToApplyByApplyPolicy, applyPolicyViolations, err := policyChecker.CheckApplyPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations)
 			if err != nil {
 				msg := fmt.Sprintf("Failed to run apply policy check before apply. %v", err)
 				slog.Error("Failed to run apply policy check before apply", "error", err)
 				return nil, msg, fmt.Errorf("%s", msg)
 			}
 			if !allowedToApplyByApplyPolicy {
-				msg := reportPolicyError(job.ProjectName, command, requestedBy, reporter)
+				var applyPolicyFormatter func(report string) string
+				summary := fmt.Sprintf("Policy violation for <b>%v - %v</b>", job.ProjectName, command)
+				if reporter.SupportsMarkdown() {
+					applyPolicyFormatter = reporting.AsCollapsibleComment(summary, false)
+				} else {
+					applyPolicyFormatter = reporting.AsComment(summary)
+				}
+
+				applyPolicyReportMessage := fmt.Sprintf("User %s is not allowed to perform action: %s. Check your policies :x:<br>", requestedBy, command)
+				if len(applyPolicyViolations) > 0 {
+					preformattedMessages := make([]string, 0)
+					for _, message := range applyPolicyViolations {
+						preformattedMessages = append(preformattedMessages, fmt.Sprintf("    %v", message))
+					}
+					applyPolicyReportMessage = applyPolicyReportMessage + strings.Join(preformattedMessages, "<br>")
+				}
+				_, _, err = reporter.Report(applyPolicyReportMessage, applyPolicyFormatter)
+				if err != nil {
+					slog.Error("Failed to report apply policy violation.", "error", err)
+				}
+
+				msg := fmt.Sprintf("Apply is not allowed due to policy violations")
 				slog.Error(msg)
 				return nil, msg, errors.New(msg)
 			}

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -429,6 +429,19 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 				return nil, msg, errors.New(msg)
 			}
 
+			// Check apply policy before apply
+			allowedToApplyByApplyPolicy, err := policyChecker.CheckApplyPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations)
+			if err != nil {
+				msg := fmt.Sprintf("Failed to run apply policy check before apply. %v", err)
+				slog.Error("Failed to run apply policy check before apply", "error", err)
+				return nil, msg, fmt.Errorf("%s", msg)
+			}
+			if !allowedToApplyByApplyPolicy {
+				msg := reportPolicyError(job.ProjectName, command, requestedBy, reporter)
+				slog.Error(msg)
+				return nil, msg, errors.New(msg)
+			}
+
 			// Running apply
 
 			applySummary, applyPerformed, output, err := diggerExecutor.Apply()

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -430,13 +430,28 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			}
 
 			// Check apply policy before apply
+			slog.Debug("Calling CheckApplyPolicy",
+				"organisation", SCMOrganisation,
+				"repository", SCMrepository,
+				"projectName", job.ProjectName,
+				"projectDir", job.ProjectDir,
+				"command", command,
+				"requestedBy", requestedBy)
 			allowedToApplyByApplyPolicy, applyPolicyViolations, err := policyChecker.CheckApplyPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, requestedBy, teams, approvals, approvalTeams, planPolicyViolations)
+			slog.Debug("CheckApplyPolicy result",
+				"allowed", allowedToApplyByApplyPolicy,
+				"violationsCount", len(applyPolicyViolations),
+				"violations", applyPolicyViolations,
+				"error", err)
 			if err != nil {
 				msg := fmt.Sprintf("Failed to run apply policy check before apply. %v", err)
 				slog.Error("Failed to run apply policy check before apply", "error", err)
 				return nil, msg, fmt.Errorf("%s", msg)
 			}
 			if !allowedToApplyByApplyPolicy {
+				slog.Info("Apply policy check denied",
+					"violationsCount", len(applyPolicyViolations),
+					"violations", applyPolicyViolations)
 				var applyPolicyFormatter func(report string) string
 				summary := fmt.Sprintf("Policy violation for <b>%v - %v</b>", job.ProjectName, command)
 				if reporter.SupportsMarkdown() {
@@ -446,12 +461,19 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 				}
 
 				applyPolicyReportMessage := fmt.Sprintf("User %s is not allowed to perform action: %s. Check your policies :x:<br>", requestedBy, command)
+				slog.Debug("Base report message created", "message", applyPolicyReportMessage)
 				if len(applyPolicyViolations) > 0 {
+					slog.Debug("Adding violations to report", "count", len(applyPolicyViolations))
 					preformattedMessages := make([]string, 0)
-					for _, message := range applyPolicyViolations {
-						preformattedMessages = append(preformattedMessages, fmt.Sprintf("    %v", message))
+					for i, message := range applyPolicyViolations {
+						formatted := fmt.Sprintf("    %v", message)
+						preformattedMessages = append(preformattedMessages, formatted)
+						slog.Debug("Formatted violation", "index", i, "original", message, "formatted", formatted)
 					}
 					applyPolicyReportMessage = applyPolicyReportMessage + strings.Join(preformattedMessages, "<br>")
+					slog.Debug("Final report message with violations", "message", applyPolicyReportMessage)
+				} else {
+					slog.Warn("No violations in array despite policy denial")
 				}
 				_, _, err = reporter.Report(applyPolicyReportMessage, applyPolicyFormatter)
 				if err != nil {

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"github.com/diggerhq/digger/libs/git_utils"
 	"github.com/samber/lo"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -116,10 +117,21 @@ func (p DiggerRepoPolicyProvider) GetPlanPolicy(organisation string, repository 
 }
 
 func (p DiggerRepoPolicyProvider) GetApplyPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
+	slog.Debug("GetApplyPolicy called",
+		"organisation", organisation,
+		"repository", repository,
+		"projectname", projectname,
+		"projectDir", projectDir,
+		"managementRepoUrl", p.ManagementRepoUrl)
 	policy, err := p.getPolicyFileContents(repository, projectname, projectDir, "apply.rego")
 	if err != nil {
+		slog.Error("Error getting apply policy file", "error", err)
 		return policy, err
 	}
+	slog.Debug("GetApplyPolicy result",
+		"policyLength", len(policy),
+		"policyEmpty", policy == "",
+		"policyContent", policy)
 	return policy, nil
 }
 

--- a/ee/cli/pkg/policy/policy.go
+++ b/ee/cli/pkg/policy/policy.go
@@ -115,6 +115,14 @@ func (p DiggerRepoPolicyProvider) GetPlanPolicy(organisation string, repository 
 	return policy, nil
 }
 
+func (p DiggerRepoPolicyProvider) GetApplyPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
+	policy, err := p.getPolicyFileContents(repository, projectname, projectDir, "apply.rego")
+	if err != nil {
+		return policy, err
+	}
+	return policy, nil
+}
+
 func (p DiggerRepoPolicyProvider) GetDriftPolicy() (string, error) {
 	return "", nil
 

--- a/libs/policy/core.go
+++ b/libs/policy/core.go
@@ -13,7 +13,7 @@ type Checker interface {
 	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error)
 	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
-	CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error)
+	CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error)
 }
 
 type PolicyCheckerProvider interface {

--- a/libs/policy/core.go
+++ b/libs/policy/core.go
@@ -13,7 +13,7 @@ type Checker interface {
 	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error)
 	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
-	CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error)
+	CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string, planOutput string) (bool, []string, error)
 }
 
 type PolicyCheckerProvider interface {

--- a/libs/policy/core.go
+++ b/libs/policy/core.go
@@ -4,6 +4,7 @@ type Provider interface {
 	GetAccessPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
 	GetPlanPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
 	GetDriftPolicy() (string, error)
+	GetApplyPolicy(organisation string, repository string, projectname string, projectDir string) (string, error)
 	GetOrganisation() string // TODO: remove this method from here since out of place
 }
 
@@ -12,6 +13,7 @@ type Checker interface {
 	CheckAccessPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error)
 	CheckPlanPolicy(SCMrepository string, SCMOrganisation string, projectname string, projectDir string, requestedBy string, teams []string, approvals []string, approvalTeams []string, planOutput string) (bool, []string, error)
 	CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error)
+	CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error)
 }
 
 type PolicyCheckerProvider interface {

--- a/libs/policy/mocks.go
+++ b/libs/policy/mocks.go
@@ -14,3 +14,7 @@ func (t MockPolicyChecker) CheckPlanPolicy(SCMrepository string, SCMOrganisation
 func (t MockPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMrepository string, projectname string) (bool, error) {
 	return true, nil
 }
+
+func (t MockPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error) {
+	return true, nil, nil
+}

--- a/libs/policy/mocks.go
+++ b/libs/policy/mocks.go
@@ -15,6 +15,6 @@ func (t MockPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMrepositor
 	return true, nil
 }
 
-func (t MockPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error) {
+func (t MockPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string, planOutput string) (bool, []string, error) {
 	return true, nil, nil
 }

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -42,8 +42,8 @@ func (p NoOpPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMrepositor
 	return true, nil
 }
 
-func (p NoOpPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
-	return true, nil
+func (p NoOpPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error) {
+	return true, nil, nil
 }
 
 func getAccessPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.Response, error) {
@@ -707,7 +707,7 @@ func (p DiggerPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMreposit
 	return true, nil
 }
 
-func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
+func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error) {
 	slog.Debug("Checking apply policy",
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
@@ -719,7 +719,7 @@ func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMreposit
 
 	if err != nil {
 		slog.Error("Error fetching apply policy", "error", err)
-		return false, err
+		return false, nil, err
 	}
 
 	input := map[string]interface{}{
@@ -735,7 +735,7 @@ func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMreposit
 
 	if policy == "" {
 		slog.Debug("No apply policy found, allowing action")
-		return true, nil
+		return true, nil, nil
 	}
 
 	ctx := context.Background()
@@ -744,43 +744,53 @@ func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMreposit
 		"policy", policy)
 
 	query, err := rego.New(
-		rego.Query("data.digger.allow"),
+		rego.Query("data.digger.deny"),
 		rego.Module("digger", policy),
 	).PrepareForEval(ctx)
 
 	if err != nil {
 		slog.Error("Failed to prepare apply policy evaluation", "error", err)
-		return false, err
+		return false, nil, err
 	}
 
 	results, err := query.Eval(ctx, rego.EvalInput(input))
 	if len(results) == 0 || len(results[0].Expressions) == 0 {
 		slog.Error("No result found from apply policy evaluation")
-		return false, fmt.Errorf("no result found")
+		return false, nil, fmt.Errorf("no result found")
 	}
 
 	expressions := results[0].Expressions
 
+	decisionsResult := make([]string, 0)
 	for _, expression := range expressions {
-		decision, ok := expression.Value.(bool)
+		decisions, ok := expression.Value.([]interface{})
+
 		if !ok {
-			slog.Error("Apply policy decision is not a boolean")
-			return false, fmt.Errorf("decision is not a boolean")
+			slog.Error("Apply policy decision is not a slice of interfaces")
+			return false, nil, fmt.Errorf("decision is not a slice of interfaces")
 		}
-		if !decision {
-			slog.Info("Apply policy denied action",
-				"user", requestedBy,
-				"action", command,
-				"project", projectName)
-			return false, nil
+		if len(decisions) > 0 {
+			for _, d := range decisions {
+				decisionsResult = append(decisionsResult, d.(string))
+				slog.Info("Apply policy violation", "reason", d)
+			}
 		}
+	}
+
+	if len(decisionsResult) > 0 {
+		slog.Info("Apply policy check failed",
+			"violations", len(decisionsResult),
+			"organisation", SCMOrganisation,
+			"repository", SCMrepository,
+			"project", projectName)
+		return false, decisionsResult, nil
 	}
 
 	slog.Info("Apply policy allowed action",
 		"user", requestedBy,
 		"action", command,
 		"project", projectName)
-	return true, nil
+	return true, []string{}, nil
 }
 
 func NewPolicyChecker(hostname string, organisationName string, authToken string) Checker {

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -42,7 +42,7 @@ func (p NoOpPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMrepositor
 	return true, nil
 }
 
-func (p NoOpPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error) {
+func (p NoOpPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string, planOutput string) (bool, []string, error) {
 	return true, nil, nil
 }
 
@@ -707,13 +707,14 @@ func (p DiggerPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMreposit
 	return true, nil
 }
 
-func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, []string, error) {
+func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string, planOutput string) (bool, []string, error) {
 	slog.Debug("Checking apply policy",
 		"organisation", SCMOrganisation,
 		"repository", SCMrepository,
 		"project", projectName,
 		"command", command,
-		"requestedBy", requestedBy)
+		"requestedBy", requestedBy,
+		"hasPlanOutput", planOutput != "")
 
 	policy, err := p.PolicyProvider.GetApplyPolicy(SCMOrganisation, SCMrepository, projectName, projectDir)
 
@@ -731,6 +732,23 @@ func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMreposit
 		"planPolicyViolations": planPolicyViolations,
 		"action":               command,
 		"project":              projectName,
+	}
+
+	// Include terraform plan JSON if available
+	if planOutput != "" {
+		slog.Debug("Parsing terraform plan for apply policy", "planLength", len(planOutput))
+		var tfplan map[string]interface{}
+		err := json.Unmarshal([]byte(planOutput), &tfplan)
+		if err != nil {
+			slog.Error("Failed to parse terraform plan JSON for apply policy", "error", err)
+			// Don't fail the policy check, just proceed without plan data
+		} else {
+			input["terraform"] = tfplan
+			slog.Debug("Terraform plan included in apply policy input",
+				"hasResourceChanges", tfplan["resource_changes"] != nil)
+		}
+	} else {
+		slog.Debug("No terraform plan available for apply policy check")
 	}
 
 	if policy == "" {

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -754,28 +754,51 @@ func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMreposit
 	}
 
 	results, err := query.Eval(ctx, rego.EvalInput(input))
+	slog.Debug("OPA evaluation completed",
+		"resultsCount", len(results),
+		"error", err)
+
 	if len(results) == 0 || len(results[0].Expressions) == 0 {
 		slog.Error("No result found from apply policy evaluation")
 		return false, nil, fmt.Errorf("no result found")
 	}
 
 	expressions := results[0].Expressions
+	slog.Debug("Processing expressions from OPA results",
+		"expressionCount", len(expressions))
 
 	decisionsResult := make([]string, 0)
-	for _, expression := range expressions {
+	for i, expression := range expressions {
+		slog.Debug("Processing expression",
+			"index", i,
+			"valueType", fmt.Sprintf("%T", expression.Value),
+			"value", expression.Value)
+
 		decisions, ok := expression.Value.([]interface{})
 
 		if !ok {
-			slog.Error("Apply policy decision is not a slice of interfaces")
+			slog.Error("Apply policy decision is not a slice of interfaces",
+				"actualType", fmt.Sprintf("%T", expression.Value))
 			return false, nil, fmt.Errorf("decision is not a slice of interfaces")
 		}
+
+		slog.Debug("Decisions array received",
+			"decisionsCount", len(decisions))
+
 		if len(decisions) > 0 {
-			for _, d := range decisions {
-				decisionsResult = append(decisionsResult, d.(string))
-				slog.Info("Apply policy violation", "reason", d)
+			for j, d := range decisions {
+				decisionStr := d.(string)
+				decisionsResult = append(decisionsResult, decisionStr)
+				slog.Info("Apply policy violation found",
+					"index", j,
+					"reason", decisionStr)
 			}
 		}
 	}
+
+	slog.Debug("Final decisions result",
+		"totalViolations", len(decisionsResult),
+		"violations", decisionsResult)
 
 	if len(decisionsResult) > 0 {
 		slog.Info("Apply policy check failed",

--- a/libs/policy/policy.go
+++ b/libs/policy/policy.go
@@ -42,6 +42,10 @@ func (p NoOpPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMrepositor
 	return true, nil
 }
 
+func (p NoOpPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
+	return true, nil
+}
+
 func getAccessPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.Response, error) {
 	organisation := p.DiggerOrganisation
 	u, err := url.Parse(p.DiggerHost)
@@ -132,6 +136,36 @@ func getDriftPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.R
 	return string(body), resp, nil
 }
 
+func getApplyPolicyForOrganisation(p *DiggerHttpPolicyProvider) (string, *http.Response, error) {
+	organisation := p.DiggerOrganisation
+	u, err := url.Parse(p.DiggerHost)
+	if err != nil {
+		slog.Error("Failed to parse digger cloud URL", "url", p.DiggerHost, "error", err)
+		return "", nil, fmt.Errorf("not able to parse digger cloud url: %v", err)
+	}
+	u.Path = "/orgs/" + organisation + "/apply-policy"
+
+	slog.Debug("Fetching org apply policy", "organisation", organisation, "url", u.String())
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+p.AuthToken)
+
+	resp, err := p.HttpClient.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", resp, nil
+	}
+	return string(body), resp, nil
+}
+
 func getAccessPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projectName string) (string, *http.Response, error) {
 	// fetch RBAC policies for project from Digger API
 	u, err := url.Parse(p.DiggerHost)
@@ -175,6 +209,39 @@ func getPlanPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, pr
 	u.Path = "/repos/" + namespace + "/projects/" + projectName + "/plan-policy"
 
 	slog.Debug("Fetching namespace plan policy",
+		"namespace", namespace,
+		"projectName", projectName,
+		"url", u.String())
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+p.AuthToken)
+
+	resp, err := p.HttpClient.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", resp, nil
+	}
+	return string(body), resp, nil
+}
+
+func getApplyPolicyForNamespace(p *DiggerHttpPolicyProvider, namespace string, projectName string) (string, *http.Response, error) {
+	u, err := url.Parse(p.DiggerHost)
+	if err != nil {
+		slog.Error("Failed to parse digger cloud URL", "url", p.DiggerHost, "error", err)
+		return "", nil, fmt.Errorf("not able to parse digger cloud url: %v", err)
+	}
+	u.Path = "/repos/" + namespace + "/projects/" + projectName + "/apply-policy"
+
+	slog.Debug("Fetching namespace apply policy",
 		"namespace", namespace,
 		"projectName", projectName,
 		"url", u.String())
@@ -331,6 +398,61 @@ func (p DiggerHttpPolicyProvider) GetDriftPolicy() (string, error) {
 			"statusCode", resp.StatusCode,
 			"response", content)
 		return "", errors.New(fmt.Sprintf("unexpected response while fetching organisation policy: %v, code %v", content, resp.StatusCode))
+	}
+}
+
+func (p DiggerHttpPolicyProvider) GetApplyPolicy(organisation string, repo string, projectName string, projectDir string) (string, error) {
+	namespace := fmt.Sprintf("%v-%v", organisation, repo)
+
+	slog.Debug("Getting apply policy",
+		"organisation", organisation,
+		"repo", repo,
+		"projectName", projectName,
+		"projectDir", projectDir)
+
+	content, resp, err := getApplyPolicyForNamespace(&p, namespace, projectName)
+	if err != nil {
+		slog.Error("Failed to fetch apply policy for namespace",
+			"namespace", namespace,
+			"error", err)
+		return "", err
+	}
+
+	// project policy found
+	if resp.StatusCode == 200 && content != "" {
+		slog.Debug("Found project apply policy", "namespace", namespace, "projectName", projectName)
+		return content, nil
+	}
+
+	// check if project policy was empty or not found (retrieve org policy if so)
+	if (resp.StatusCode == 200 && content == "") || resp.StatusCode == 404 {
+		slog.Debug("Project apply policy not found, falling back to org policy",
+			"organisation", organisation)
+
+		content, resp, err := getApplyPolicyForOrganisation(&p)
+		if err != nil {
+			slog.Error("Failed to fetch apply policy for organisation",
+				"organisation", organisation,
+				"error", err)
+			return "", err
+		}
+		if resp.StatusCode == 200 {
+			slog.Debug("Found organisation apply policy", "organisation", organisation)
+			return content, nil
+		} else if resp.StatusCode == 404 {
+			slog.Debug("Organisation apply policy not found", "organisation", organisation)
+			return "", nil
+		} else {
+			slog.Error("Unexpected response for organisation policy",
+				"statusCode", resp.StatusCode,
+				"response", content)
+			return "", errors.New(fmt.Sprintf("unexpected response while fetching organisation policy: %v, code %v", content, resp.StatusCode))
+		}
+	} else {
+		slog.Error("Unexpected response for project policy",
+			"statusCode", resp.StatusCode,
+			"response", content)
+		return "", errors.New(fmt.Sprintf("unexpected response while fetching project policy: %v code %v", content, resp.StatusCode))
 	}
 }
 
@@ -581,6 +703,82 @@ func (p DiggerPolicyChecker) CheckDriftPolicy(SCMOrganisation string, SCMreposit
 
 	slog.Info("Drift detection enabled by policy",
 		"organisation", SCMOrganisation,
+		"project", projectName)
+	return true, nil
+}
+
+func (p DiggerPolicyChecker) CheckApplyPolicy(SCMOrganisation string, SCMrepository string, projectName string, projectDir string, command string, prNumber *int, requestedBy string, teams []string, approvals []string, approvalTeams []string, planPolicyViolations []string) (bool, error) {
+	slog.Debug("Checking apply policy",
+		"organisation", SCMOrganisation,
+		"repository", SCMrepository,
+		"project", projectName,
+		"command", command,
+		"requestedBy", requestedBy)
+
+	policy, err := p.PolicyProvider.GetApplyPolicy(SCMOrganisation, SCMrepository, projectName, projectDir)
+
+	if err != nil {
+		slog.Error("Error fetching apply policy", "error", err)
+		return false, err
+	}
+
+	input := map[string]interface{}{
+		"user":                 requestedBy,
+		"organisation":         SCMOrganisation,
+		"teams":                teams,
+		"approvals":            approvals,
+		"approval_teams":       approvalTeams,
+		"planPolicyViolations": planPolicyViolations,
+		"action":               command,
+		"project":              projectName,
+	}
+
+	if policy == "" {
+		slog.Debug("No apply policy found, allowing action")
+		return true, nil
+	}
+
+	ctx := context.Background()
+	slog.Debug("Evaluating apply policy",
+		"input", input,
+		"policy", policy)
+
+	query, err := rego.New(
+		rego.Query("data.digger.allow"),
+		rego.Module("digger", policy),
+	).PrepareForEval(ctx)
+
+	if err != nil {
+		slog.Error("Failed to prepare apply policy evaluation", "error", err)
+		return false, err
+	}
+
+	results, err := query.Eval(ctx, rego.EvalInput(input))
+	if len(results) == 0 || len(results[0].Expressions) == 0 {
+		slog.Error("No result found from apply policy evaluation")
+		return false, fmt.Errorf("no result found")
+	}
+
+	expressions := results[0].Expressions
+
+	for _, expression := range expressions {
+		decision, ok := expression.Value.(bool)
+		if !ok {
+			slog.Error("Apply policy decision is not a boolean")
+			return false, fmt.Errorf("decision is not a boolean")
+		}
+		if !decision {
+			slog.Info("Apply policy denied action",
+				"user", requestedBy,
+				"action", command,
+				"project", projectName)
+			return false, nil
+		}
+	}
+
+	slog.Info("Apply policy allowed action",
+		"user", requestedBy,
+		"action", command,
 		"project", projectName)
 	return true, nil
 }

--- a/libs/policy/policy_test.go
+++ b/libs/policy/policy_test.go
@@ -59,6 +59,10 @@ func (s *DiggerDefaultPolicyProvider) GetDriftPolicy() (string, error) {
 	return "package digger\n", nil
 }
 
+func (s *DiggerDefaultPolicyProvider) GetApplyPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
+	return "package digger\n", nil
+}
+
 func (s *DiggerDefaultPolicyProvider) GetOrganisation() string {
 	return "ORGANISATIONDIGGER"
 }
@@ -87,6 +91,10 @@ func (s *DiggerExamplePolicyProvider) GetPlanPolicy(organisation string, reposit
 }
 
 func (s *DiggerExamplePolicyProvider) GetDriftPolicy() (string, error) {
+	return "package digger\n", nil
+}
+
+func (s *DiggerExamplePolicyProvider) GetApplyPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n", nil
 }
 
@@ -121,6 +129,10 @@ func (s *DiggerExamplePolicyProvider2) GetPlanPolicy(organisation string, reposi
 }
 
 func (s *DiggerExamplePolicyProvider2) GetDriftPolicy() (string, error) {
+	return "package digger\n", nil
+}
+
+func (s *DiggerExamplePolicyProvider2) GetApplyPolicy(organisation string, repository string, projectname string, projectDir string) (string, error) {
 	return "package digger\n", nil
 }
 


### PR DESCRIPTION
Introduction of apply polices which are applied just before an apply goes through. It takes the  same input as the plan policy. Apply policy will also pass the plan summary **IF** plan artefacts are configured, otherwise it will not pass it.

Ai declaration: used claude code in a directed way to ship this feature