### PR TITLE
additional validation in the statesman service

### DIFF
--- a/taco/internal/domain/identifier_resolver.go
+++ b/taco/internal/domain/identifier_resolver.go
@@ -24,5 +24,10 @@ type IdentifierResolver interface {
 	
 	// ResolveTag resolves a tag identifier to UUID within an organization
 	ResolveTag(ctx context.Context, identifier, orgID string) (string, error)
+
+	// UnitBelongsToOrg validates that a unit UUID belongs to the specified organization.
+	// Returns true if the unit exists and belongs to the org, false otherwise.
+	// This is used for security validation when a UUID is provided directly.
+	UnitBelongsToOrg(ctx context.Context, unitUUID, orgID string) (bool, error)
 }
 

--- a/taco/internal/repositories/identifier_resolver.go
+++ b/taco/internal/repositories/identifier_resolver.go
@@ -119,6 +119,27 @@ func (r *gormIdentifierResolver) ResolveTag(ctx context.Context, identifier, org
 	return r.resolveResource(ctx, "tags", identifier, orgID)
 }
 
+// UnitBelongsToOrg validates that a unit UUID belongs to the specified organization.
+// This is a security check to prevent IDOR attacks where an attacker provides
+// a unit UUID from another organization.
+func (r *gormIdentifierResolver) UnitBelongsToOrg(ctx context.Context, unitUUID, orgID string) (bool, error) {
+	if r.db == nil {
+		return false, fmt.Errorf("database not available")
+	}
+
+	var count int64
+	err := r.db.WithContext(ctx).
+		Table("units").
+		Where("id = ? AND org_id = ?", unitUUID, orgID).
+		Count(&count).Error
+
+	if err != nil {
+		return false, fmt.Errorf("failed to verify unit ownership: %w", err)
+	}
+
+	return count > 0, nil
+}
+
 // resolveResource is the generic resolver for org-scoped resources
 func (r *gormIdentifierResolver) resolveResource(ctx context.Context, table, identifier, orgID string) (string, error) {
 	if r.db == nil {

--- a/taco/internal/unit/handler.go
+++ b/taco/internal/unit/handler.go
@@ -42,40 +42,54 @@ func NewHandler(store domain.UnitManagement, blobStore storage.UnitStore, rbacMa
 }
 
 // resolveUnitIdentifier resolves a unit identifier (name or UUID) to its UUID
+// SECURITY: This function validates org ownership for all unit identifiers,
+// including direct UUIDs, to prevent IDOR attacks.
 func (h *Handler) resolveUnitIdentifier(ctx context.Context, identifier string) (string, error) {
 	// URL-decode first (Echo params may be URL-encoded)
 	decoded, err := domain.DecodeURLPath(identifier)
 	if err != nil {
 		return "", err
 	}
-	
+
 	normalized := domain.DecodeUnitID(decoded)
-	
-	// If already a UUID, return as-is
+
+	// Get org from context - required for security validation
+	orgCtx, ok := domain.OrgFromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("organization context required")
+	}
+
+	// If already a UUID, VALIDATE it belongs to the org (SECURITY FIX)
 	if domain.IsUUID(normalized) {
+		// If resolver is not available, we cannot validate - fail secure
+		if h.resolver == nil {
+			return "", fmt.Errorf("cannot validate unit ownership: resolver not available")
+		}
+
+		belongs, err := h.resolver.UnitBelongsToOrg(ctx, normalized, orgCtx.OrgID)
+		if err != nil {
+			return "", fmt.Errorf("failed to verify unit ownership: %w", err)
+		}
+		if !belongs {
+			// Don't reveal that the unit exists in another org
+			return "", fmt.Errorf("unit not found")
+		}
 		return normalized, nil
 	}
-	
+
 	// If resolver is not available, return normalized name (will fail at repository layer)
 	if h.resolver == nil {
 		return normalized, nil
 	}
-	
-	// Get org from context for resolution
-	orgCtx, ok := domain.OrgFromContext(ctx)
-	if !ok {
-		// No org context, return normalized name
-		return normalized, nil
-	}
-	
+
 	// Resolve name to UUID using the identifier resolver
-	// Note: ResolveUnit signature is (ctx, identifier, orgID)
+	// Note: ResolveUnit already validates org scope for name-based lookups
 	uuid, err := h.resolver.ResolveUnit(ctx, normalized, orgCtx.OrgID)
 	if err != nil {
 		// If resolution fails, return error
 		return "", err
 	}
-	
+
 	return uuid, nil
 }
 


### PR DESCRIPTION
Adding additional checks around unit ID's to ensure that they belong to the current orgID/userID especially during the unit delete operation. Protects against IDOR attacks

AI disclosure: used claude code in a directed way 