### PR TITLE
fix: add helm dependency build where necessary for CI

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - develop
       - sp/fix-helm-release
-    paths:
-      - "helm-charts/**"
+    # paths:
+    #   - "helm-charts/**"
   workflow_dispatch: # Allow manual triggering
 
 permissions:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - develop
-      - sp/fix-helm-release
-    # paths:
-    #   - "helm-charts/**"
+    paths:
+      - "helm-charts/**"
   workflow_dispatch: # Allow manual triggering
 
 permissions:
@@ -20,14 +19,14 @@ jobs:
     strategy:
       matrix:
         chart:
-          # - digger-backend
-          # - taco-orchestrator
-          # - taco-statesman
-          # - taco-token-service
+          - digger-backend
+          - taco-orchestrator
+          - taco-statesman
+          - taco-token-service
           - taco-drift
-          # - taco-ui
+          - taco-ui
           - taco-sidecar
-          # - opentaco-platform-reference
+          - opentaco-platform-reference
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -22,12 +22,12 @@ jobs:
         chart:
           # - digger-backend
           # - taco-orchestrator
-          - taco-statesman
-          - taco-token-service
+          # - taco-statesman
+          # - taco-token-service
           - taco-drift
-          - taco-ui
+          # - taco-ui
           - taco-sidecar
-          - opentaco-platform-reference
+          # - opentaco-platform-reference
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - sp/fix-helm-release
     paths:
       - "helm-charts/**"
   workflow_dispatch: # Allow manual triggering
@@ -19,8 +20,8 @@ jobs:
     strategy:
       matrix:
         chart:
-          - digger-backend
-          - taco-orchestrator
+          # - digger-backend
+          # - taco-orchestrator
           - taco-statesman
           - taco-token-service
           - taco-drift
@@ -41,6 +42,9 @@ jobs:
       - name: Package and push ${{ matrix.chart }}
         run: |
           cd helm-charts/${{ matrix.chart }}
+          if grep -q "^dependencies:" Chart.yaml; then
+            helm dependency build
+          fi
           helm package .
           helm push ${{ matrix.chart }}-*.tgz oci://ghcr.io/diggerhq/helm-charts
 

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -33,6 +33,12 @@ jobs:
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
+      - name: Build chart dependencies (if any)
+        run: |
+          if grep -q "^dependencies:" helm-charts/${{ matrix.chart }}/Chart.yaml; then
+            helm dependency build helm-charts/${{ matrix.chart }}
+          fi
+
       - name: Lint chart
         run: |
           helm lint helm-charts/${{ matrix.chart }}


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

Used opencode to pinpoint the issue.

---

Adds `helm dependency build` to release where necessary

NOTE: set as `draft` because it modifies the workflow trigger temporarily to publish the remaining charts. I'll revert that change before merging.