### PR TITLE
fix(storage): migrate GitHub artifact upload from deprecated v1-v3 API to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -489,6 +489,7 @@ runs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'])
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
           core.exportVariable('ACTIONS_RUNTIME_URL', process.env['ACTIONS_RUNTIME_URL'])
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL'])
 
     - name: create cache dir
       run: |

--- a/libs/storage/plan_storage.go
+++ b/libs/storage/plan_storage.go
@@ -36,75 +36,78 @@ func (gps *GithubPlanStorage) StorePlanFile(fileContents []byte, artifactName st
 		"size", len(fileContents))
 
 	actionsRuntimeToken := os.Getenv("ACTIONS_RUNTIME_TOKEN")
-	actionsRuntimeURL := os.Getenv("ACTIONS_RUNTIME_URL")
+	actionsResultsURL := os.Getenv("ACTIONS_RESULTS_URL")
 	githubRunID := os.Getenv("GITHUB_RUN_ID")
-	artifactBase := fmt.Sprintf("%s_apis/pipelines/workflows/%s/artifacts?api-version=6.0-preview", actionsRuntimeURL, githubRunID)
+	githubRunAttempt := os.Getenv("GITHUB_RUN_ATTEMPT")
 
-	headers := map[string]string{
-		"Accept":        "application/json;api-version=6.0-preview",
+	if actionsResultsURL == "" {
+		return fmt.Errorf("ACTIONS_RESULTS_URL is not set; GitHub Actions Artifacts v4 requires this environment variable")
+	}
+
+	twirpBase := strings.TrimRight(actionsResultsURL, "/") + "/twirp/github.actions.results.api.v1.ArtifactService"
+
+	jsonHeaders := map[string]string{
 		"Authorization": "Bearer " + actionsRuntimeToken,
 		"Content-Type":  "application/json",
 	}
 
-	// Create Artifact
-	createArtifactURL := artifactBase
-	createArtifactData := map[string]string{"type": "actions_storage", "name": artifactName}
-	createArtifactBody, _ := json.Marshal(createArtifactData)
+	// Step 1: CreateArtifact
+	createReqBody, _ := json.Marshal(map[string]interface{}{
+		"workflow_run_backend_id":     githubRunID,
+		"workflow_job_run_backend_id": githubRunAttempt,
+		"name":                        artifactName,
+		"version":                     4,
+	})
 
-	slog.Debug("Creating GitHub artifact", "url", createArtifactURL, "name", artifactName)
-	createArtifactResponse, err := doRequest("POST", createArtifactURL, headers, createArtifactBody)
-	if createArtifactResponse == nil || err != nil {
-		slog.Error("Failed to create GitHub artifact",
-			"error", err,
-			"artifactName", artifactName)
-		return fmt.Errorf("could not create artifact with github %v", err)
-	}
-	defer createArtifactResponse.Body.Close()
-
-	// Extract Resource URL
-	createArtifactResponseBody, _ := io.ReadAll(createArtifactResponse.Body)
-	var createArtifactResponseMap map[string]interface{}
-	json.Unmarshal(createArtifactResponseBody, &createArtifactResponseMap)
-	resourceURL := createArtifactResponseMap["fileContainerResourceUrl"].(string)
-
-	// Upload Data
-	uploadURL := fmt.Sprintf("%s?itemPath=%s/%s", resourceURL, artifactName, storedPlanFilePath)
-	uploadData := fileContents
-	dataLen := len(uploadData)
-	headers["Content-Type"] = "application/octet-stream"
-	headers["Content-Range"] = fmt.Sprintf("bytes 0-%v/%v", dataLen-1, dataLen)
-
-	slog.Debug("Uploading file to GitHub artifact",
-		"url", uploadURL,
-		"size", dataLen)
-	_, err = doRequest("PUT", uploadURL, headers, uploadData)
+	createURL := twirpBase + "/CreateArtifact"
+	slog.Debug("Creating GitHub artifact (v4)", "url", createURL, "name", artifactName)
+	createResp, err := doRequest("POST", createURL, jsonHeaders, createReqBody)
 	if err != nil {
-		slog.Error("Failed to upload file to GitHub artifact",
-			"error", err,
-			"artifactName", artifactName)
-		return fmt.Errorf("could not upload artifact file %v", err)
+		slog.Error("Failed to create GitHub artifact (v4)", "error", err, "artifactName", artifactName)
+		return fmt.Errorf("could not create artifact with github: %v", err)
+	}
+	defer createResp.Body.Close()
+
+	createRespBody, _ := io.ReadAll(createResp.Body)
+	var createRespMap map[string]interface{}
+	if err := json.Unmarshal(createRespBody, &createRespMap); err != nil {
+		return fmt.Errorf("failed to parse CreateArtifact response: %v", err)
+	}
+	signedUploadURL, ok := createRespMap["signed_upload_url"].(string)
+	if !ok || signedUploadURL == "" {
+		return fmt.Errorf("CreateArtifact response missing signed_upload_url: %s", string(createRespBody))
 	}
 
-	// Update Artifact Size
-	headers = map[string]string{
-		"Accept":        "application/json;api-version=6.0-preview",
-		"Authorization": "Bearer " + actionsRuntimeToken,
-		"Content-Type":  "application/json",
+	// Step 2: Upload file to signed URL (Azure Blob)
+	dataLen := len(fileContents)
+	uploadHeaders := map[string]string{
+		"x-ms-blob-type":         "BlockBlob",
+		"x-ms-blob-content-type": "application/octet-stream",
+		"Content-Length":         fmt.Sprintf("%d", dataLen),
 	}
-	updateArtifactURL := fmt.Sprintf("%s&artifactName=%s", artifactBase, artifactName)
-	updateArtifactData := map[string]int{"size": dataLen}
-	updateArtifactBody, _ := json.Marshal(updateArtifactData)
-
-	slog.Debug("Finalizing GitHub artifact upload",
-		"url", updateArtifactURL,
-		"size", dataLen)
-	_, err = doRequest("PATCH", updateArtifactURL, headers, updateArtifactBody)
+	slog.Debug("Uploading file to signed URL (v4)", "size", dataLen)
+	_, err = doRequest("PUT", signedUploadURL, uploadHeaders, fileContents)
 	if err != nil {
-		slog.Error("Failed to finalize GitHub artifact upload",
-			"error", err,
-			"artifactName", artifactName)
-		return fmt.Errorf("could finalize artifact upload: %v", err)
+		slog.Error("Failed to upload file to signed URL (v4)", "error", err, "artifactName", artifactName)
+		return fmt.Errorf("could not upload artifact file: %v", err)
 	}
+
+	// Step 3: FinalizeArtifact
+	finalizeReqBody, _ := json.Marshal(map[string]interface{}{
+		"workflow_run_backend_id":     githubRunID,
+		"workflow_job_run_backend_id": githubRunAttempt,
+		"name":                        artifactName,
+		"size":                        fmt.Sprintf("%d", dataLen),
+	})
+
+	finalizeURL := twirpBase + "/FinalizeArtifact"
+	slog.Debug("Finalizing GitHub artifact upload (v4)", "url", finalizeURL, "size", dataLen)
+	finalizeResp, err := doRequest("POST", finalizeURL, jsonHeaders, finalizeReqBody)
+	if err != nil {
+		slog.Error("Failed to finalize GitHub artifact upload (v4)", "error", err, "artifactName", artifactName)
+		return fmt.Errorf("could not finalize artifact upload: %v", err)
+	}
+	defer finalizeResp.Body.Close()
 
 	slog.Info("Successfully stored plan file in GitHub artifacts",
 		"owner", gps.Owner,

--- a/libs/storage/plan_storage.go
+++ b/libs/storage/plan_storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +19,34 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
+
+func extractArtifactBackendIDs(runtimeToken string) (workflowRunBackendID, workflowJobRunBackendID string, err error) {
+	parts := strings.Split(runtimeToken, ".")
+	if len(parts) != 3 {
+		return "", "", fmt.Errorf("invalid ACTIONS_RUNTIME_TOKEN: expected 3 JWT parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", fmt.Errorf("failed to base64-decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Scp string `json:"scp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", "", fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+	for _, scope := range strings.Split(claims.Scp, " ") {
+		const prefix = "Actions.Results:"
+		if !strings.HasPrefix(scope, prefix) {
+			continue
+		}
+		ids := strings.SplitN(strings.TrimPrefix(scope, prefix), ":", 2)
+		if len(ids) == 2 && ids[0] != "" && ids[1] != "" {
+			return ids[0], ids[1], nil
+		}
+	}
+	return "", "", fmt.Errorf("ACTIONS_RUNTIME_TOKEN has no Actions.Results scope")
+}
 
 type GithubPlanStorage struct {
 	Client            *github.Client
@@ -37,11 +66,17 @@ func (gps *GithubPlanStorage) StorePlanFile(fileContents []byte, artifactName st
 
 	actionsRuntimeToken := os.Getenv("ACTIONS_RUNTIME_TOKEN")
 	actionsResultsURL := os.Getenv("ACTIONS_RESULTS_URL")
-	githubRunID := os.Getenv("GITHUB_RUN_ID")
-	githubRunAttempt := os.Getenv("GITHUB_RUN_ATTEMPT")
 
 	if actionsResultsURL == "" {
 		return fmt.Errorf("ACTIONS_RESULTS_URL is not set; GitHub Actions Artifacts v4 requires this environment variable")
+	}
+	if actionsRuntimeToken == "" {
+		return fmt.Errorf("ACTIONS_RUNTIME_TOKEN is not set; GitHub Actions Artifacts v4 requires this environment variable")
+	}
+
+	workflowRunBackendID, workflowJobRunBackendID, err := extractArtifactBackendIDs(actionsRuntimeToken)
+	if err != nil {
+		return fmt.Errorf("could not extract artifact backend IDs from ACTIONS_RUNTIME_TOKEN: %w", err)
 	}
 
 	twirpBase := strings.TrimRight(actionsResultsURL, "/") + "/twirp/github.actions.results.api.v1.ArtifactService"
@@ -53,8 +88,8 @@ func (gps *GithubPlanStorage) StorePlanFile(fileContents []byte, artifactName st
 
 	// Step 1: CreateArtifact
 	createReqBody, _ := json.Marshal(map[string]interface{}{
-		"workflow_run_backend_id":     githubRunID,
-		"workflow_job_run_backend_id": githubRunAttempt,
+		"workflow_run_backend_id":     workflowRunBackendID,
+		"workflow_job_run_backend_id": workflowJobRunBackendID,
 		"name":                        artifactName,
 		"version":                     4,
 	})
@@ -94,8 +129,8 @@ func (gps *GithubPlanStorage) StorePlanFile(fileContents []byte, artifactName st
 
 	// Step 3: FinalizeArtifact
 	finalizeReqBody, _ := json.Marshal(map[string]interface{}{
-		"workflow_run_backend_id":     githubRunID,
-		"workflow_job_run_backend_id": githubRunAttempt,
+		"workflow_run_backend_id":     workflowRunBackendID,
+		"workflow_job_run_backend_id": workflowJobRunBackendID,
 		"name":                        artifactName,
 		"size":                        fmt.Sprintf("%d", dataLen),
 	})

--- a/libs/storage/plan_storage_test.go
+++ b/libs/storage/plan_storage_test.go
@@ -1,0 +1,421 @@
+package storage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeJWT builds a structurally-valid JWT whose `scp` claim encodes the given
+// Actions.Results scope. Production code only base64-decodes the payload and
+// reads the claim — no signature verification — so the header and signature
+// segments are fixed dummies.
+func makeJWT(t *testing.T, runID, jobRunID string) string {
+	t.Helper()
+	return makeJWTWithScope(t, "Actions.Results:"+runID+":"+jobRunID)
+}
+
+func makeJWTWithScope(t *testing.T, scp string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]string{"scp": scp})
+	require.NoError(t, err)
+	return makeJWTWithRawPayload(t, payload)
+}
+
+func makeJWTWithRawPayload(t *testing.T, payload []byte) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	signature := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	return header + "." + body + "." + signature
+}
+
+func TestExtractArtifactBackendIDs_HappyPath(t *testing.T) {
+	token := makeJWT(t, "abc123", "def456")
+
+	runID, jobRunID, err := extractArtifactBackendIDs(token)
+
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", runID)
+	assert.Equal(t, "def456", jobRunID)
+}
+
+func TestExtractArtifactBackendIDs_PicksActionsResultsAmongOtherScopes(t *testing.T) {
+	token := makeJWTWithScope(t, "Foo:1:2 Actions.Results:run-9:job-9 Bar:x:y")
+
+	runID, jobRunID, err := extractArtifactBackendIDs(token)
+
+	require.NoError(t, err)
+	assert.Equal(t, "run-9", runID)
+	assert.Equal(t, "job-9", jobRunID)
+}
+
+func TestExtractArtifactBackendIDs_Errors(t *testing.T) {
+	cases := []struct {
+		name           string
+		token          string
+		errorSubstring string
+	}{
+		{
+			name:           "empty token",
+			token:          "",
+			errorSubstring: "3 JWT parts",
+		},
+		{
+			name:           "single segment",
+			token:          "onlyone",
+			errorSubstring: "3 JWT parts",
+		},
+		{
+			name:           "two segments",
+			token:          "header.payload",
+			errorSubstring: "3 JWT parts",
+		},
+		{
+			name:           "four segments",
+			token:          "a.b.c.d",
+			errorSubstring: "3 JWT parts",
+		},
+		{
+			name:           "invalid base64 payload",
+			token:          "header.!!!notbase64!!!.sig",
+			errorSubstring: "failed to base64-decode",
+		},
+		{
+			name:           "payload not json",
+			token:          makeJWTWithRawPayload(t, []byte("not-json")),
+			errorSubstring: "failed to parse JWT claims",
+		},
+		{
+			name:           "scp without Actions.Results scope",
+			token:          makeJWTWithScope(t, "OtherScope:1:2 SomethingElse:3:4"),
+			errorSubstring: "no Actions.Results scope",
+		},
+		{
+			name:           "empty scp claim",
+			token:          makeJWTWithScope(t, ""),
+			errorSubstring: "no Actions.Results scope",
+		},
+		{
+			name:           "scp claim absent from payload",
+			token:          makeJWTWithRawPayload(t, []byte(`{"other":"value"}`)),
+			errorSubstring: "no Actions.Results scope",
+		},
+		{
+			name:           "Actions.Results scope without jobRunID",
+			token:          makeJWTWithScope(t, "Actions.Results:onlyone"),
+			errorSubstring: "no Actions.Results scope",
+		},
+		{
+			name:           "Actions.Results with empty runID",
+			token:          makeJWTWithScope(t, "Actions.Results::jobid"),
+			errorSubstring: "no Actions.Results scope",
+		},
+		{
+			name:           "Actions.Results with empty jobRunID",
+			token:          makeJWTWithScope(t, "Actions.Results:runid:"),
+			errorSubstring: "no Actions.Results scope",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runID, jobRunID, err := extractArtifactBackendIDs(tc.token)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errorSubstring)
+			assert.Empty(t, runID)
+			assert.Empty(t, jobRunID)
+		})
+	}
+}
+
+type recordedRequest struct {
+	Method  string
+	Path    string
+	Headers http.Header
+	Body    []byte
+}
+
+type capturedRequests struct {
+	mu       sync.Mutex
+	Create   []recordedRequest
+	Upload   []recordedRequest
+	Finalize []recordedRequest
+}
+
+func (c *capturedRequests) record(slot *[]recordedRequest, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	*slot = append(*slot, recordedRequest{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: r.Header.Clone(),
+		Body:    body,
+	})
+}
+
+type artifactServerOpts struct {
+	CreateStatus   int
+	CreateBody     string // if "", a valid CreateArtifact JSON pointing signed_upload_url at <server>/upload is used
+	UploadStatus   int
+	FinalizeStatus int
+	FinalizeBody   string
+}
+
+const (
+	createPath   = "/twirp/github.actions.results.api.v1.ArtifactService/CreateArtifact"
+	finalizePath = "/twirp/github.actions.results.api.v1.ArtifactService/FinalizeArtifact"
+	uploadPath   = "/upload"
+)
+
+func setupArtifactServer(t *testing.T, opts artifactServerOpts) (*httptest.Server, *capturedRequests) {
+	t.Helper()
+	captured := &capturedRequests{}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == createPath:
+			captured.record(&captured.Create, r)
+			status := opts.CreateStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			body := opts.CreateBody
+			if body == "" {
+				body = `{"signed_upload_url":"` + server.URL + uploadPath + `"}`
+			}
+			_, _ = w.Write([]byte(body))
+		case r.URL.Path == uploadPath:
+			captured.record(&captured.Upload, r)
+			status := opts.UploadStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+		case r.URL.Path == finalizePath:
+			captured.record(&captured.Finalize, r)
+			status := opts.FinalizeStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			body := opts.FinalizeBody
+			if body == "" {
+				body = "{}"
+			}
+			_, _ = w.Write([]byte(body))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, captured
+}
+
+func TestStorePlanFile_HappyPath(t *testing.T) {
+	server, captured := setupArtifactServer(t, artifactServerOpts{})
+	token := makeJWT(t, "run-42", "job-99")
+	t.Setenv("ACTIONS_RESULTS_URL", server.URL)
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", token)
+
+	gps := &GithubPlanStorage{}
+	contents := []byte("plan-file-bytes")
+
+	err := gps.StorePlanFile(contents, "my-artifact", "plan.tfplan")
+	require.NoError(t, err)
+
+	require.Len(t, captured.Create, 1, "CreateArtifact should be called exactly once")
+	require.Len(t, captured.Upload, 1, "Upload PUT should be called exactly once")
+	require.Len(t, captured.Finalize, 1, "FinalizeArtifact should be called exactly once")
+
+	createReq := captured.Create[0]
+	assert.Equal(t, http.MethodPost, createReq.Method)
+	assert.Equal(t, "Bearer "+token, createReq.Headers.Get("Authorization"))
+	assert.Equal(t, "application/json", createReq.Headers.Get("Content-Type"))
+	var createBody map[string]any
+	require.NoError(t, json.Unmarshal(createReq.Body, &createBody))
+	assert.Equal(t, "run-42", createBody["workflow_run_backend_id"])
+	assert.Equal(t, "job-99", createBody["workflow_job_run_backend_id"])
+	assert.Equal(t, "my-artifact", createBody["name"])
+	assert.EqualValues(t, 4, createBody["version"])
+
+	uploadReq := captured.Upload[0]
+	assert.Equal(t, http.MethodPut, uploadReq.Method)
+	assert.Equal(t, "BlockBlob", uploadReq.Headers.Get("x-ms-blob-type"))
+	assert.Equal(t, "application/octet-stream", uploadReq.Headers.Get("x-ms-blob-content-type"))
+	assert.Equal(t, "15", uploadReq.Headers.Get("Content-Length"))
+	assert.Equal(t, contents, uploadReq.Body)
+
+	finalizeReq := captured.Finalize[0]
+	assert.Equal(t, http.MethodPost, finalizeReq.Method)
+	assert.Equal(t, "Bearer "+token, finalizeReq.Headers.Get("Authorization"))
+	var finalizeBody map[string]any
+	require.NoError(t, json.Unmarshal(finalizeReq.Body, &finalizeBody))
+	assert.Equal(t, "run-42", finalizeBody["workflow_run_backend_id"])
+	assert.Equal(t, "job-99", finalizeBody["workflow_job_run_backend_id"])
+	assert.Equal(t, "my-artifact", finalizeBody["name"])
+	assert.Equal(t, "15", finalizeBody["size"])
+}
+
+func TestStorePlanFile_MissingResultsURL(t *testing.T) {
+	t.Setenv("ACTIONS_RESULTS_URL", "")
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", makeJWT(t, "r", "j"))
+
+	gps := &GithubPlanStorage{}
+	err := gps.StorePlanFile([]byte("data"), "name", "path")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ACTIONS_RESULTS_URL is not set")
+}
+
+func TestStorePlanFile_MissingRuntimeToken(t *testing.T) {
+	t.Setenv("ACTIONS_RESULTS_URL", "http://example.invalid")
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", "")
+
+	gps := &GithubPlanStorage{}
+	err := gps.StorePlanFile([]byte("data"), "name", "path")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ACTIONS_RUNTIME_TOKEN is not set")
+}
+
+func TestStorePlanFile_MalformedToken(t *testing.T) {
+	server, captured := setupArtifactServer(t, artifactServerOpts{})
+	t.Setenv("ACTIONS_RESULTS_URL", server.URL)
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", "not-a-jwt")
+
+	gps := &GithubPlanStorage{}
+	err := gps.StorePlanFile([]byte("data"), "name", "path")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not extract artifact backend IDs")
+	assert.Empty(t, captured.Create, "no HTTP calls should be made when token is malformed")
+	assert.Empty(t, captured.Upload)
+	assert.Empty(t, captured.Finalize)
+}
+
+func TestStorePlanFile_ServerErrors(t *testing.T) {
+	cases := []struct {
+		name           string
+		opts           artifactServerOpts
+		errorSubstring string
+		wantUpload     bool
+		wantFinalize   bool
+	}{
+		{
+			name:           "CreateArtifact returns 500",
+			opts:           artifactServerOpts{CreateStatus: http.StatusInternalServerError},
+			errorSubstring: "could not create artifact",
+		},
+		{
+			name:           "CreateArtifact returns 400",
+			opts:           artifactServerOpts{CreateStatus: http.StatusBadRequest},
+			errorSubstring: "could not create artifact",
+		},
+		{
+			name:           "CreateArtifact returns non-JSON body",
+			opts:           artifactServerOpts{CreateBody: "not-json"},
+			errorSubstring: "failed to parse CreateArtifact response",
+		},
+		{
+			name:           "CreateArtifact response missing signed_upload_url",
+			opts:           artifactServerOpts{CreateBody: `{"foo":"bar"}`},
+			errorSubstring: "missing signed_upload_url",
+		},
+		{
+			name:           "CreateArtifact response has empty signed_upload_url",
+			opts:           artifactServerOpts{CreateBody: `{"signed_upload_url":""}`},
+			errorSubstring: "missing signed_upload_url",
+		},
+		{
+			name:           "CreateArtifact response has wrong-typed signed_upload_url",
+			opts:           artifactServerOpts{CreateBody: `{"signed_upload_url":42}`},
+			errorSubstring: "missing signed_upload_url",
+		},
+		{
+			name:           "Upload PUT returns 403",
+			opts:           artifactServerOpts{UploadStatus: http.StatusForbidden},
+			errorSubstring: "could not upload artifact file",
+			wantUpload:     true,
+		},
+		{
+			name:           "FinalizeArtifact returns 500",
+			opts:           artifactServerOpts{FinalizeStatus: http.StatusInternalServerError},
+			errorSubstring: "could not finalize artifact upload",
+			wantUpload:     true,
+			wantFinalize:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server, captured := setupArtifactServer(t, tc.opts)
+			t.Setenv("ACTIONS_RESULTS_URL", server.URL)
+			t.Setenv("ACTIONS_RUNTIME_TOKEN", makeJWT(t, "r", "j"))
+
+			gps := &GithubPlanStorage{}
+			err := gps.StorePlanFile([]byte("payload"), "art", "path")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errorSubstring)
+			assert.Len(t, captured.Create, 1, "CreateArtifact must always be attempted")
+			if tc.wantUpload {
+				assert.Len(t, captured.Upload, 1, "Upload should have been called")
+			} else {
+				assert.Empty(t, captured.Upload, "Upload must not be called when CreateArtifact already failed")
+			}
+			if tc.wantFinalize {
+				assert.Len(t, captured.Finalize, 1, "Finalize should have been called")
+			} else {
+				assert.Empty(t, captured.Finalize, "Finalize must not be called when an earlier step failed")
+			}
+		})
+	}
+}
+
+func TestStorePlanFile_TrailingSlashInResultsURL(t *testing.T) {
+	server, captured := setupArtifactServer(t, artifactServerOpts{})
+	t.Setenv("ACTIONS_RESULTS_URL", server.URL+"/")
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", makeJWT(t, "r", "j"))
+
+	gps := &GithubPlanStorage{}
+	err := gps.StorePlanFile([]byte("data"), "name", "path")
+	require.NoError(t, err)
+
+	require.Len(t, captured.Create, 1)
+	assert.Equal(t, createPath, captured.Create[0].Path,
+		"trailing slash in ACTIONS_RESULTS_URL must not produce a doubled slash in the request path")
+	require.Len(t, captured.Finalize, 1)
+	assert.Equal(t, finalizePath, captured.Finalize[0].Path)
+}
+
+func TestStorePlanFile_EmptyFileContents(t *testing.T) {
+	server, captured := setupArtifactServer(t, artifactServerOpts{})
+	t.Setenv("ACTIONS_RESULTS_URL", server.URL)
+	t.Setenv("ACTIONS_RUNTIME_TOKEN", makeJWT(t, "r", "j"))
+
+	gps := &GithubPlanStorage{}
+	err := gps.StorePlanFile([]byte{}, "name", "path")
+	require.NoError(t, err)
+
+	require.Len(t, captured.Upload, 1)
+	assert.Equal(t, "0", captured.Upload[0].Headers.Get("Content-Length"))
+	assert.Empty(t, captured.Upload[0].Body)
+
+	require.Len(t, captured.Finalize, 1)
+	var finalizeBody map[string]any
+	require.NoError(t, json.Unmarshal(captured.Finalize[0].Body, &finalizeBody))
+	assert.Equal(t, "0", finalizeBody["size"])
+}


### PR DESCRIPTION
## Summary

Fixes #1702

The old `StorePlanFile` implementation called `_apis/pipelines/workflows/{runID}/artifacts?api-version=6.0-preview` (via `ACTIONS_RUNTIME_URL`), the deprecated Artifacts v1-v3 internal API. GitHub has removed this endpoint, causing HTTP 400 errors for anyone using `upload-plan-destination: github`.

This PR migrates the upload path to the **Artifacts v4 Twirp/JSON protocol** used by `@actions/artifact` v2+, the same protocol that `actions/upload-artifact@v4` uses internally:

1. `POST {ACTIONS_RESULTS_URL}/twirp/github.actions.results.api.v1.ArtifactService/CreateArtifact` → receive `signed_upload_url`
2. `PUT` file contents to the signed Azure Blob URL (`x-ms-blob-type: BlockBlob`)
3. `POST .../FinalizeArtifact` to commit the upload

The download path (`DownloadLatestPlans`, `PlanExists`, `RetrievePlan`) already uses the stable GitHub REST API (`go-github`) and is unchanged.

## Changes

This PR contains three commits, each addressing a distinct piece needed to make v4 upload work:

### 1. `libs/storage/plan_storage.go` — replace v1-v3 calls with v4 Twirp/JSON

The download path is unchanged. Only `StorePlanFile` is rewritten.

### 2. `action.yml` — expose `ACTIONS_RESULTS_URL` to the digger CLI

GitHub Actions does **not** inject the runtime service env vars (`ACTIONS_RUNTIME_TOKEN`, `ACTIONS_RESULTS_URL`, etc.) into shell `run:` steps — they are only injected into Node.js JavaScript actions. The digger CLI is launched from a `run:` step, so it sees these variables as empty.

action.yml already had a Node.js step that re-exports the v1-v3 vars (`ACTIONS_RUNTIME_URL`, `ACTIONS_RUNTIME_TOKEN`, `ACTIONS_CACHE_URL`) via `core.exportVariable()` for exactly this reason. This PR adds `ACTIONS_RESULTS_URL` to that list (one-line change). Without this, the Go code aborts immediately with `ACTIONS_RESULTS_URL is not set`.

### 3. `libs/storage/plan_storage.go` — derive backend IDs from the JWT, not from env vars

The Twirp service rejects requests with `HTTP 401 "invalid auth token"` when `workflow_run_backend_id` is set to `GITHUB_RUN_ID`. The official `@actions/artifact` v2 package does **not** use `GITHUB_RUN_ID` / `GITHUB_RUN_ATTEMPT` — it parses the JWT in `ACTIONS_RUNTIME_TOKEN` and reads the `scp` claim, which has the form:

```
Actions.Results:<workflow_run_backend_id>:<workflow_job_run_backend_id>
```

The IDs the backend ties to the bearer token are baked into the token itself, so they must be extracted from the JWT — not guessed from env vars. This PR adds a small base64-decode-only JWT payload parser (no signature verification — the token is the runner's own) and uses the extracted IDs in `CreateArtifact` and `FinalizeArtifact`.

## Test plan

End-to-end verified with a real PR on a GitHub-hosted runner: https://github.com/kiwamizamurai/digger_tutorial/pull/4

Successful run output:

```
level=INFO msg="Successfully stored plan file in GitHub artifacts"
  owner=kiwamizamurai repo=digger_tutorial artifactName=sandbox size=2607
```

All three Twirp steps succeeded (`CreateArtifact` → signed-URL `PUT` → `FinalizeArtifact`).

- [x] `go build ./libs/storage/...` passes
- [x] `CreateArtifact` returns `signed_upload_url`
- [x] Azure Blob `PUT` succeeds
- [x] `FinalizeArtifact` commits the artifact
- [x] Plan can be downloaded by a subsequent step (existing REST path is untouched)

> Note: Twirp supports both binary protobuf and JSON encoding. This implementation uses JSON to avoid adding a protobuf dependency.