### PR TITLE
fix: redact credentials

### DIFF
--- a/libs/execution/opentofu.go
+++ b/libs/execution/opentofu.go
@@ -142,10 +142,11 @@ func (tf OpenTofu) runOpentofuCommand(command string, printOutputToStdout bool, 
 	}
 
 	cmd := exec.Command("tofu", expandedArgs...)
+
 	slog.Info("Running OpenTofu command",
 		slog.Group("command",
 			"binary", "tofu",
-			"args", expandedArgs,
+			"args", RedactSecrets(expandedArgs),
 			"workingDir", tf.WorkingDir,
 		),
 	)
@@ -166,7 +167,7 @@ func (tf OpenTofu) runOpentofuCommand(command string, printOutputToStdout bool, 
 	if err != nil && cmd.ProcessState.ExitCode() != 2 {
 		slog.Error("Command execution failed",
 			"command", "tofu",
-			"args", expandedArgs,
+			"args", RedactSecrets(expandedArgs),
 			"exitCode", cmd.ProcessState.ExitCode(),
 			"error", err,
 		)


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

As raised in #2572 , we might not exactly want to log all args, for now i am choosing to redact all sensitive args but open to thoughts on leaving the access keys logged

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
N/A

