### PR TITLE
fix: prevent fmt.Sprintf from mangling % characters in plan output

### DIFF
--- a/libs/comment_utils/reporting/comments.go
+++ b/libs/comment_utils/reporting/comments.go
@@ -13,12 +13,7 @@ func GetTerraformOutputAsCollapsibleComment(summary string, open bool) func(stri
 	}
 
 	return func(comment string) string {
-		return fmt.Sprintf(`<details %v><summary>`+summary+`</summary>
-
-`+"```terraform"+`
-`+comment+`
-`+"```"+`
-</details>`, openTag)
+		return fmt.Sprintf("<details %s><summary>%s</summary>\n\n```terraform\n%s\n```\n</details>", openTag, summary, comment)
 	}
 }
 
@@ -36,9 +31,7 @@ func AsCollapsibleComment(summary string, open bool) func(string) string {
 		openTag = ""
 	}
 	return func(comment string) string {
-		return fmt.Sprintf(`<details %v><summary>`+summary+`</summary>
-  `+comment+`
-</details>`, openTag)
+		return fmt.Sprintf("<details %s><summary>%s</summary>\n  %s\n</details>", openTag, summary, comment)
 	}
 }
 

--- a/libs/comment_utils/reporting/comments_test.go
+++ b/libs/comment_utils/reporting/comments_test.go
@@ -1,0 +1,92 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetTerraformOutputAsCollapsibleComment_PercentInComment(t *testing.T) {
+	// MySQL wildcard host 10.% in resource addresses should not be mangled
+	formatter := GetTerraformOutputAsCollapsibleComment("Plan output", true)
+	comment := `mysql_user.app["10.%"]: Refreshing state...`
+
+	result := formatter(comment)
+
+	if !strings.Contains(result, `10.%`) {
+		t.Errorf("percent in comment was mangled: %s", result)
+	}
+	if strings.Contains(result, `MISSING`) || strings.Contains(result, `BADWIDTH`) {
+		t.Errorf("fmt.Sprintf interpreted percent as format verb: %s", result)
+	}
+}
+
+func TestGetTerraformOutputAsCollapsibleComment_PercentInSummary(t *testing.T) {
+	formatter := GetTerraformOutputAsCollapsibleComment("Plan for project_100%_done", false)
+	result := formatter("no changes")
+
+	if !strings.Contains(result, "100%_done") {
+		t.Errorf("percent in summary was mangled: %s", result)
+	}
+}
+
+func TestGetTerraformOutputAsCollapsibleComment_OpenTag(t *testing.T) {
+	formatter := GetTerraformOutputAsCollapsibleComment("Plan output", true)
+	result := formatter("some plan")
+
+	if !strings.Contains(result, `open="true"`) {
+		t.Errorf("expected open tag in result: %s", result)
+	}
+	if !strings.Contains(result, "<summary>Plan output</summary>") {
+		t.Errorf("expected summary in result: %s", result)
+	}
+	if !strings.Contains(result, "some plan") {
+		t.Errorf("expected comment body in result: %s", result)
+	}
+}
+
+func TestGetTerraformOutputAsCollapsibleComment_ClosedTag(t *testing.T) {
+	formatter := GetTerraformOutputAsCollapsibleComment("Plan output", false)
+	result := formatter("some plan")
+
+	if strings.Contains(result, `open="true"`) {
+		t.Errorf("did not expect open tag in result: %s", result)
+	}
+}
+
+func TestAsCollapsibleComment_PercentInComment(t *testing.T) {
+	formatter := AsCollapsibleComment("Instructions", false)
+	comment := `override_special = "~!#%^&*()"`
+
+	result := formatter(comment)
+
+	if !strings.Contains(result, `#%^&`) {
+		t.Errorf("percent in comment was mangled: %s", result)
+	}
+	if strings.Contains(result, `MISSING`) || strings.Contains(result, `BADWIDTH`) {
+		t.Errorf("fmt.Sprintf interpreted percent as format verb: %s", result)
+	}
+}
+
+func TestAsCollapsibleComment_PercentInSummary(t *testing.T) {
+	formatter := AsCollapsibleComment("100% complete", true)
+	result := formatter("details here")
+
+	if !strings.Contains(result, "100% complete") {
+		t.Errorf("percent in summary was mangled: %s", result)
+	}
+}
+
+func TestAsCollapsibleComment_OpenTag(t *testing.T) {
+	formatter := AsCollapsibleComment("Title", true)
+	result := formatter("body")
+
+	if !strings.Contains(result, `open="true"`) {
+		t.Errorf("expected open tag in result: %s", result)
+	}
+	if !strings.Contains(result, "<summary>Title</summary>") {
+		t.Errorf("expected summary in result: %s", result)
+	}
+	if !strings.Contains(result, "body") {
+		t.Errorf("expected comment body in result: %s", result)
+	}
+}


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

This PR was written with the assistance of Claude Code (code fix, tests, and PR description generated by Claude Code, reviewed manually).

---

## Problem

`GetTerraformOutputAsCollapsibleComment` and `AsCollapsibleComment` embed the `comment` and `summary` strings directly into the format string passed to `fmt.Sprintf`. Any `%` characters in the content get interpreted as format verbs, producing `%!(MISSING)` / `%!(BADWIDTH)` in the output.

Real-world examples that trigger this:
- MySQL wildcard host `10.%` in `mysql_user` / `mysql_grant` resource addresses
- `override_special = "~!#%^&*()..."` in `random_password` resources

**Before** (broken):
```go
return fmt.Sprintf(`<details %v><summary>` + summary + `</summary>\n...\n` + comment + `\n...`, openTag)
```

**After** (fixed):
```go
return fmt.Sprintf("<details %s><summary>%s</summary>\n\n```terraform\n%s\n```\n</details>", openTag, summary, comment)
```

## Changes

- `GetTerraformOutputAsCollapsibleComment`: pass `summary` and `comment` as `%s` arguments instead of interpolating into the format string
- `AsCollapsibleComment`: same fix
- Added regression tests for both functions covering `%` in comments, `%` in summaries, and open/closed tag behavior

`GetTerraformOutputAsComment` and `AsComment` use string concatenation (not `fmt.Sprintf`) so they are unaffected.

## Test plan

- [x] `go test -v ./libs/comment_utils/reporting/` — all 7 tests pass
- [x] Verified tests fail on the unfixed code with `%!(MISSING)` errors, confirming they catch the bug