### PR TITLE
Allow trusted bot comments via trusted_appIDs

### DIFF
--- a/backend/controllers/github.go
+++ b/backend/controllers/github.go
@@ -113,11 +113,6 @@ func (d DiggerController) GithubAppWebHook(c *gin.Context) {
 			"issueNumber", *event.Issue.Number,
 		)
 
-		if event.Sender.Type != nil && *event.Sender.Type == "Bot" {
-			slog.Debug("Ignoring bot comment", "senderType", *event.Sender.Type)
-			c.String(http.StatusOK, "OK")
-			return
-		}
 		go func(ctx context.Context) {
 			defer logging.InheritRequestLogger(ctx)()
 			handleIssueCommentEvent(gh, event, d.CiBackendProvider, appId64, d.GithubWebhookPostIssueCommentHooks)

--- a/backend/controllers/github_comment.go
+++ b/backend/controllers/github_comment.go
@@ -173,6 +173,27 @@ func handleIssueCommentEvent(gh utils.GithubClientProvider, payload *github.Issu
 		return fmt.Errorf("error getting digger config")
 	}
 
+	if payload.Sender.GetType() == "Bot" {
+		if lo.Contains(prLabelsStr, "digger:allowbot") {
+			slog.Info("Allowing bot comment due to label override",
+				"issueNumber", issueNumber,
+				"label", "digger:allowbot",
+			)
+		} else {
+			commentUserID := payload.GetComment().GetUser().GetID()
+			if commentUserID == 0 {
+				commentUserID = payload.GetSender().GetID()
+			}
+			if !lo.Contains(config.TrustedAppIDs, commentUserID) {
+				slog.Info("Ignoring bot comment from untrusted app",
+					"issueNumber", issueNumber,
+					"commentUserId", commentUserID,
+				)
+				return nil
+			}
+		}
+	}
+
 	if config.DisableDiggerApplyComment && strings.HasPrefix(cleanedComment, "digger apply") {
 		slog.Info("Digger configured to disable apply comment in PRs, ignoring comment", "DisableDiggerApplyComment", config.DisableDiggerApplyComment)
 		if os.Getenv("DIGGER_REPORT_BEFORE_LOADING_CONFIG") == "1" {

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -35,6 +35,8 @@ report_terraform_outputs: true
 mention_drifted_projects_in_pr: false
 disable_digger_apply_comment: false
 disable_digger_apply_status_check: false
+trusted_appIDs:
+  - 41898282
 respect_layers: false
 reporting:
   ai_summary: false
@@ -199,6 +201,10 @@ workflows:
 
 <ParamField path="disable_digger_apply_status_check" type="boolean" default="false">
   Disable the status check that verifies apply was executed.
+</ParamField>
+
+<ParamField path="trusted_appIDs" type="array" default="[]">
+  Allow bot comments from these GitHub user IDs. Example: `trusted_appIDs: [41898282]` for GitHub Actions.
 </ParamField>
 
 <ParamField path="comment_render_mode" type="string" default="basic">

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -25,6 +25,7 @@ type DiggerConfig struct {
 	AutoMerge                     bool
 	AutoMergeStrategy             AutomergeStrategy
 	Telemetry                     bool
+	TrustedAppIDs                 []int64
 	Workflows                     map[string]Workflow
 	MentionDriftedProjectsInPR    bool
 	TraverseToNestedProjects      bool

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -280,6 +280,12 @@ func ConvertDiggerYamlToConfig(diggerYaml *DiggerConfigYaml) (*DiggerConfig, gra
 		diggerConfig.CommentRenderMode = CommentRenderModeBasic
 	}
 
+	if diggerYaml.TrustedAppIDs != nil {
+		diggerConfig.TrustedAppIDs = append([]int64(nil), diggerYaml.TrustedAppIDs...)
+	} else {
+		diggerConfig.TrustedAppIDs = []int64{}
+	}
+
 	if diggerYaml.MentionDriftedProjectsInPR != nil {
 		diggerConfig.MentionDriftedProjectsInPR = *diggerYaml.MentionDriftedProjectsInPR
 	} else {

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -19,6 +19,7 @@ type DiggerConfigYaml struct {
 	Projects                      []*ProjectYaml               `yaml:"projects"`
 	AutoMerge                     *bool                        `yaml:"auto_merge"`
 	AutoMergeStrategy             *string                      `yaml:"auto_merge_strategy"`
+	TrustedAppIDs                 []int64                      `yaml:"trusted_appIDs,omitempty"`
 	CommentRenderMode             *string                      `yaml:"comment_render_mode"`
 	Workflows                     map[string]*WorkflowYaml     `yaml:"workflows"`
 	Telemetry                     *bool                        `yaml:"telemetry,omitempty"`


### PR DESCRIPTION
Add an optional trusted_appIDs list to the config file, and moved the comment bot filter from the webhook entrypoint down into the comment handler, which is sort of where I would've expected to find it.  I won't be offended if you want it moved back up to where it will reject earlier, but this made sense to me. :)  I also won't be offended if it turns out this is garbage, because my golang...  It's not good.

Also allow comments from all bot accounts when the digger:allowbot PR label is applied.

Closes https://github.com/diggerhq/digger/issues/2553

### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> I used ChatGPT Codex to make the initial code changes because my golang is weak; reviewed and cleaned up manually.