### PR TITLE
improve error messages for units when permission denied

### DIFF
--- a/taco/internal/unit/handler.go
+++ b/taco/internal/unit/handler.go
@@ -149,6 +149,18 @@ func (h *Handler) CreateUnit(c echo.Context) error {
 				"detail": fmt.Sprintf("A unit with name '%s' already exists in this organization", name),
 			})
 		}
+		if err == storage.ErrForbidden {
+			logger.Warn("Permission denied to create unit",
+				"operation", "create_unit",
+				"name", name,
+				"org_id", orgCtx.OrgID,
+			)
+			analytics.SendEssential("unit_create_failed_forbidden")
+			return c.JSON(http.StatusForbidden, map[string]string{
+				"error": "Permission denied",
+				"detail": "You don't have permission to create units. Contact your administrator to request access.",
+			})
+		}
 		logger.Error("Failed to create unit",
 			"operation", "create_unit",
 			"name", name,

--- a/ui/src/api/statesman_units.ts
+++ b/ui/src/api/statesman_units.ts
@@ -202,7 +202,11 @@ export async function createUnit(
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to create unit: ${response.statusText}`);
+        const errorBody = await response.json().catch(() => ({}));
+        if (response.status === 403) {
+            throw new Error(errorBody.detail || "You don't have permission to create units. Contact your administrator to request access.");
+        }
+        throw new Error(errorBody.detail || errorBody.error || `Failed to create unit: ${response.statusText}`);
     }
 
     return response.json();


### PR DESCRIPTION
Got this error message on unit creation for an old org, logs showed that it was actually a forbidden message so we have the fix for it now to properly show the error message in that case:

<img width="1116" height="734" alt="Screenshot 2026-01-15 at 17 04 30" src="https://github.com/user-attachments/assets/a07e2d39-3571-4635-baef-95eb43b3193a" />
