### PR TITLE
fix(ci): allow external contributors to run CI with Depot OIDC

### DIFF
--- a/.github/workflows/backend_test.yml
+++ b/.github/workflows/backend_test.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download Go
@@ -28,7 +31,6 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           project: f11hp4hlmg
-          token: ${{ secrets.DEPOT_TOKEN }}
           context: .
           file: ./Dockerfile_backend
           push: false

--- a/.github/workflows/ee_backend_test.yml
+++ b/.github/workflows/ee_backend_test.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download Go
@@ -28,7 +31,6 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           project: kcld4zgwzx
-          token: ${{ secrets.DEPOT_TOKEN }}
           context: .
           file: ./Dockerfile_backend_ee
           push: false

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -17,6 +17,8 @@ env:
 
 jobs:
   build-and-push:
+    # Skip for external contributors (fork PRs don't have access to secrets)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -228,7 +230,7 @@ jobs:
   summary:
     needs: [build-and-push, update-helm-chart]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Deployment Summary
         run: |


### PR DESCRIPTION
## Summary
- Switch `backend_test.yml` and `ee_backend_test.yml` to use OIDC authentication instead of `DEPOT_TOKEN` secret, enabling fork PRs to run CI
- Skip `staging-deploy.yml` for fork PRs since external contributors shouldn't trigger staging deployments

## Changes
| Workflow | Change | Behavior for Fork PRs |
|----------|--------|----------------------|
| `backend_test.yml` | OIDC auth | Runs with OIDC tokens |
| `ee_backend_test.yml` | OIDC auth | Runs with OIDC tokens |
| `staging-deploy.yml` | Skip condition | Skipped entirely |

## Manual Step Required
Configure Trust Relationships in Depot project settings to enable OIDC for `pull_request` builds from forks:
- Project `f11hp4hlmg` (backend)
- Project `kcld4zgwzx` (ee_backend)

Go to each project's settings → Trust Relationships → Enable access for `pull_request` builds from forks.

## Test plan
- [ ] Configure Depot Trust Relationships for both projects
- [ ] Merge this PR
- [ ] Test with an external fork PR to verify CI runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)