### PR TITLE
fix(#2608): auto-detect digger-os and digger-arch inputs in github ac…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -255,13 +255,13 @@ inputs:
     required: false
     default: ""
   digger-os:
-    description: "OS variant of the digger CLI to install. Valid configurable values are: windows, linux, darwin, freebsd."
+    description: "OS variant of the digger CLI to install. Valid configurable values are: windows, linux, darwin, freebsd. Defaults to runner.os if empty."
     required: false
-    default: "Linux"
+    default: ""
   digger-arch:
-    description: "Architecture of the digger CLI to install. Valid configurable values are: amd64, arm64, 386."
+    description: "Architecture of the digger CLI to install. Valid configurable values are: amd64, arm64, 386. Defaults to runner.arch if empty."
     required: false
-    default: "X64"
+    default: ""
   log-level:
     description: "Log level for digger CLI. Valid values are: DEBUG, INFO, WARN, ERROR."
     required: false
@@ -590,8 +590,27 @@ runs:
       run: |
         set -euo pipefail
 
+        if [[ -z "$DIGGER_OS" ]]; then
+          case "${{ runner.os }}" in
+            Linux) DIGGER_OS="linux" ;;
+            macOS) DIGGER_OS="darwin" ;;
+            Windows) DIGGER_OS="windows" ;;
+            *) DIGGER_OS="linux" ;;
+          esac
+        fi
+
+        if [[ -z "$DIGGER_ARCH" ]]; then
+          case "${{ runner.arch }}" in
+            X64) DIGGER_ARCH="amd64" ;;
+            ARM64) DIGGER_ARCH="arm64" ;;
+            ARM) DIGGER_ARCH="arm" ;;
+            X86) DIGGER_ARCH="386" ;;
+            *) DIGGER_ARCH="amd64" ;;
+          esac
+        fi
+
         echo "🔧 Downloading Digger CLI..."
-        echo "Runner OS: ${{ runner.os }}, Arch: ${{ runner.arch }}, Digger Version: ${DIGGER_VERSION}"
+        echo "Resolved OS: ${DIGGER_OS}, Arch: ${DIGGER_ARCH}, Digger Version: ${DIGGER_VERSION}"
 
         if [[ ${{ inputs.ee }} == "true" ]]; then
           if [[ ${{ inputs.fips }} == "true" ]]; then


### PR DESCRIPTION
## What Resolves #2608.
Currently, `action.yml` hardcodes its inputs to default to `Linux` and `X64`. When users run Digger on non-x86 Linux machines or macOS self-hosted runners (Apple Silicon), the CLI download step fails because it blindly requests the legacy `Linux-X64` binary payload without accounting for the actual runner architecture.
This Pull Request introduces auto-detection functionality that gracefully falls back to the native `runner.os` and `runner.arch` metrics exclusively when the `digger-os` or `digger-arch` inputs are omitted.
## How
- Updated `action.yml` to set the default value of the OS and Architecture inputs to an empty string `""`.
- Added a bash variable-assignment block inside the `name: download, install, and run digger` step.
- Mapped GitHub's `runner.os` (Linux, macOS, Windows) and `runner.arch` (X64, ARM64, etc.) outputs into their corresponding Golang static binary compilation identifiers (`linux`, `darwin`, `amd64`, `arm64`, etc.).
- Backwards compatibility is preserved utilizing strict `-z` empty-string checks; if a user continues explicitly providing properties to the `with:` segment on old configurations, auto-detection gracefully yields control.
## Testing
- Performed static bash syntax validation on the modified shell payload snippet to prevent composite action crashes.
---
*Disclosure: I consulted with an AI assistant while writing the implementation for this auto-detect feature.*
 reviewed and verified manually._

