### PR TITLE
fix: validate and truncate characters exceeding limit

### DIFF
--- a/backend/controllers/projects_helpers.go
+++ b/backend/controllers/projects_helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"unicode/utf8"
 
 	"github.com/diggerhq/digger/backend/models"
 	"github.com/diggerhq/digger/backend/utils"
@@ -13,12 +14,11 @@ import (
 	orchestrator_scheduler "github.com/diggerhq/digger/libs/scheduler"
 )
 
-
-func GenerateChecksSummaryForBatch( batch *models.DiggerBatch) (string, error) {
+func GenerateChecksSummaryForBatch(batch *models.DiggerBatch) (string, error) {
 	summaryEndpoint := os.Getenv("DIGGER_AI_SUMMARY_ENDPOINT")
 	if summaryEndpoint == "" {
 		slog.Error("DIGGER_AI_SUMMARY_ENDPOINT not set")
-		return"", fmt.Errorf("could not generate AI summary, ai summary endpoint missing")
+		return "", fmt.Errorf("could not generate AI summary, ai summary endpoint missing")
 	}
 	apiToken := os.Getenv("DIGGER_AI_SUMMARY_API_TOKEN")
 
@@ -73,12 +73,12 @@ func GenerateChecksSummaryForBatch( batch *models.DiggerBatch) (string, error) {
 	return summary, nil
 }
 
-func GenerateChecksSummaryForJob( job *models.DiggerJob) (string, error) {
+func GenerateChecksSummaryForJob(job *models.DiggerJob) (string, error) {
 	batch := job.Batch
 	summaryEndpoint := os.Getenv("DIGGER_AI_SUMMARY_ENDPOINT")
 	if summaryEndpoint == "" {
 		slog.Error("AI summary endpoint not configured", "batch", batch.ID, "jobId", job.ID, "DiggerJobId", job.DiggerJobID)
-		return"", fmt.Errorf("could not generate AI summary, ai summary endpoint missing")
+		return "", fmt.Errorf("could not generate AI summary, ai summary endpoint missing")
 	}
 	apiToken := os.Getenv("DIGGER_AI_SUMMARY_API_TOKEN")
 
@@ -100,7 +100,7 @@ func GenerateChecksSummaryForJob( job *models.DiggerJob) (string, error) {
 	summary := ""
 
 	if job.WorkflowRunUrl != nil {
-		summary += fmt.Sprintf(":link: <a href='%v'>CI job</a>\n\n", *job.WorkflowRunUrl )
+		summary += fmt.Sprintf(":link: <a href='%v'>CI job</a>\n\n", *job.WorkflowRunUrl)
 	}
 
 	if aiSummary != "FOUR_OH_FOUR" {
@@ -109,7 +109,6 @@ func GenerateChecksSummaryForJob( job *models.DiggerJob) (string, error) {
 
 	return summary, nil
 }
-
 
 func UpdateCheckRunForBatch(gh utils.GithubClientProvider, batch *models.DiggerBatch) error {
 	slog.Info("Updating PR status for batch",
@@ -284,7 +283,6 @@ func UpdateCheckRunForBatch(gh utils.GithubClientProvider, batch *models.DiggerB
 	return nil
 }
 
-
 // more modern check runs on github have their own page
 func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) error {
 	batch := job.Batch
@@ -359,11 +357,11 @@ func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) 
 			"error", err)
 		return fmt.Errorf("could not get conclusion for job: %v", err)
 	}
-	
+
 	// Validate status and conclusion before sending to GitHub
 	validStatuses := map[string]bool{"queued": true, "in_progress": true, "completed": true}
 	validConclusions := map[string]bool{"": true, "success": true, "failure": true, "neutral": true, "cancelled": true, "timed_out": true, "action_required": true, "skipped": true}
-	
+
 	if !validStatuses[status] {
 		slog.Warn("Invalid Check Run status detected",
 			"jobId", job.DiggerJobID,
@@ -371,7 +369,7 @@ func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) 
 			"checkRunStatus", status,
 			"validStatuses", []string{"queued", "in_progress", "completed"})
 	}
-	
+
 	if !validConclusions[conclusion] {
 		slog.Warn("Invalid Check Run conclusion detected",
 			"jobId", job.DiggerJobID,
@@ -379,7 +377,7 @@ func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) 
 			"checkRunConclusion", conclusion,
 			"validConclusions", []string{"", "success", "failure", "neutral", "cancelled", "timed_out", "action_required", "skipped"})
 	}
-	
+
 	slog.Debug("Preparing to update Check Run for job",
 		"jobId", job.DiggerJobID,
 		"jobStatus", job.Status,
@@ -394,11 +392,19 @@ func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) 
 		conclusionPtr = &conclusion
 	}
 
+	// Character limit check - GitHub check run text field has a 65535 character limit
+	const maxCheckRunTextLength = 65535
+	cutOffMsg := "\n[Character limit exceeded, output truncated]"
+	if utf8.RuneCountInString(job.TerraformOutput) > maxCheckRunTextLength {
+		runes := []rune(job.TerraformOutput)
+		truncateAt := maxCheckRunTextLength - utf8.RuneCountInString(cutOffMsg)
+		job.TerraformOutput = string(runes[:truncateAt]) + cutOffMsg
+	}
+
 	text := "" +
 		"```terraform\n" +
 		job.TerraformOutput +
 		"```\n"
-
 
 	var summary = ""
 	if job.Status == orchestrator_scheduler.DiggerJobSucceeded || job.Status == orchestrator_scheduler.DiggerJobFailed {
@@ -407,7 +413,6 @@ func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) 
 			slog.Warn("Error generating checks summary for batch", "batchId", batch.ID, "error", err)
 		}
 	}
-
 
 	slog.Debug("Updating PR status for job", "jobId", job.DiggerJobID, "status", status, "conclusion", conclusion)
 	if isPlan {

--- a/backend/controllers/projects_test.go
+++ b/backend/controllers/projects_test.go
@@ -2,7 +2,9 @@ package controllers
 
 import (
 	"net/http"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/diggerhq/digger/backend/models"
 	"github.com/diggerhq/digger/backend/utils"
@@ -111,4 +113,56 @@ func TestAutomergeWhenBatchIsSuccessfulStatus(t *testing.T) {
 	err = AutomergePRforBatchIfEnabled(gh, &batch)
 	assert.NoError(t, err)
 	assert.True(t, isMergeCalled)
+}
+
+func TestCharacterLimit(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputLength    int
+		expectTruncate bool
+	}{
+		{
+			name:           "under limit - no truncation",
+			inputLength:    1000,
+			expectTruncate: false,
+		},
+		{
+			name:           "at limit - no truncation",
+			inputLength:    65535,
+			expectTruncate: false,
+		},
+		{
+			name:           "over limit - truncation applied",
+			inputLength:    70000,
+			expectTruncate: true,
+		},
+	}
+
+	const maxCheckRunTextLength = 65535
+	cutOffMsg := "\n[Character limit exceeded, output truncated]"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := strings.Repeat("a", tt.inputLength)
+
+			result := input
+			if utf8.RuneCountInString(result) > maxCheckRunTextLength {
+				runes := []rune(result)
+				truncateAt := maxCheckRunTextLength - utf8.RuneCountInString(cutOffMsg)
+				result = string(runes[:truncateAt]) + cutOffMsg
+			}
+
+			if tt.expectTruncate {
+				assert.Equal(t, maxCheckRunTextLength, utf8.RuneCountInString(result),
+					"truncated output should be exactly 65535 characters")
+				assert.True(t, strings.HasSuffix(result, cutOffMsg),
+					"truncated output should end with cutoff message")
+			} else {
+				assert.Equal(t, tt.inputLength, utf8.RuneCountInString(result),
+					"non-truncated output should maintain original length")
+				assert.False(t, strings.HasSuffix(result, cutOffMsg),
+					"non-truncated output should not have cutoff message")
+			}
+		})
+	}
 }


### PR DESCRIPTION
as pointed out in #2542 , Github enforces a character limit of 65535, this PR adds a check to ensure terraform output does not exceed this limit and if it does, truncate the output to avoid hitting the charcter limit 


