### PR TITLE
fix: remove web middleware from github setup and exchange-code routes

### DIFF
--- a/backend/bootstrap/main.go
+++ b/backend/bootstrap/main.go
@@ -170,11 +170,12 @@ func Bootstrap(templates embed.FS, diggerController controllers.DiggerController
 
 	githubGroup := r.Group("/github")
 	githubGroup.Use(middleware.GetWebMiddleware())
-	// authless endpoint because we no longer rely on orgId
+	// Auth for these endpoints is handled by the UI layer before proxying, so
+	// they do not require the backend web middleware.
 	r.GET("/github/callback", diggerController.GithubAppCallbackPage)
+	r.GET("/github/setup", controllers.GithubAppSetup)
+	r.GET("/github/exchange-code", diggerController.GithubSetupExchangeCode)
 	githubGroup.GET("/repos", diggerController.GithubReposPage)
-	githubGroup.GET("/setup", controllers.GithubAppSetup)
-	githubGroup.GET("/exchange-code", diggerController.GithubSetupExchangeCode)
 
 	publicPrefix := utils.NormalizePublicPathPrefix(os.Getenv("DIGGER_PUBLIC_PATH_PREFIX"))
 	if publicPrefix != "" {
@@ -185,9 +186,9 @@ func Bootstrap(templates embed.FS, diggerController controllers.DiggerController
 		prefixedGithubGroup := prefixed.Group("/github")
 		prefixedGithubGroup.Use(middleware.GetWebMiddleware())
 		prefixed.GET("/github/callback", diggerController.GithubAppCallbackPage)
+		prefixed.GET("/github/setup", controllers.GithubAppSetup)
+		prefixed.GET("/github/exchange-code", diggerController.GithubSetupExchangeCode)
 		prefixedGithubGroup.GET("/repos", diggerController.GithubReposPage)
-		prefixedGithubGroup.GET("/setup", controllers.GithubAppSetup)
-		prefixedGithubGroup.GET("/exchange-code", diggerController.GithubSetupExchangeCode)
 	}
 
 	authorized := r.Group("/")


### PR DESCRIPTION
DISCLAIMER: I consulted Claude Opus to understand the codebase and come up with a solution based on the issue described below.

These endpoints are proxied through the UI, which handles authentication before forwarding the request. The backend web middleware expects a session cookie that is not present in proxied requests, causing a 403 on `/orchestrator/github/setup`.

This aligns `/github/setup` and `/github/exchange-code` with `/github/callback`, which was already registered outside the auth group for the same reason.

<img width="575" height="436" alt="image" src="https://github.com/user-attachments/assets/34e4c471-26c6-40fe-9fad-e10284b078f8" />

<img width="486" height="273" alt="image" src="https://github.com/user-attachments/assets/ca6fd01e-6d3e-4877-8bad-9bcd159494ae" />
