### PR TITLE
fix: bump internal checkout action to v4.3.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -315,12 +315,12 @@ runs:
         exit 1
       shell: bash
       if: inputs.setup-google-cloud == 'true'
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         clean: false
         ref: refs/pull/${{ github.event.issue.number }}/merge
       if: ${{ github.event_name == 'issue_comment' && inputs.configure-checkout == 'true' }}
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         clean: false
       if: ${{ github.event_name != 'issue_comment' && inputs.configure-checkout == 'true' }}


### PR DESCRIPTION
## Summary
- bump Digger's internal `actions/checkout` pin from `v4.3.0` to `v4.3.1`
- pick up the checkout credential cleanup changes needed for compatibility with workflows already using `actions/checkout@v6`
- avoid duplicate GitHub Authorization headers during Digger's nested checkout flow