### PR TITLE
fix(#1472): include project id in plan and apply headers

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -587,9 +587,9 @@ func reportTerraformPlanOutput(reporter reporting.Reporter, projectId string, pl
 	var formatter func(string) string
 
 	if reporter.SupportsMarkdown() {
-		formatter = reporting.GetTerraformOutputAsCollapsibleComment("Plan output", true)
+		formatter = reporting.GetTerraformOutputAsCollapsibleComment(fmt.Sprintf("Plan output for **%v**", projectId), true)
 	} else {
-		formatter = reporting.GetTerraformOutputAsComment("Plan output")
+		formatter = reporting.GetTerraformOutputAsComment(fmt.Sprintf("Plan output for %v", projectId))
 	}
 
 	_, _, err := reporter.Report(plan, formatter)

--- a/libs/execution/execution.go
+++ b/libs/execution/execution.go
@@ -457,9 +457,9 @@ func reportApplyError(r reporting.Reporter, err error) {
 func reportTerraformApplyOutput(r reporting.Reporter, projectId string, applyOutput string) {
 	var formatter func(string) string
 	if r.SupportsMarkdown() {
-		formatter = reporting.GetTerraformOutputAsCollapsibleComment("Apply output", false)
+		formatter = reporting.GetTerraformOutputAsCollapsibleComment(fmt.Sprintf("Apply output for **%v**", projectId), false)
 	} else {
-		formatter = reporting.GetTerraformOutputAsComment("Apply output")
+		formatter = reporting.GetTerraformOutputAsComment(fmt.Sprintf("Apply output for %v", projectId))
 	}
 
 	_, _, commentErr := r.Report(applyOutput, formatter)


### PR DESCRIPTION
### :brain: **Ai UsageDetails (if applicable):**

## What Resolves #1472.
Digger's PR reporting currently outputs generic headers like "Apply output" or "Plan output," which becomes extremely difficult to parse for users operating within Monorepos mapping to multiple projects. 
This Pull Request addresses the issue by injecting the `projectId` dynamically into both `reportTerraformApplyOutput` and `reportTerraformPlanOutput` so that each collapsible comment clearly identifies its target project (e.g., "Apply output for my-project").
## How
- Updated `libs/execution/execution.go` to explicitly include the `projectId` in the Apply output comment strings.
- Updated `cli/pkg/digger/digger.go` to explicitly include the `projectId` in the Plan output comment strings.
- Preserved existing markdown formatting by `**bolding**` the injected project IDs when the platform supports it.
## Testing
- Relies on automated CI test suites to verify string comparisons and backwards compatibility.
---
*Disclosure: I consulted with an AI assistant while writing this code and reviewed and verified manually*


