### PR TITLE
Auto-succeed digger/apply check when plan shows zero changes

### DIFF
--- a/backend/controllers/projects_helpers.go
+++ b/backend/controllers/projects_helpers.go
@@ -248,6 +248,72 @@ func UpdateCheckRunForBatch(gh utils.GithubClientProvider, batch *models.DiggerB
 				"checkRunId", *batch.CheckRunId,
 				"status", status)
 		}
+
+		// Check if plan batch succeeded with zero changes and auto-succeed the apply check
+		if batch.Status == orchestrator_scheduler.BatchJobSucceeded {
+			allJobsHaveZeroChanges := true
+			for _, job := range jobs {
+				if job.DiggerJobSummary.ResourcesCreated > 0 ||
+				   job.DiggerJobSummary.ResourcesUpdated > 0 ||
+				   job.DiggerJobSummary.ResourcesDeleted > 0 {
+					allJobsHaveZeroChanges = false
+					break
+				}
+			}
+
+			if allJobsHaveZeroChanges {
+				slog.Info("Plan batch completed with zero changes - auto-succeeding apply check",
+					"batchId", batch.ID,
+					"prNumber", batch.PrNumber,
+				)
+
+				// Find and update the digger/apply check to success
+				completedStatus := "completed"
+				successConclusion := "success"
+				applyTitle := "No changes to apply"
+				applySummary := "All plan jobs completed with zero changes. The apply check has been automatically set to succeeded."
+				applyMessage := "All terraform plans show no changes:\n\n" + message
+
+				applyOpts := github.GithubCheckRunUpdateOptions{
+					Status:     &completedStatus,
+					Conclusion: &successConclusion,
+					Title:      &applyTitle,
+					Summary:    &applySummary,
+					Text:       &applyMessage,
+					Actions:    nil, // No actions needed since there's nothing to apply
+				}
+
+				// Get the digger/apply check run for this commit and update it
+				// We need to find it by name since we don't store its ID
+				checkRuns, err := ghPrService.GetCheckRunsForCommit(batch.CommitSha)
+				if err != nil {
+					slog.Warn("Failed to get check runs for commit to update apply check",
+						"batchId", batch.ID,
+						"commitSha", batch.CommitSha,
+						"error", err,
+					)
+				} else {
+					for _, checkRun := range checkRuns {
+						if checkRun.GetName() == "digger/apply" {
+							_, err = ghPrService.UpdateCheckRun(fmt.Sprintf("%d", checkRun.GetID()), applyOpts)
+							if err != nil {
+								slog.Warn("Failed to auto-succeed apply check for zero-change plan",
+									"batchId", batch.ID,
+									"checkRunId", checkRun.GetID(),
+									"error", err,
+								)
+							} else {
+								slog.Info("Successfully auto-succeeded apply check for zero-change plan",
+									"batchId", batch.ID,
+									"checkRunId", checkRun.GetID(),
+								)
+							}
+							break
+						}
+					}
+				}
+			}
+		}
 	} else {
 		if disableDiggerApplyStatusCheck == false {
 			status := serializedBatch.ToCheckRunStatus()

--- a/backend/utils/github.go
+++ b/backend/utils/github.go
@@ -331,6 +331,18 @@ func SetPRCheckForJobs(ghService *github2.GithubService, prNumber int, jobs []sc
 				Id: strconv.FormatInt(*cr.ID, 10),
 				Url: GetCheckDetailedUrl(*cr.ID, repoOwner, repoName, prNumber),
 			}
+
+			// Also create the apply check in queued state for plan batches
+			// This will be automatically set to success if plan shows zero changes
+			slog.Debug("Setting aggregate apply status (queued) for plan batch", "prNumber", prNumber)
+			_, err = ghService.CreateCheckRun("digger/apply", "queued", "", "Waiting for plan to complete...", "The apply check will automatically succeed if there are no changes to apply", "", commitSha, nil)
+			if err != nil {
+				slog.Warn("Failed to create aggregate apply check run (queued) for plan batch",
+					"prNumber", prNumber,
+					"error", err,
+				)
+				// Don't fail the entire operation if apply check creation fails
+			}
 		} else {
 			slog.Debug("Setting aggregate apply status", "prNumber", prNumber)
 			cr, err = ghService.CreateCheckRun("digger/apply", "in_progress", "", "Pending start...", "", jobsSummaryTable, commitSha, nil)

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -599,6 +599,27 @@ func (svc GithubService) UpdateCheckRun(checkRunId string, options GithubCheckRu
 	return checkRun, err
 }
 
+func (svc GithubService) GetCheckRunsForCommit(commitSha string) ([]*github.CheckRun, error) {
+	ctx := context.Background()
+	client := svc.Client
+	owner := svc.Owner
+	repoName := svc.RepoName
+
+	opts := &github.ListCheckRunsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	checkRuns, _, err := client.Checks.ListCheckRunsForRef(ctx, owner, repoName, commitSha, opts)
+	if err != nil {
+		slog.Error("Failed to list check runs for commit",
+			"commitSha", commitSha,
+			"error", err)
+		return nil, err
+	}
+
+	return checkRuns.CheckRuns, nil
+}
+
 func (svc GithubService) GetCombinedPullRequestStatus(prNumber int) (string, error) {
 	pr, _, err := svc.Client.PullRequests.Get(context.Background(), svc.Owner, svc.RepoName, prNumber)
 	if err != nil {


### PR DESCRIPTION
This change implements automatic success for the digger/apply check when all plan jobs complete with zero infrastructure changes, eliminating the need for manual intervention in no-change scenarios.

Changes:
- Create both digger/plan and digger/apply checks when PR opens with plan jobs
- The apply check starts in "queued" state with message indicating it will auto-succeed if no changes are detected
- After plan batch completes successfully, detect if all jobs have zero changes (ResourcesCreated = 0, ResourcesUpdated = 0, ResourcesDeleted = 0)
- If all jobs have zero changes, automatically update apply check to "completed" with "success" conclusion
- Add GetCheckRunsForCommit() method to query check runs for a commit SHA

Benefits:
- Improved UX: Users see both checks immediately when PR opens
- Automation: No manual action needed for zero-change plans
- Clear communication: Check messages explain the automatic behavior
- No breaking changes: Existing behavior for plans with changes unchanged


### :brain: **Ai UsageDetails (if applicable):**

Used cursor to ship this feature in a directed way, reviewed the code and tested it myself

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._


