### PR TITLE
docs: redirect old home page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,12 @@
     "dark": "#8101E4"
   },
   "favicon": "/favicon.png",
+  "redirects": [
+    {
+      "source": "/readme/introduction",
+      "destination": "/introduction/introduction"
+    }
+  ],
   "navigation": {
     "anchors": [
       {


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

opencode used to create redirect. Validated locally with `mint dev`

---

As part of docs refactor, I changed homepage filename. This redirect to keep old links from hitting a 404.