### PR TITLE
additional verification of org_id and user_id in token service

### DIFF
--- a/taco/internal/token_service/handler.go
+++ b/taco/internal/token_service/handler.go
@@ -48,6 +48,11 @@ type VerifyTokenRequest struct {
 	OrgID  string `json:"org_id"`
 }
 
+// DeleteTokenRequest represents the request to delete a token
+type DeleteTokenRequest struct {
+	OrgID string `json:"org_id" validate:"required"`
+}
+
 // CreateToken creates a new token
 func (h *Handler) CreateToken(c echo.Context) error {
 	var req CreateTokenRequest
@@ -85,10 +90,14 @@ func (h *Handler) CreateToken(c echo.Context) error {
 	return c.JSON(http.StatusCreated, toTokenResponse(token))
 }
 
-// ListTokens lists all tokens for a user and org
+// ListTokens lists all tokens for an org (org_id is required)
 func (h *Handler) ListTokens(c echo.Context) error {
-	userID := c.QueryParam("user_id")
 	orgID := c.QueryParam("org_id")
+	if orgID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "org_id is required"})
+	}
+
+	userID := c.QueryParam("user_id") // Optional filter within org
 
 	tokens, err := h.repo.ListTokens(c.Request().Context(), userID, orgID)
 	if err != nil {
@@ -110,16 +119,26 @@ func (h *Handler) ListTokens(c echo.Context) error {
 	return c.JSON(http.StatusOK, responses)
 }
 
-// DeleteToken deletes a token by ID
+// DeleteToken deletes a token by ID with org ownership validation
 func (h *Handler) DeleteToken(c echo.Context) error {
 	tokenID := c.Param("id")
 	if tokenID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Token ID is required"})
 	}
 
-	if err := h.repo.DeleteToken(c.Request().Context(), tokenID); err != nil {
+	// Parse org_id from request body for ownership validation
+	var req DeleteTokenRequest
+	if err := c.Bind(&req); err != nil || req.OrgID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "org_id is required"})
+	}
+
+	// Delete with org validation - returns "not found" if token doesn't belong to org
+	if err := h.repo.DeleteTokenForOrg(c.Request().Context(), tokenID, req.OrgID); err != nil {
+		if err.Error() == "token not found" {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "Token not found"})
+		}
 		logger := logging.FromContext(c)
-		logger.Error("Failed to delete token", "token_id", tokenID, "error", err)
+		logger.Error("Failed to delete token", "token_id", tokenID, "org_id", req.OrgID, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
@@ -153,18 +172,19 @@ func (h *Handler) VerifyToken(c echo.Context) error {
 	})
 }
 
-// GetToken retrieves a token by ID
+// GetToken retrieves a token by ID with org ownership validation
 func (h *Handler) GetToken(c echo.Context) error {
 	tokenID := c.Param("id")
-	if tokenID == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Token ID is required"})
+	orgID := c.QueryParam("org_id")
+
+	if tokenID == "" || orgID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Token ID and org_id are required"})
 	}
 
-	token, err := h.repo.GetToken(c.Request().Context(), tokenID)
+	// Get with org validation - returns "not found" if token doesn't belong to org
+	token, err := h.repo.GetTokenForOrg(c.Request().Context(), tokenID, orgID)
 	if err != nil {
-		logger := logging.FromContext(c)
-		logger.Error("Failed to get token", "token_id", tokenID, "error", err)
-		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "Token not found"})
 	}
 
 	return c.JSON(http.StatusOK, toTokenResponseHidden(token)) // Hide token hash

--- a/taco/internal/token_service/repository.go
+++ b/taco/internal/token_service/repository.go
@@ -150,6 +150,30 @@ func (r *TokenRepository) GetToken(ctx context.Context, tokenID string) (*types.
 	return &token, nil
 }
 
+// GetTokenForOrg retrieves a token by ID only if it belongs to the specified org
+func (r *TokenRepository) GetTokenForOrg(ctx context.Context, tokenID, orgID string) (*types.Token, error) {
+	var token types.Token
+	if err := r.db.WithContext(ctx).Where("id = ? AND org_id = ?", tokenID, orgID).First(&token).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New(errTokenNotFound)
+		}
+		return nil, fmt.Errorf("failed to get token: %w", err)
+	}
+	return &token, nil
+}
+
+// DeleteTokenForOrg deletes a token by ID only if it belongs to the specified org
+func (r *TokenRepository) DeleteTokenForOrg(ctx context.Context, tokenID, orgID string) error {
+	result := r.db.WithContext(ctx).Where("id = ? AND org_id = ?", tokenID, orgID).Delete(&types.Token{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete token: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return errors.New(errTokenNotFound)
+	}
+	return nil
+}
+
 // generateSecureToken generates a cryptographically secure random token
 func generateSecureToken() (string, error) {
 	b := make([]byte, 32)


### PR DESCRIPTION
The token service is meant to be internal and only callabale from the gateway layer (ui proxy). The calls are authenticated and it learns about who the org_id and user_id making the call based on that. In this we add additional definsible checks on org_id and user_id within the service specifically for create, delete and list tokens - this is to add an extra layer of security in case there are any faults in the ui layer checks.

Ai assistance: used. claude code in a directed manner