### PR TITLE
fix: add target url to link to workflow run

### DIFF
--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/diggerhq/digger/libs/ci"
 	"github.com/diggerhq/digger/libs/ci/generic"
+	"github.com/diggerhq/digger/libs/comment_utils"
 	"github.com/diggerhq/digger/libs/scheduler"
 
 	"github.com/diggerhq/digger/libs/digger_config"
@@ -349,11 +350,13 @@ func (svc GithubService) SetStatus(prNumber int, status string, statusContext st
 	// 422 Validation Failed [{Resource:Status Field:description Code:custom Message:description is too long (maximum is 140 characters)}]
 	// since description isn't shown in ui setting to blank for now
 	description := ""
+	targetURl := comment_utils.GetWorkflowUrl()
 
 	_, _, err = svc.Client.Repositories.CreateStatus(context.Background(), svc.Owner, svc.RepoName, *pr.Head.SHA, &github.RepoStatus{
 		State:       &status,
 		Context:     &statusContext,
 		Description: &description,
+		TargetURL:   &targetURl,
 	})
 	return err
 }


### PR DESCRIPTION
### :brain: **Ai UsageDetails N/A 

Previously, clicking a Digger status check on a PR would redirect to the PR itself, instead of the workflow run.
This sets TargetURL on commit statuses to point directly to the Actions run.
  
  
IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

