### PR TITLE
fix: handle falsy env flags for backend auth mode

### DIFF
--- a/backend/middleware/middleware.go
+++ b/backend/middleware/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/diggerhq/digger/backend/models"
@@ -12,8 +13,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func envFlagEnabled(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	v = strings.TrimSpace(strings.ToLower(v))
+	return v == "true" || v == "1" || v == "yes" || v == "on"
+}
+
 func GetWebMiddleware() gin.HandlerFunc {
-	if _, ok := os.LookupEnv("JWT_AUTH"); ok {
+	if envFlagEnabled("JWT_AUTH") {
 		slog.Info("Using JWT middleware for web routes")
 		auth := services.Auth{
 			HttpClient: http.Client{},
@@ -22,10 +32,10 @@ func GetWebMiddleware() gin.HandlerFunc {
 			ClientId:   os.Getenv("FRONTEGG_CLIENT_ID"),
 		}
 		return JWTWebAuth(auth)
-	} else if _, ok := os.LookupEnv("HTTP_BASIC_AUTH"); ok {
+	} else if envFlagEnabled("HTTP_BASIC_AUTH") {
 		slog.Info("Using http basic auth middleware for web routes")
 		return HttpBasicWebAuth()
-	} else if _, ok := os.LookupEnv("NOOP_AUTH"); ok {
+	} else if envFlagEnabled("NOOP_AUTH") {
 		slog.Info("Using noop auth for web routes")
 		return NoopWebAuth()
 	} else {
@@ -35,7 +45,7 @@ func GetWebMiddleware() gin.HandlerFunc {
 }
 
 func GetApiMiddleware() gin.HandlerFunc {
-	if _, ok := os.LookupEnv("JWT_AUTH"); ok {
+	if envFlagEnabled("JWT_AUTH") {
 		slog.Info("Using JWT middleware for API routes")
 		auth := services.Auth{
 			HttpClient: http.Client{},
@@ -44,10 +54,10 @@ func GetApiMiddleware() gin.HandlerFunc {
 			ClientId:   os.Getenv("FRONTEGG_CLIENT_ID"),
 		}
 		return JWTBearerTokenAuth(auth)
-	} else if _, ok := os.LookupEnv("HTTP_BASIC_AUTH"); ok {
+	} else if envFlagEnabled("HTTP_BASIC_AUTH") {
 		slog.Info("Using http basic auth middleware for API routes")
 		return HttpBasicApiAuth()
-	} else if _, ok := os.LookupEnv("NOOP_AUTH"); ok {
+	} else if envFlagEnabled("NOOP_AUTH") {
 		slog.Info("Using noop auth for API routes")
 		return NoopApiAuth()
 	} else {


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

Opencode + gpt5.2 codex identified this bug while I was debugging a self-hosted backend set up (`ENV_VAR=false` being interpreted as truthy) and wrote the implementation of envFlagEnabled). I reviewed the implementation manually.

---

Adds helper function `envFlagEnabled` to parse the (JWT_AUTH / HTTP_BASIC_AUTH / NOOP_AUTH) environment variables for truthiness rather than only checking their existence.

NOTE: This will cause a behavior change in the case that one of these env vars being set to an empty string (e.g. JWT_AUTH=""). Historically, that would have returned `true` but now will return `false`.
 
If any users are relying on this behavior, the backend will hit the else clause and panic rather than expose the endpoint.

```go
else {
		slog.Error("No authentication method specified. Please specify one of JWT_AUTH or HTTP_BASIC_AUTH")
		panic("No authentication method specified. Please specify one of JWT_AUTH or HTTP_BASIC_AUTH")
	}
```
