### PR TITLE
fix: upgrade azure/login to v2.2.0 to prevent cleanup warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -362,11 +362,15 @@ runs:
       if: ${{ inputs.setup-aws == 'true' && inputs.aws-role-to-assume != '' }}
 
     - name: Configure OIDC Azure credentials
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}
         subscription-id: ${{ inputs.azure-subscription-id }}
+      env:
+        # Disable post-cleanup when Azure is not being used (v2.2.0+ feature)
+        # See: https://github.com/Azure/login/pull/484
+        AZURE_LOGIN_POST_CLEANUP: ${{ inputs.setup-azure == 'true' && 'true' || 'false' }}
       if: ${{ inputs.setup-azure == 'true' && inputs.azure-client-id != '' }}
 
     # if terraform-cache-dir is set then we set it to that otherwise set it to '${{github.workspace}}/cache'


### PR DESCRIPTION
## Summary
Fixes Azure CLI cleanup warning when `setup-azure` is false.

## Problem
Current version causes a warning:
<img width="884" height="190" alt="image" src="https://github.com/user-attachments/assets/4687511b-8813-40a5-a193-c7ccce6d0426" />

## Root Cause & Solution
Digger uses `azure/login@v2.1.1` which lacks support for `AZURE_LOGIN_POST_CLEANUP` env var.

This PR:
1. Upgrades to `azure/login@v2.2.0` (adds post-if support via https://github.com/Azure/login/pull/484)
2. Sets `AZURE_LOGIN_POST_CLEANUP: false` when Azure is not being used

## Testing
Before/after comparison: https://github.com/AyhanSetirekli/digger-azure-cleanup-test/actions/runs/22491196175

- **v2.1.1:** Warning annotation appears
- **v2.2.0:** No warning ✓

## Impact
Eliminates warnings for non-Azure workflows. No change when `setup-azure: true`.

Fixes #2540

---
**AI Assistance:** This PR was written primarily by Claude Code.
