### PR TITLE
docs: Update color scheme and add custom typography and navbar styles

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -279,5 +279,8 @@
       "slack": "https://diggertalk.slack.com/join/shared_invite/zt-1tocl4w0x-E3RkpPiK7zQkehl8O78g8Q#/shared-invite/email",
       "linkedin": "https://www.linkedin.com/company/diggerhq/"
     }
+  },
+  "modeToggle": {
+    "default": "light"
   }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,9 +7,25 @@
     "dismissible": true
   },
   "colors": {
-    "primary": "#8101E4",
-    "light": "#AF48FF",
-    "dark": "#8101E4"
+    "primary": "#131311",
+    "light": "#dfdfdf",
+    "dark": "#131311"
+  },
+  "background": {
+    "color": {
+      "light": "#f8f6f1",
+      "dark": "#0f0f0f"
+    }
+  },
+  "fonts": {
+    "heading": {
+      "family": "Newsreader",
+      "weight": 400
+    },
+    "body": {
+      "family": "Inter",
+      "weight": 400
+    }
   },
   "favicon": "/favicon.png",
   "redirects": [

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -1,0 +1,22 @@
+h5 {
+  font-family: 'Inter', sans-serif;
+}
+#navbar .nav-logo {
+  display: none;
+}
+#navbar a.select-none::before {
+  content: 'opentaco';
+  font-family: 'Newsreader', serif;
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  transition: letter-spacing 0.3s ease;
+  color: #131311;
+}
+#navbar a:hover::before {
+  letter-spacing: 0.06em;
+}
+
+.dark #navbar a.select-none::before {
+  color: #dfdfdf;
+}


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
### NA

### Changes
**Color scheme**

- Switched primary palette from purple (#8101E4, #AF48FF) to a neutral dark palette (#131311, #dfdfdf)
- Added background colors for light (#f8f6f1) and dark (#0f0f0f) themes

**Typography**

- Set Newsreader as the heading font
- Set Inter as the body font
- Applied Inter to h5 elements via custom CSS

**Navbar**

- Added custom “opentaco” text in the navbar using Newsreader
- Added letter-spacing hover effect (0.01em → 0.06em)
- Ensured correct text color in light and dark modes

