### PR TITLE
feat: merge gate status checks in no-backend mode

### DIFF
--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -346,6 +346,13 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 
 		jobs = digger.SortedCommandsByDependency(jobs, &dependencyGraph)
 
+		// Set pending status before execution
+		if scheduler.IsPlanJobs(jobs) {
+			githubPrService.SetStatus(prNumber, "pending", "digger/plan")
+		} else {
+			githubPrService.SetStatus(prNumber, "pending", "digger/apply")
+		}
+
 		allAppliesSuccessful, atLeastOneApply, err := digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "", false, false, "0", currentDir)
 		if !allAppliesSuccessful || err != nil {
 			// aggregate status checks: failure
@@ -366,6 +373,10 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			// aggregate status checks: success
 			if scheduler.IsPlanJobs(jobs) {
 				githubPrService.SetStatus(prNumber, "success", "digger/plan")
+				// Merge gate: after successful plan, apply is still pending.
+				// Users can add digger/apply as a required status check to
+				// block merge until `digger apply` is run.
+				githubPrService.SetStatus(prNumber, "pending", "digger/apply")
 			} else {
 				githubPrService.SetStatus(prNumber, "success", "digger/apply")
 			}


### PR DESCRIPTION
## Summary

Adds merge-gate commit status checks to no-backend (backendless) mode. This is the minimal change needed to support "must apply before merge" workflows without the full orchestrator backend.

### Changes

In `cli/pkg/github/github.go`:

- **Before `RunJobs`**: Set `digger/plan` or `digger/apply` to **pending**
- **After successful plan**: Set `digger/plan` to **success** AND `digger/apply` to **pending**
- **After successful apply**: Set `digger/apply` to **success** (unchanged)
- **On failure**: Set status to **failure** (unchanged)

### Why

Currently, no-backend mode sets success/failure statuses after execution but never sets a **pending** status. This means there's no way to gate merge on apply — `digger/plan` passes after plan, and there's nothing blocking merge until apply runs.

The full orchestrator backend solves this (Go server + Postgres), but that's heavy for single-repo setups that just want the merge gate.

### How to use

1. Use Digger in no-backend mode as normal
2. Add `digger/apply` as a **required status check** in GitHub branch protection
3. After `digger plan` runs on a PR, `digger/apply` will be **pending** — merge blocked
4. Comment `digger apply` — `digger/apply` flips to **success** — merge unblocked

### Backward compatibility

No breaking changes. The pending statuses are additive — existing workflows that don't use required status checks are unaffected.

## Test plan

- [ ] Open a PR that triggers Digger plan in no-backend mode
- [ ] Verify `digger/plan` shows as pending, then success
- [ ] Verify `digger/apply` shows as pending after plan
- [ ] Comment `digger apply`
- [ ] Verify `digger/apply` flips to success