### PR TITLE
always infer orgID and userID from session

### DIFF
--- a/ui/src/api/helpers.ts
+++ b/ui/src/api/helpers.ts
@@ -1,15 +1,34 @@
+import { withAuth } from '@/authkit/ssr/session';
+
 function redirectWithFallback(redirectUri: string, headers?: Headers) {
     const newHeaders = headers ? new Headers(headers) : new Headers();
     newHeaders.set('Location', redirectUri);
-  
+
     return new Response(null, { status: 307, headers: newHeaders });
   }
-  
+
   function errorResponseWithFallback(errorBody: { error: { message: string; description: string } }) {
     return new Response(JSON.stringify(errorBody), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+/**
+ * Requires authentication and returns session-derived user identity.
+ * Use this instead of accepting userId/organizationId from client input
+ * to prevent IDOR vulnerabilities.
+ */
+export async function requireAuth() {
+  const auth = await withAuth();
+  if (!auth.user) {
+    throw new Error('Unauthorized');
+  }
+  return {
+    userId: auth.user.id,
+    email: auth.user.email!,
+    organizationId: auth.organizationId!,
+  };
+}
 
 export { redirectWithFallback, errorResponseWithFallback };

--- a/ui/src/api/orchestrator_serverFunctions.ts
+++ b/ui/src/api/orchestrator_serverFunctions.ts
@@ -4,31 +4,28 @@ import { fetchRepos } from "./orchestrator_repos";
 import { getOrgSettings, updateOrgSettings } from "./orchestrator_orgs";
 import { testSlackWebhook } from "./drift_slack";
 import { fetchProjects, updateProject, fetchProject } from "./orchestrator_projects";
+import { requireAuth } from "./helpers";
 
 export const getOrgSettingsFn = createServerFn({method: 'GET'})
-  .inputValidator((data : {userId: string, organisationId: string}) => data)
-  .handler(async ({ data }) => {
-    const settings : any = await getOrgSettings(data.organisationId, data.userId)
+  .handler(async () => {
+    const auth = await requireAuth();
+    const settings : any = await getOrgSettings(auth.organizationId, auth.userId)
     return settings
 })
 
 export const updateOrgSettingsFn = createServerFn({method: 'POST'})
-  .inputValidator((data : {userId: string, organisationId: string, settings: OrgSettings}) => data)
+  .inputValidator((data : {settings: OrgSettings}) => data)
   .handler(async ({ data }) => {
-    const settings : any = await updateOrgSettings(data.organisationId, data.userId, data.settings)
+    const auth = await requireAuth();
+    const settings : any = await updateOrgSettings(auth.organizationId, auth.userId, data.settings)
     return settings.result
 })
 
 export const getProjectsFn = createServerFn({method: 'GET'})
-    .inputValidator((data : {userId: string, organisationId: string}) => {
-      if (!data.userId || !data.organisationId) {
-        throw new Error('Missing required fields: userId and organisationId are required')
-      }
-      return data
-    })
-    .handler(async ({ data }) => {
+    .handler(async () => {
+      const auth = await requireAuth();
       try {
-        const projects : any = await fetchProjects(data.organisationId, data.userId)
+        const projects : any = await fetchProjects(auth.organizationId, auth.userId)
         return projects.result || []
       } catch (error) {
         console.error('Error in getProjectsFn:', error)
@@ -38,66 +35,69 @@ export const getProjectsFn = createServerFn({method: 'GET'})
 
 
 export const updateProjectFn = createServerFn({method: 'POST'})
-    .inputValidator((data : {projectId: string, driftEnabled: boolean, organisationId: string, userId: string}) => data)
+    .inputValidator((data : {projectId: string, driftEnabled: boolean}) => data)
     .handler(async ({ data }) => {
-    const project : any = await updateProject(data.projectId, data.driftEnabled, data.organisationId, data.userId)
-    return project.result
+      const auth = await requireAuth();
+      const project : any = await updateProject(data.projectId, data.driftEnabled, auth.organizationId, auth.userId)
+      return project.result
   })
 
 export const getReposFn = createServerFn({method: 'GET'})
-    .inputValidator((data : {organisationId: string, userId: string}) => data)
-    .handler(async ({ data }) => {
-    let repos = []
-    try {
-        const reposData :any = await fetchRepos(data.organisationId, data.userId)
-        repos = reposData.result
-      } catch (error) {
-        console.error('Error fetching repos:', error)
-        throw error
-      }
-      return repos
+    .handler(async () => {
+      const auth = await requireAuth();
+      let repos = []
+      try {
+          const reposData :any = await fetchRepos(auth.organizationId, auth.userId)
+          repos = reposData.result
+        } catch (error) {
+          console.error('Error fetching repos:', error)
+          throw error
+        }
+        return repos
   })
 
 export const getProjectFn = createServerFn({method: 'GET'})
-    .inputValidator((data : {projectId: string, organisationId: string, userId: string}) => data)
+    .inputValidator((data : {projectId: string}) => data)
     .handler(async ({ data }) => {
-    const project : any = await fetchProject(data.projectId, data.organisationId, data.userId)
-    return project
+      const auth = await requireAuth();
+      const project : any = await fetchProject(data.projectId, auth.organizationId, auth.userId)
+      return project
   })
 
 
 export const getRepoDetailsFn = createServerFn({method: 'GET'})
-    .inputValidator((data : {repoId: string, organisationId: string, userId: string}) => data)
+    .inputValidator((data : {repoId: string}) => data)
     .handler(async ({ data }) => {
-      const { repoId, organisationId, userId } = data;
+      const auth = await requireAuth();
+      const { repoId } = data;
       let allJobs: Job[] = [];
-      let repo: Repo 
+      let repo: Repo
       try {
         const response = await fetch(`${process.env.ORCHESTRATOR_BACKEND_URL}/api/repos/${repoId}/jobs`, {
           method: 'GET',
           headers: {
             'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
-            'DIGGER_ORG_ID': organisationId,
-            'DIGGER_USER_ID': userId,
+            'DIGGER_ORG_ID': auth.organizationId,
+            'DIGGER_USER_ID': auth.userId,
             'DIGGER_ORG_SOURCE': 'workos',
           },
         });
-      
+
         if (!response.ok) {
           throw new Error('Failed to fetch jobs');
         }
-      
+
         const result = await response.json();
-        
-        repo = result.repo    
+
+        repo = result.repo
         allJobs = result.jobs || []
-    
+
       } catch (error) {
         console.error('Error fetching jobs:', error);
         allJobs = [];
         throw error
       }
-  
+
       return { repo, allJobs }
     })
 
@@ -106,4 +106,3 @@ export const switchToOrganizationFn = createServerFn({method: 'POST'})
     .handler(async ({ data }) => {
       return null
     })
-

--- a/ui/src/api/statesman_serverFunctions.ts
+++ b/ui/src/api/statesman_serverFunctions.ts
@@ -1,75 +1,81 @@
 import { createServerFn } from "@tanstack/react-start"
 import { createUnit, getUnit, listUnits, getUnitVersions, unlockUnit, lockUnit, getUnitStatus, deleteUnit, downloadLatestState, forcePushState, restoreUnitStateVersion } from "./statesman_units"
+import { requireAuth } from "./helpers"
 
 export const listUnitsFn = createServerFn({method: 'GET'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string}) => data)
-  .handler(async ({ data }) => {
-    const units : any = await listUnits(data.organisationId, data.userId, data.email);
+  .handler(async () => {
+    const auth = await requireAuth();
+    const units : any = await listUnits(auth.organizationId, auth.userId, auth.email);
     return units;
 })
 
 export const getUnitFn = createServerFn({method: 'GET'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    const unit : any = await getUnit(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    const unit : any = await getUnit(auth.organizationId, auth.userId, auth.email, data.unitId)
     return unit
 })
 
 export const getUnitVersionsFn = createServerFn({method: 'GET'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    const unitVersions : any = await getUnitVersions(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    const unitVersions : any = await getUnitVersions(auth.organizationId, auth.userId, auth.email, data.unitId)
     return unitVersions
 })
 
 export const lockUnitFn = createServerFn({method: 'POST'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    const unit : any = await lockUnit(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    const unit : any = await lockUnit(auth.organizationId, auth.userId, auth.email, data.unitId)
     return unit
 })
 
 export const unlockUnitFn = createServerFn({method: 'POST'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    const unit : any = await unlockUnit(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    const unit : any = await unlockUnit(auth.organizationId, auth.userId, auth.email, data.unitId)
     return unit
 })
 
 export const downloadLatestStateFn = createServerFn({method: 'GET'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    const state : any = await downloadLatestState(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    const state : any = await downloadLatestState(auth.organizationId, auth.userId, auth.email, data.unitId)
     return state
 })
 
 export const forcePushStateFn = createServerFn({method: 'POST'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string, state: string}) => data)
+  .inputValidator((data : {unitId: string, state: string}) => data)
   .handler(async ({ data }) => {
-    const state : any = await forcePushState(data.organisationId, data.userId, data.email, data.unitId, data.state)
+    const auth = await requireAuth();
+    const state : any = await forcePushState(auth.organizationId, auth.userId, auth.email, data.unitId, data.state)
     return state
 })
 
 export const restoreUnitStateVersionFn = createServerFn({method: 'POST'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string, timestamp: string, lockId: string}) => data)
+  .inputValidator((data : {unitId: string, timestamp: string, lockId: string}) => data)
   .handler(async ({ data }) => {
-    const state : any = await restoreUnitStateVersion(data.organisationId, data.userId, data.email, data.unitId, data.timestamp, data.lockId)
+    const auth = await requireAuth();
+    const state : any = await restoreUnitStateVersion(auth.organizationId, auth.userId, auth.email, data.unitId, data.timestamp, data.lockId)
     return state
 })
 
 export const getUnitStatusFn = createServerFn({method: 'GET'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    const unitStatus : any = await getUnitStatus(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    const unitStatus : any = await getUnitStatus(auth.organizationId, auth.userId, auth.email, data.unitId)
     return unitStatus
 })
 
 export const createUnitFn = createServerFn({method: 'POST'})
   .inputValidator((data : {
-    userId: string, 
-    organisationId: string, 
-    email: string, 
-    name: string, 
+    name: string,
     requestId?: string,
     tfeAutoApply?: boolean,
     tfeExecutionMode?: string,
@@ -78,10 +84,11 @@ export const createUnitFn = createServerFn({method: 'POST'})
     tfeWorkingDirectory?: string
   }) => data)
   .handler(async ({ data }) => {
+    const auth = await requireAuth();
     const unit : any = await createUnit(
-      data.organisationId, 
-      data.userId, 
-      data.email, 
+      auth.organizationId,
+      auth.userId,
+      auth.email,
       data.name,
       data.tfeAutoApply,
       data.tfeExecutionMode,
@@ -94,9 +101,6 @@ export const createUnitFn = createServerFn({method: 'POST'})
 
 export const updateUnitFn = createServerFn({method: 'POST'})
   .inputValidator((data : {
-    userId: string, 
-    organisationId: string, 
-    email: string, 
     unitId: string,
     tfeAutoApply?: boolean,
     tfeExecutionMode?: string,
@@ -105,11 +109,12 @@ export const updateUnitFn = createServerFn({method: 'POST'})
     tfeWorkingDirectory?: string
   }) => data)
   .handler(async ({ data }) => {
+    const auth = await requireAuth();
     const { updateUnit } = await import("./statesman_units")
     const unit : any = await updateUnit(
-      data.organisationId, 
-      data.userId, 
-      data.email, 
+      auth.organizationId,
+      auth.userId,
+      auth.email,
       data.unitId,
       data.tfeAutoApply,
       data.tfeExecutionMode,
@@ -121,7 +126,8 @@ export const updateUnitFn = createServerFn({method: 'POST'})
 })
 
 export const deleteUnitFn = createServerFn({method: 'POST'})
-  .inputValidator((data : {userId: string, organisationId: string, email: string, unitId: string}) => data)
+  .inputValidator((data : {unitId: string}) => data)
   .handler(async ({ data }) => {
-    await deleteUnit(data.organisationId, data.userId, data.email, data.unitId)
+    const auth = await requireAuth();
+    await deleteUnit(auth.organizationId, auth.userId, auth.email, data.unitId)
 })

--- a/ui/src/api/tokens_serverFunctions.ts
+++ b/ui/src/api/tokens_serverFunctions.ts
@@ -2,17 +2,19 @@ import { createServerFn } from "@tanstack/react-start";
 import { createToken, getTokens } from "./tokens";
 import { verifyToken } from "./tokens";
 import { deleteToken } from "./tokens";
+import { requireAuth } from "./helpers";
 
 export const getTokensFn = createServerFn({method: 'GET'})
-    .inputValidator((data: {organizationId: string, userId: string}) => data)
-    .handler(async ({data: {organizationId, userId}}) => {
-        return getTokens(organizationId, userId);
+    .handler(async () => {
+        const auth = await requireAuth();
+        return getTokens(auth.organizationId, auth.userId);
 })
 
 export const createTokenFn = createServerFn({method: 'POST'})
-    .inputValidator((data: {organizationId: string, userId: string, name: string, expiresAt: string | null}) => data)
-    .handler(async ({data: {organizationId, userId, name, expiresAt}}) => {
-        return createToken(organizationId, userId, name, expiresAt);
+    .inputValidator((data: {name: string, expiresAt: string | null}) => data)
+    .handler(async ({data: {name, expiresAt}}) => {
+        const auth = await requireAuth();
+        return createToken(auth.organizationId, auth.userId, name, expiresAt);
 })
 
 export const verifyTokenFn = createServerFn({method: 'POST'})
@@ -22,7 +24,8 @@ export const verifyTokenFn = createServerFn({method: 'POST'})
 })
 
 export const deleteTokenFn = createServerFn({method: 'POST'})
-    .inputValidator((data: {organizationId: string, userId: string, tokenId: string}) => data)
-    .handler(async ({data: {organizationId, userId, tokenId}}) => {
-        return deleteToken(organizationId, userId, tokenId);
+    .inputValidator((data: {tokenId: string}) => data)
+    .handler(async ({data: {tokenId}}) => {
+        const auth = await requireAuth();
+        return deleteToken(auth.organizationId, auth.userId, tokenId);
 })

--- a/ui/src/authkit/serverFunctions.ts
+++ b/ui/src/authkit/serverFunctions.ts
@@ -9,6 +9,7 @@ import { WidgetScope } from 'node_modules/@workos-inc/node/lib/widgets/interface
 import { syncOrgToBackend } from '@/api/orchestrator_orgs';
 import { syncOrgToStatesman } from '@/api/statesman_orgs';
 import { serverCache } from '@/lib/cache.server';
+import { requireAuth } from '@/api/helpers';
 
 export const getAuthorizationUrl = createServerFn({ method: 'GET' })
   .inputValidator((options?: GetAuthURLOptions) => options)
@@ -46,20 +47,21 @@ export const getOrganisationDetails = createServerFn({method: 'GET'})
 
 
 export const createOrganization = createServerFn({method: 'POST'})
-  .inputValidator((data: {name: string, userId: string, email: string}) => data)
-  .handler(async ({data: {name, userId, email}}) : Promise<Organization> => {
+  .inputValidator((data: {name: string}) => data)
+  .handler(async ({data: {name}}) : Promise<Organization> => {
+    const auth = await requireAuth();
     try {
       const organization = await getWorkOS().organizations.createOrganization({ name: name });
 
       await getWorkOS().userManagement.createOrganizationMembership({
         organizationId: organization.id,
-        userId: userId,
+        userId: auth.userId,
         roleSlug: "admin",
       });
 
       try {
-        await syncOrgToBackend(organization.id, organization.name, email);
-        await syncOrgToStatesman(organization.id, organization.name, organization.name, userId, email);
+        await syncOrgToBackend(organization.id, organization.name, auth.email);
+        await syncOrgToStatesman(organization.id, organization.name, organization.name, auth.userId, auth.email);
       } catch (error) {
         console.error('Error syncing organization to backend:', error);
         throw error;
@@ -132,26 +134,27 @@ export const ensureOrgExists = createServerFn({method: 'GET'})
 
 
 export const getWidgetsAuthToken = createServerFn({method: 'GET'})
-    .inputValidator((args: {userId: string, organizationId: string, scopes?: WidgetScope[]}) => args)
-    .handler(async ({data: {userId, organizationId, scopes}}) : Promise<string> => {
+    .inputValidator((args: {scopes?: WidgetScope[]}) => args)
+    .handler(async ({data: {scopes}}) : Promise<string> => {
+  const auth = await requireAuth();
   // Check cache first
-  const cached = serverCache.getWidgetToken(userId, organizationId);
+  const cached = serverCache.getWidgetToken(auth.userId, auth.organizationId);
   if (cached) {
-    console.debug(`✅ Widget token cache hit for ${userId}:${organizationId}`);
+    console.debug(`✅ Widget token cache hit for ${auth.userId}:${auth.organizationId}`);
     return cached;
   }
-  
+
   // Cache miss - generate new token
-  console.debug(`❌ Widget token cache miss, generating new token for ${userId}:${organizationId}`);
+  console.debug(`❌ Widget token cache miss, generating new token for ${auth.userId}:${auth.organizationId}`);
   const token = await getWorkOS().widgets.getToken({
-    userId: userId,
-    organizationId: organizationId,
+    userId: auth.userId,
+    organizationId: auth.organizationId,
     scopes: scopes ?? ['widgets:users-table:manage'] as WidgetScope[],
   });
-  
+
   // Store in cache
-  serverCache.setWidgetToken(userId, organizationId, token);
-  
+  serverCache.setWidgetToken(auth.userId, auth.organizationId, token);
+
   return token;
 })
 

--- a/ui/src/components/CreateOrganisationButtonWOS.tsx
+++ b/ui/src/components/CreateOrganisationButtonWOS.tsx
@@ -29,7 +29,7 @@ function validateOrgName(name: string): string | null {
   return null;
 }
 
-export default function CreateOrganizationBtn({ userId, email }: { userId: string, email: string }) {
+export default function CreateOrganizationBtn() {
   const [name, setName] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -65,7 +65,7 @@ export default function CreateOrganizationBtn({ userId, email }: { userId: strin
     }
     
     try {
-      const organization = await createOrganization({ data: { name: name.trim(), userId: userId, email: email } });
+      const organization = await createOrganization({ data: { name: name.trim() } });
       toast({
         title: "Organization created",
         description: "The page will now reload to refresh organisations list. To use this new organization, select it from the list.",

--- a/ui/src/components/OnboardingSteps.tsx
+++ b/ui/src/components/OnboardingSteps.tsx
@@ -511,9 +511,6 @@ jobs:
 
                 {!steps.unitCreated && (
                   <UnitCreateForm
-                    userId={userId}
-                    email={email}
-                    organisationId={organisationId}
                     onCreated={handleCreateUnit}
                     onBringOwnState={() => { setOnboardingMode('pr_only'); setCurrentStep('github') }}
                   />

--- a/ui/src/components/UnitCreateForm.tsx
+++ b/ui/src/components/UnitCreateForm.tsx
@@ -8,9 +8,6 @@ import { createUnitFn } from '@/api/statesman_serverFunctions'
 import { Cloud, HardDrive } from 'lucide-react'
 
 type UnitCreateFormProps = {
-  userId: string
-  email: string
-  organisationId: string
   onCreated: (unit: { id: string; name: string }) => void
   onCreatedOptimistic?: (tempUnit: { id: string; name: string; isOptimistic: boolean }) => void
   onCreatedFailed?: () => void
@@ -18,15 +15,12 @@ type UnitCreateFormProps = {
   showBringOwnState?: boolean
 }
 
-export default function UnitCreateForm({ 
-  userId, 
-  email, 
-  organisationId, 
-  onCreated, 
+export default function UnitCreateForm({
+  onCreated,
   onCreatedOptimistic,
   onCreatedFailed,
-  onBringOwnState, 
-  showBringOwnState = true 
+  onBringOwnState,
+  showBringOwnState = true
 }: UnitCreateFormProps) {
   const [unitName, setUnitName] = React.useState('')
   const [unitType, setUnitType] = React.useState<'local' | 'remote'>('local')
@@ -57,9 +51,6 @@ const remoteRunsEnabled = true
       const finalUnitType = remoteRunsEnabled ? unitType : 'local'
       const unit = await createUnitFn({
         data: {
-          userId,
-          organisationId,
-          email,
           name: unitName.trim(),
           // Enable TFE remote execution for remote type
           // Auto-apply defaults to false - user must explicitly approve applies
@@ -69,12 +60,6 @@ const remoteRunsEnabled = true
           tfeEngine: finalUnitType === 'remote' ? engine : undefined,
         },
       })
-      // analytics: track unit creation
-      try {
-        const user = { id: userId, email }
-        const { trackUnitCreated } = await import('@/lib/analytics')
-        trackUnitCreated(user, organisationId, { id: unit.id, name: unit.name })
-      } catch {}
       onCreated({ id: unit.id, name: unit.name })
     } catch (e: any) {
       setError(e?.message ?? 'Failed to create unit')

--- a/ui/src/components/UnitStateForceUploadDialog.tsx
+++ b/ui/src/components/UnitStateForceUploadDialog.tsx
@@ -12,7 +12,7 @@ import { Upload } from 'lucide-react'
 import { forcePushStateFn } from '@/api/statesman_serverFunctions'
 import { toast } from '@/hooks/use-toast'
 
-export default function UnitStateForceUploadDialog({ userId, organisationId, userEmail, unitId, isDisabled }: { userId: string, organisationId: string, userEmail: string, unitId: string, isDisabled: boolean }) {
+export default function UnitStateForceUploadDialog({ unitId, isDisabled }: { unitId: string, isDisabled: boolean }) {
   const [open, setOpen] = useState(false)
   const [fileContent, setFileContent] = useState<string | null>(null)
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
@@ -41,9 +41,6 @@ export default function UnitStateForceUploadDialog({ userId, organisationId, use
       setStatus('loading')
       await forcePushStateFn({
         data: {
-          userId: userId,
-          organisationId: organisationId,
-          email: userEmail,
           unitId: unitId,
           state: fileContent,
         },

--- a/ui/src/components/WorkosOrgSwitcher.tsx
+++ b/ui/src/components/WorkosOrgSwitcher.tsx
@@ -6,8 +6,6 @@ import { OrganizationSwitcher, WorkOsWidgets } from '@workos-inc/widgets'
 import { DropdownMenu } from '@radix-ui/themes'
 
 type WorkosOrgSwitcherProps = {
-  userId: string
-  organisationId: string
   label?: string
   redirectTo?: string
   /**
@@ -22,8 +20,6 @@ type WorkosOrgSwitcherProps = {
 }
 
 export default function WorkosOrgSwitcher({
-  userId,
-  organisationId,
   label = 'My Orgs',
   redirectTo = '/dashboard/units',
   wrapWithProvider = false,
@@ -65,7 +61,7 @@ export default function WorkosOrgSwitcher({
   React.useEffect(() => {
     (async () => {
       try {
-        const token = await getWidgetsAuthToken({ data: { userId, organizationId: organisationId } })
+        const token = await getWidgetsAuthToken({ data: {} })
         setAuthToken(token)
         setLoading(false)
       } catch (e: any) {
@@ -73,7 +69,7 @@ export default function WorkosOrgSwitcher({
         setLoading(false)
       }
     })()
-  }, [userId, organisationId])
+  }, [])
 
   if (loading) return <p>Loading WorkOS…</p>
   if (error) return <p className="text-red-600">Error: {error}</p>

--- a/ui/src/components/WorkosSettings.tsx
+++ b/ui/src/components/WorkosSettings.tsx
@@ -71,7 +71,7 @@ export function WorkosSettings({ userId, email, organisationId, role }: WorkosSe
   React.useEffect(() => {
     (async () => {
       try {
-        const authToken = await getWidgetsAuthToken({ data: { userId, organizationId: organisationId } });
+        const authToken = await getWidgetsAuthToken({ data: {} });
         setAuthToken(authToken);
         setLoading(false);
       } catch (e: any) {
@@ -79,7 +79,7 @@ export function WorkosSettings({ userId, email, organisationId, role }: WorkosSe
         setLoading(false);
       }
     })();
-  }, [userId, organisationId]);
+  }, []);
 
 
   if (loading) return <p>Loading WorkOS…</p>;
@@ -96,7 +96,7 @@ export function WorkosSettings({ userId, email, organisationId, role }: WorkosSe
         />
         <div className="h-4" />
         {/* Add your org creation UI here */}
-        <CreateOrganizationBtn userId={userId} email={email} />
+        <CreateOrganizationBtn />
         <div className="h-4" />
         <UserProfile authToken={authToken} />
         <div className="h-4" />

--- a/ui/src/routes/_authenticated/_dashboard.tsx
+++ b/ui/src/routes/_authenticated/_dashboard.tsx
@@ -40,7 +40,7 @@ function DashboardComponent() {
                   
                 </h3>}
                 <div className="mt-2" />
-                {workosEnabled && <WorkosOrgSwitcher userId={user?.id || ''} organisationId={organisationId || ''} showSettingsItem />}
+                {workosEnabled && <WorkosOrgSwitcher showSettingsItem />}
                 
                 <div className="h-[1px] bg-border mt-2" />
               </div>

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/drift.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/drift.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute(
   pendingComponent: PageLoading,
   loader: async ({ context }) => {
     const { user, organisationId } = context;
-    const settings = await getOrgSettingsFn({data: {userId: user?.id || '', organisationId: organisationId || ''}})
+    const settings = await getOrgSettingsFn()
     return { settings, user, organisationId }
   }
 })
@@ -43,7 +43,7 @@ function RouteComponent() {
     const handleSave = async () => {
         try {
           setSaving(true)
-          await updateOrgSettingsFn({data: {userId: user?.id || '', organisationId: organisationId || '', settings: settingsState}})
+          await updateOrgSettingsFn({data: {settings: settingsState}})
           toast({
             title: "Success",
             description: "Slack webhook settings saved successfully",

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/projects.$projectid.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/projects.$projectid.tsx
@@ -46,7 +46,7 @@ export const Route = createFileRoute(
   ),
   loader: async ({ context, params: {projectid} }) => {
     const { user, organisationId } = context;
-    const project = await getProjectFn({data: {projectId: projectid, organisationId, userId: user?.id || ''}})
+    const project = await getProjectFn({data: {projectId: projectid}})
 
     return { project }
   }

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/projects.index.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/projects.index.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute(
   loader: async ({ context }) => {
     const { user, organisationId } = context;
     try {
-      const projects = await getProjectsFn({data: {userId: user?.id || '', organisationId: organisationId || ''}})
+      const projects = await getProjectsFn()
       return { projects, user, organisationId }
     } catch (error) {
       console.error('Error loading projects:', error);
@@ -50,9 +50,7 @@ function RouteComponent() {
                 {
                     data: {
                         projectId: project.id.toString(),
-                        driftEnabled: !project.drift_enabled,
-                        organisationId: organisationId || "",
-                        userId: user?.id || ""
+                        driftEnabled: !project.drift_enabled
                     }
                 }
             );

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/repos.$repoId.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/repos.$repoId.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/_authenticated/_dashboard/dashboard/repos
   pendingComponent: PageLoading,
   loader: async ({ params: {repoId}, context }) => {
     const { user, organisationId } = context;
-    const { repo, allJobs } = await getRepoDetailsFn({data: {repoId, organisationId, userId: user?.id || ''}})
+    const { repo, allJobs } = await getRepoDetailsFn({data: {repoId}})
     return { repo, allJobs }
   }
 })

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/repos.index.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/repos.index.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute('/_authenticated/_dashboard/dashboard/repos
   pendingComponent: PageLoading,
   loader: async ({ context }) => {
     const { user, organisationId } = context;
-    const repos = await getReposFn({data: {organisationId, userId: user?.id || ''}})
+    const repos = await getReposFn()
     return { user, repos, organisationId };
   },
 })

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/settings.tokens.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/settings.tokens.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute(
   component: RouteComponent,
   loader: async ({ context }) => {
     const { user, organisationId } = context;
-    const tokens = await getTokensFn({data: {organizationId: organisationId, userId: user?.id || ''}})
+    const tokens = await getTokensFn()
     return { tokens, user, organisationId }
   },
   // Disable caching for token data - always fetch fresh
@@ -67,14 +67,14 @@ function RouteComponent() {
     setSubmitting(true)
     try {
       const expiresAt = computeExpiry(expiry)
-      const created = await createTokenFn({data: {organizationId: organisationId, userId: user?.id || '', name: nickname || 'New Token', expiresAt}})
+      const created = await createTokenFn({data: {name: nickname || 'New Token', expiresAt}})
       if (created && created.token) {
         setNewToken(created.token)
       }
       setOpen(false)
       setNickname('')
       setExpiry('no_expiry')
-      const newTokenList = await getTokensFn({data: {organizationId: organisationId, userId: user?.id || ''}})
+      const newTokenList = await getTokensFn()
       setTokenList(newTokenList)
     } finally {
       setSubmitting(false)
@@ -82,7 +82,7 @@ function RouteComponent() {
   }
 
   const handleRevokeToken = async (tokenId: string) => {
-    deleteTokenFn({data: {organizationId: organisationId, userId: user?.id || '', tokenId: tokenId}}).then(() => {
+    deleteTokenFn({data: {tokenId: tokenId}}).then(() => {
       toast({
         title: 'Token revoked',
         description: 'The token has been revoked',
@@ -95,7 +95,7 @@ function RouteComponent() {
       })
     }).finally(async () => {
       setSubmitting(false)
-      const newTokenList = await getTokensFn({data: {organizationId: organisationId, userId: user?.id || ''}})
+      const newTokenList = await getTokensFn()
       setTokenList(newTokenList)
     })
   }

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/units.$unitId.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/units.$unitId.tsx
@@ -87,25 +87,25 @@ export const Route = createFileRoute(
   ),
   loader: async ({ context, params: {unitId} }) => {
     const { user, organisationId, organisationName } = context;
-    
+
     // Run all API calls in parallel instead of sequentially! 🚀
     const [unitData, unitVersionsData, unitStatusData] = await Promise.all([
-      getUnitFn({data: {organisationId: organisationId || '', userId: user?.id || '', email: user?.email || '', unitId: unitId}}),
-      getUnitVersionsFn({data: {organisationId: organisationId || '', userId: user?.id || '', email: user?.email || '', unitId: unitId}}),
-      getUnitStatusFn({data: {organisationId: organisationId || '', userId: user?.id || '', email: user?.email || '', unitId: unitId}})
+      getUnitFn({data: {unitId: unitId}}),
+      getUnitVersionsFn({data: {unitId: unitId}}),
+      getUnitStatusFn({data: {unitId: unitId}})
     ]);
-    
+
     const publicServerConfig = context.publicServerConfig
     const publicHostname = publicServerConfig.PUBLIC_HOSTNAME || '<hostname>'
 
 
-    return { 
-      unitData: unitData, 
+    return {
+      unitData: unitData,
       unitStatus: unitStatusData,
-      unitVersions: unitVersionsData.versions, 
-      user, 
+      unitVersions: unitVersionsData.versions,
+      user,
       organisationId,
-      organisationName, 
+      organisationName,
       publicHostname,
 
     }
@@ -174,9 +174,6 @@ function RouteComponent() {
     try {
       await unlockUnitFn({
         data: {
-          userId: user?.id || '',
-          organisationId: organisationId || '',
-          email: user?.email || '',
           unitId: unit.id,
         },
       })
@@ -202,9 +199,6 @@ function RouteComponent() {
     try {
       await lockUnitFn({
         data: {
-          userId: user?.id || '',
-          organisationId: organisationId || '',
-          email: user?.email || '',
           unitId: unit.id,
         },
       })
@@ -231,9 +225,6 @@ function RouteComponent() {
     try {
       await deleteUnitFn({
         data: {
-          userId: user?.id || '',
-          organisationId: organisationId || '',
-          email: user?.email || '',
           unitId: unit.id,
         },
       })
@@ -262,9 +253,6 @@ function RouteComponent() {
     try {
       const state : any = await downloadLatestStateFn({
         data: {
-          userId: user?.id || '',
-          organisationId: organisationId || '',
-          email: user?.email || '',
           unitId: unit.id,
         },
       })
@@ -278,16 +266,13 @@ function RouteComponent() {
         variant: "destructive"
       })
       return
-    } 
+    }
   }
   
   const handleRestoreStateVersion = async (timestamp: string, lockId: string) => {
     try {
       await restoreUnitStateVersionFn({
         data: {
-          userId: user?.id || '',
-          organisationId: organisationId || '',
-          email: user?.email || '',
           unitId: unit.id,
           timestamp: timestamp,
           lockId: lockId,
@@ -317,9 +302,6 @@ function RouteComponent() {
     try {
       await updateUnitFn({
         data: {
-          userId: user?.id || '',
-          organisationId: organisationId || '',
-          email: user?.email || '',
           unitId: unit.id,
           tfeAutoApply: undefined,
           tfeExecutionMode: undefined,
@@ -587,7 +569,7 @@ function RouteComponent() {
                       This will overwrite the remote state with your local state, ignoring any locks or version history.
                       Only use this if you are absolutely sure your local state is correct.
                     </p>
-                    <UnitStateForceUploadDialog userId={user?.id || ''} organisationId={organisationId || ''} userEmail={user?.email || ''} unitId={unit.id} isDisabled={unit.locked} />
+                    <UnitStateForceUploadDialog unitId={unit.id} isDisabled={unit.locked} />
                   </div>
 
                   <div className="pt-4 border-t">

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/units.index.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/units.index.tsx
@@ -34,16 +34,10 @@ export const Route = createFileRoute(
   pendingComponent: PageLoading,
   loader: async ({ context }) => {
     const { user, organisationId } = context;
-    
-    const unitsData = await listUnitsFn({
-      data: {
-        organisationId: organisationId || '', 
-        userId: user?.id || '', 
-        email: user?.email || ''
-      }
-    });
-    
-    return { unitsData: unitsData, user, organisationId } 
+
+    const unitsData = await listUnitsFn();
+
+    return { unitsData: unitsData, user, organisationId }
   }
 })
 
@@ -145,14 +139,11 @@ function CreateUnitModal({ onUnitCreated, onUnitOptimistic, onUnitFailed }: {
         </DialogHeader>
         <div className="py-2">
           <UnitCreateForm
-            userId={user?.id || ''}
-            email={user?.email || ''}
-            organisationId={organisationId}
             onCreatedOptimistic={(tempUnit) => {
               onUnitOptimistic(tempUnit)
               setOpen(false)
             }}
-            onCreated={() => { 
+            onCreated={() => {
               setOpen(false)
               onUnitCreated()
             }}
@@ -187,7 +178,7 @@ function RouteComponent() {
   
   // Handle actual creation - refresh from server
   async function handleUnitCreated() {
-    const unitsData = await listUnitsFn({data: {organisationId: organisationId, userId: user?.id || '', email: user?.email || ''}})
+    const unitsData = await listUnitsFn()
     setUnits(unitsData.units)
   }
   


### PR DESCRIPTION
The tanstack ui layer has been in some cases trusting userID and orgID parsed from some frontend components - sent to server functions. To make this more secure we should instead always parse the JWT token on the server functions and retrieve orgID and user ID from there.

AI Disclosure: I have used claude code to plan and ship this feature in a directed way