### PR TITLE
Handle issue comments for `digger apply` on Drift Detection issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -319,11 +319,11 @@ runs:
       with:
         clean: false
         ref: refs/pull/${{ github.event.issue.number }}/merge
-      if: ${{ github.event_name == 'issue_comment' && inputs.configure-checkout == 'true' }}
+      if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && inputs.configure-checkout == 'true' }}
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       with:
         clean: false
-      if: ${{ github.event_name != 'issue_comment' && inputs.configure-checkout == 'true' }}
+      if: ${{ !(github.event_name == 'issue_comment' && github.event.issue.pull_request) && inputs.configure-checkout == 'true' }}
     - name: Set up Google Auth Using A Service Account Key
       uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
       with:

--- a/action.yml
+++ b/action.yml
@@ -585,6 +585,7 @@ runs:
         TERRAGRUNT_PROVIDER_CACHE_DIR: ${{ env.TF_PLUGIN_CACHE_DIR }}
         DIGGER_RUN_SPEC: ${{inputs.digger-spec}}
         DIGGER_LOG_LEVEL: ${{ inputs.log-level }}
+        ACTION_REPOSITORY: ${{ github.action_repository }}
       id: digger
       shell: bash
       run: |
@@ -595,12 +596,12 @@ runs:
 
         if [[ ${{ inputs.ee }} == "true" ]]; then
           if [[ ${{ inputs.fips }} == "true" ]]; then
-            DOWNLOAD_URL="https://github.com/diggerhq/digger/releases/download/${DIGGER_VERSION}/digger-ee-cli-${DIGGER_OS}-${DIGGER_ARCH}-fips"
+            DOWNLOAD_URL="https://github.com/${ACTION_REPOSITORY}/releases/download/${DIGGER_VERSION}/digger-ee-cli-${DIGGER_OS}-${DIGGER_ARCH}-fips"
           else
-            DOWNLOAD_URL="https://github.com/diggerhq/digger/releases/download/${DIGGER_VERSION}/digger-ee-cli-${DIGGER_OS}-${DIGGER_ARCH}"
+            DOWNLOAD_URL="https://github.com/${ACTION_REPOSITORY}/releases/download/${DIGGER_VERSION}/digger-ee-cli-${DIGGER_OS}-${DIGGER_ARCH}"
           fi
         else
-          DOWNLOAD_URL="https://github.com/diggerhq/digger/releases/download/${DIGGER_VERSION}/digger-cli-${DIGGER_OS}-${DIGGER_ARCH}"
+          DOWNLOAD_URL="https://github.com/${ACTION_REPOSITORY}/releases/download/${DIGGER_VERSION}/digger-cli-${DIGGER_OS}-${DIGGER_ARCH}"
         fi
 
         echo "Downloading from: $DOWNLOAD_URL"
@@ -614,7 +615,7 @@ runs:
           echo "3. Network connectivity issues"
           echo ""
           echo "Suggestions:"
-          echo "- Check if release ${DIGGER_VERSION} exists at: https://github.com/diggerhq/digger/releases"
+          echo "- Check if release ${DIGGER_VERSION} exists at: https://github.com/${ACTION_REPOSITORY}/releases"
           echo "- Verify the architecture combination is supported"
           echo "- Try using a different release version"
           exit 1

--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -56,7 +56,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 	hostName := os.Getenv("DIGGER_HOSTNAME")
 	token := os.Getenv("DIGGER_TOKEN")
 	orgName := os.Getenv("DIGGER_ORGANISATION")
-	var policyChecker, _ = policyCheckerProvider.Get(hostName, token, orgName)
+	policyChecker, _ := policyCheckerProvider.Get(hostName, token, orgName)
 
 	ghToken := os.Getenv("GITHUB_TOKEN")
 	if ghToken == "" {
@@ -300,10 +300,14 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		if prEvent, ok := ghEvent.(github.PullRequestEvent); ok {
 			jobs, coversAllImpactedProjects, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig, true)
 		} else if commentEvent, ok := ghEvent.(github.IssueCommentEvent); ok {
-			prBranchName, _, _, _, err := githubPrService.GetBranchName(*commentEvent.Issue.Number)
-
-			if err != nil {
-				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Error while retrieving default branch from Issue: %v", err), 6)
+			var prBranchName string
+			if commentEvent.Issue.IsPullRequest() {
+				prBranchName, _, _, _, err = githubPrService.GetBranchName(*commentEvent.Issue.Number)
+				if err != nil {
+					usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Error while retrieving default branch from Issue: %v", err), 6)
+				}
+			} else {
+				prBranchName = *commentEvent.Repo.DefaultBranch
 			}
 			defaultBranch := *commentEvent.Repo.DefaultBranch
 			repoFullName := *commentEvent.Repo.FullName

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -624,6 +624,16 @@ func (svc GithubService) GetCheckRunsForCommit(commitSha string) ([]*github.Chec
 }
 
 func (svc GithubService) GetCombinedPullRequestStatus(prNumber int) (string, error) {
+	isPullRequest, err := svc.IsPullRequest(prNumber)
+	if err != nil {
+		slog.Error("error checking if PR is issue", "error", err, "prNumber", prNumber)
+		return "", fmt.Errorf("error checking if PR is issue: %v", err)
+	}
+
+	if !isPullRequest {
+		return "success", nil
+	}
+
 	pr, _, err := svc.Client.PullRequests.Get(context.Background(), svc.Owner, svc.RepoName, prNumber)
 	if err != nil {
 		slog.Error("error getting pull request", "error", err, "prNumber", prNumber)

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -294,14 +295,16 @@ func (svc GithubService) DeleteComment(id string) error {
 
 type GithubCommentReaction string
 
-const GithubCommentPlusOneReaction GithubCommentReaction = "+1"
-const GithubCommentMinusOneReaction GithubCommentReaction = "-1"
-const GithubCommentLaughReaction GithubCommentReaction = "laugh"
-const GithubCommentConfusedReaction GithubCommentReaction = "confused"
-const GithubCommentHeartReaction GithubCommentReaction = "heart"
-const GithubCommentHoorayReaction GithubCommentReaction = "hooray"
-const GithubCommentRocketReaction GithubCommentReaction = "rocket"
-const GithubCommentEyesReaction GithubCommentReaction = "eyes"
+const (
+	GithubCommentPlusOneReaction  GithubCommentReaction = "+1"
+	GithubCommentMinusOneReaction GithubCommentReaction = "-1"
+	GithubCommentLaughReaction    GithubCommentReaction = "laugh"
+	GithubCommentConfusedReaction GithubCommentReaction = "confused"
+	GithubCommentHeartReaction    GithubCommentReaction = "heart"
+	GithubCommentHoorayReaction   GithubCommentReaction = "hooray"
+	GithubCommentRocketReaction   GithubCommentReaction = "rocket"
+	GithubCommentEyesReaction     GithubCommentReaction = "eyes"
+)
 
 func (svc GithubService) CreateCommentReaction(id string, reaction string) error {
 	commentId, err := strconv.ParseInt(id, 10, 64)
@@ -1064,7 +1067,6 @@ func ProcessGitHubEvent(ghEvent interface{}, diggerConfig *digger_config.DiggerC
 			"action", *event.Action)
 
 		changedFiles, err := ciService.GetChangedFiles(prNumber)
-
 		if err != nil {
 			slog.Error("could not get changed files", "error", err, "prNumber", prNumber)
 			return nil, nil, 0, fmt.Errorf("could not get changed files")
@@ -1081,14 +1083,29 @@ func ProcessGitHubEvent(ghEvent interface{}, diggerConfig *digger_config.DiggerC
 			"prNumber", prNumber,
 			"comment", *event.Comment.Body)
 
-		changedFiles, err := ciService.GetChangedFiles(prNumber)
+		if event.Issue.IsPullRequest() {
+			changedFiles, err := ciService.GetChangedFiles(prNumber)
+			if err != nil {
+				slog.Error("could not get changed files", "error", err, "prNumber", prNumber)
+				return nil, nil, 0, fmt.Errorf("could not get changed files")
+			}
 
-		if err != nil {
-			slog.Error("could not get changed files", "error", err, "prNumber", prNumber)
-			return nil, nil, 0, fmt.Errorf("could not get changed files")
+			impactedProjects, _ = diggerConfig.GetModifiedProjects(changedFiles)
+		} else {
+			// Drift detection issue title is in the format: "Drift detected in project: $projectName"
+			// Extract project name from issue title
+			re := regexp.MustCompile(`^Drift detected in project: (\S+)`)
+			matches := re.FindStringSubmatch(*event.Issue.Title)
+			var projectName string
+			if len(matches) > 1 {
+				projectName = matches[1]
+			} else {
+				slog.Error("could not extract project name from issue title", "issueTitle", *event.Issue.Title)
+				return nil, nil, 0, fmt.Errorf("could not extract project name from issue title")
+			}
+			impactedProjects = diggerConfig.GetProjects(projectName)
 		}
 
-		impactedProjects, _ = diggerConfig.GetModifiedProjects(changedFiles)
 		requestedProject := scheduler.ParseProjectName(*event.Comment.Body)
 
 		if requestedProject == "" {
@@ -1137,7 +1154,6 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 		"action", *payload.Action)
 
 	changedFiles, err := ciService.GetChangedFiles(prNumber)
-
 	if err != nil {
 		slog.Error("could not get changed files", "error", err, "prNumber", prNumber)
 		return nil, nil, prNumber, fmt.Errorf("could not get changed files")


### PR DESCRIPTION
### Overview

This change enables handling of `digger apply` comments on Issues automatically created by Digger Drift Detection.

### Background

Previously, when a `digger apply` comment was posted on a Drift Detection Issue, it was not properly processed. As a result, it was not possible to trigger the apply workflow directly from the Issue.

### Changes

- Added support for handling comment events on Drift Detection–generated Issues

- Detect and process digger apply comments on those Issues

### Testing

This behavior has been tested using the test Issue at https://github.com/golemiso/debug-digger/issues/2, confirming that digger apply comments on a Drift Detection issue are correctly handled and trigger the expected actions.

### Expected Impact

- Allows the full Drift Detection → Issue → `digger apply` workflow to be completed directly within the Issue

- Improves operational consistency and usability

### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

NA