### PR TITLE
fix: adjust GitHub check run char limit considering the MD terraform text wrapper

### DIFF
--- a/backend/controllers/projects_helpers.go
+++ b/backend/controllers/projects_helpers.go
@@ -512,9 +512,12 @@ func UpdateCheckRunForJob(gh utils.GithubClientProvider, job *models.DiggerJob) 
 	// Character limit check - GitHub check run text field has a 65535 character limit
 	const maxCheckRunTextLength = 65535
 	cutOffMsg := "\n[Character limit exceeded, output truncated]"
-	if utf8.RuneCountInString(job.TerraformOutput) > maxCheckRunTextLength {
+	wrapper := "```terraform\n" + "```\n"
+	maxOutputLength := maxCheckRunTextLength - utf8.RuneCountInString(wrapper)
+
+	if utf8.RuneCountInString(job.TerraformOutput) > maxOutputLength {
 		runes := []rune(job.TerraformOutput)
-		truncateAt := maxCheckRunTextLength - utf8.RuneCountInString(cutOffMsg)
+		truncateAt := maxOutputLength - utf8.RuneCountInString(cutOffMsg)
 		job.TerraformOutput = string(runes[:truncateAt]) + cutOffMsg
 	}
 

--- a/backend/controllers/projects_test.go
+++ b/backend/controllers/projects_test.go
@@ -128,7 +128,7 @@ func TestCharacterLimit(t *testing.T) {
 		},
 		{
 			name:           "at limit - no truncation",
-			inputLength:    65535,
+			inputLength:    65535 - 17, // account for wrapper
 			expectTruncate: false,
 		},
 		{
@@ -140,25 +140,29 @@ func TestCharacterLimit(t *testing.T) {
 
 	const maxCheckRunTextLength = 65535
 	cutOffMsg := "\n[Character limit exceeded, output truncated]"
+	wrapper := "```terraform\n" + "```\n"
+	maxOutputLength := maxCheckRunTextLength - utf8.RuneCountInString(wrapper)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input := strings.Repeat("a", tt.inputLength)
 
 			result := input
-			if utf8.RuneCountInString(result) > maxCheckRunTextLength {
+			if utf8.RuneCountInString(result) > maxOutputLength {
 				runes := []rune(result)
-				truncateAt := maxCheckRunTextLength - utf8.RuneCountInString(cutOffMsg)
+				truncateAt := maxOutputLength - utf8.RuneCountInString(cutOffMsg)
 				result = string(runes[:truncateAt]) + cutOffMsg
 			}
 
+			text := "```terraform\n" + result + "```\n"
+
 			if tt.expectTruncate {
-				assert.Equal(t, maxCheckRunTextLength, utf8.RuneCountInString(result),
+				assert.Equal(t, maxCheckRunTextLength, utf8.RuneCountInString(text),
 					"truncated output should be exactly 65535 characters")
 				assert.True(t, strings.HasSuffix(result, cutOffMsg),
 					"truncated output should end with cutoff message")
 			} else {
-				assert.Equal(t, tt.inputLength, utf8.RuneCountInString(result),
+				assert.LessOrEqual(t, utf8.RuneCountInString(text), maxCheckRunTextLength,
 					"non-truncated output should maintain original length")
 				assert.False(t, strings.HasSuffix(result, cutOffMsg),
 					"non-truncated output should not have cutoff message")


### PR DESCRIPTION
The existing truncation logic in `UpdateCheckRunForJob` truncates `TerraformOutput` to 65,535 characters, but then wraps it in a markdown code block ("```terraform\n ... ```\n") adding 17 characters.

This causes the final text sent to GitHub's Check Run API to be 65,552 characters, exceeding the 65,535 limit and resulting in a 422 error.

The fix subtracts the wrapper length from the truncation limit so the final text stays within bounds.
Test is also updated to assert on the final wrapped text rather than just the raw output.

Follows up on https://github.com/diggerhq/digger/pull/2550
Relates to https://github.com/diggerhq/digger/issues/2542

### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> Code and docs generated by Claude Code; reviewed manually
> GitHub Copilot for additional validation
