### PR TITLE
fix: return error when lock acquisition fails instead of nil

### DIFF
--- a/libs/execution/execution.go
+++ b/libs/execution/execution.go
@@ -31,7 +31,6 @@ type LockingExecutorWrapper struct {
 }
 
 func (l LockingExecutorWrapper) Plan() (*iac_utils.IacSummary, bool, bool, string, string, error) {
-	plan := ""
 	locked, err := l.ProjectLock.Lock()
 	if err != nil {
 		return nil, false, false, "", "", fmt.Errorf("digger plan, error locking project: %v", err)
@@ -39,9 +38,8 @@ func (l LockingExecutorWrapper) Plan() (*iac_utils.IacSummary, bool, bool, strin
 	slog.Info("Lock result", "locked", locked)
 	if locked {
 		return l.Executor.Plan()
-	} else {
-		return nil, false, false, plan, "", nil
 	}
+	return nil, false, false, "", "", fmt.Errorf("failed to acquire lock for project")
 }
 
 func (l LockingExecutorWrapper) Apply() (*iac_utils.IacSummary, bool, string, error) {
@@ -53,9 +51,8 @@ func (l LockingExecutorWrapper) Apply() (*iac_utils.IacSummary, bool, string, er
 	slog.Info("Lock result", "locked", locked)
 	if locked {
 		return l.Executor.Apply()
-	} else {
-		return nil, false, "couldn't lock ", nil
 	}
+	return nil, false, "failed to acquire lock for project", fmt.Errorf("failed to acquire lock for project")
 }
 
 func (l LockingExecutorWrapper) Destroy() (bool, error) {
@@ -66,9 +63,8 @@ func (l LockingExecutorWrapper) Destroy() (bool, error) {
 	slog.Info("Lock result", "locked", locked)
 	if locked {
 		return l.Executor.Destroy()
-	} else {
-		return false, nil
 	}
+	return false, fmt.Errorf("failed to acquire lock for project")
 }
 
 func (l LockingExecutorWrapper) Unlock() error {

--- a/libs/execution/execution_test.go
+++ b/libs/execution/execution_test.go
@@ -1,6 +1,8 @@
 package execution
 
 import (
+	"github.com/diggerhq/digger/libs/iac_utils"
+	"github.com/diggerhq/digger/libs/locking"
 	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
@@ -259,4 +261,103 @@ Changes to Outputs:
 	res := cleanupTerraformPlan(stdout)
 	index := strings.Index(stdout, "OpenTofu will perform the following actions:")
 	assert.Equal(t, stdout[index:], res)
+}
+
+// mockProjectLock implements locking.ProjectLock for tests
+type mockProjectLock struct {
+	locked bool
+	err    error
+}
+
+func (m *mockProjectLock) Lock() (bool, error)  { return m.locked, m.err }
+func (m *mockProjectLock) Unlock() (bool, error) { return true, nil }
+func (m *mockProjectLock) ForceUnlock() error    { return nil }
+func (m *mockProjectLock) LockId() string        { return "test-lock" }
+
+// Compile-time check
+var _ locking.ProjectLock = &mockProjectLock{}
+
+// mockExecutor implements Executor for tests
+type mockExecutor struct {
+	planCalled    bool
+	applyCalled   bool
+	destroyCalled bool
+}
+
+func (m *mockExecutor) Plan() (*iac_utils.IacSummary, bool, bool, string, string, error) {
+	m.planCalled = true
+	return &iac_utils.IacSummary{}, true, true, "plan output", "", nil
+}
+
+func (m *mockExecutor) Apply() (*iac_utils.IacSummary, bool, string, error) {
+	m.applyCalled = true
+	return &iac_utils.IacSummary{}, true, "apply output", nil
+}
+
+func (m *mockExecutor) Destroy() (bool, error) {
+	m.destroyCalled = true
+	return true, nil
+}
+
+func TestLockFailurePlanReturnsError(t *testing.T) {
+	exec := &mockExecutor{}
+	wrapper := LockingExecutorWrapper{
+		ProjectLock: &mockProjectLock{locked: false, err: nil},
+		Executor:    exec,
+	}
+
+	_, _, _, _, _, err := wrapper.Plan()
+	assert.Error(t, err, "Plan should return error when lock acquisition fails")
+	assert.Contains(t, err.Error(), "failed to acquire lock")
+	assert.False(t, exec.planCalled, "Executor.Plan should not be called when lock fails")
+}
+
+func TestLockFailureApplyReturnsError(t *testing.T) {
+	exec := &mockExecutor{}
+	wrapper := LockingExecutorWrapper{
+		ProjectLock: &mockProjectLock{locked: false, err: nil},
+		Executor:    exec,
+	}
+
+	_, _, msg, err := wrapper.Apply()
+	assert.Error(t, err, "Apply should return error when lock acquisition fails")
+	assert.Contains(t, err.Error(), "failed to acquire lock")
+	assert.Contains(t, msg, "failed to acquire lock")
+	assert.False(t, exec.applyCalled, "Executor.Apply should not be called when lock fails")
+}
+
+func TestLockFailureDestroyReturnsError(t *testing.T) {
+	exec := &mockExecutor{}
+	wrapper := LockingExecutorWrapper{
+		ProjectLock: &mockProjectLock{locked: false, err: nil},
+		Executor:    exec,
+	}
+
+	_, err := wrapper.Destroy()
+	assert.Error(t, err, "Destroy should return error when lock acquisition fails")
+	assert.Contains(t, err.Error(), "failed to acquire lock")
+	assert.False(t, exec.destroyCalled, "Executor.Destroy should not be called when lock fails")
+}
+
+func TestLockSuccessDelegatesToExecutor(t *testing.T) {
+	exec := &mockExecutor{}
+	wrapper := LockingExecutorWrapper{
+		ProjectLock: &mockProjectLock{locked: true, err: nil},
+		Executor:    exec,
+	}
+
+	_, planPerformed, _, _, _, err := wrapper.Plan()
+	assert.NoError(t, err)
+	assert.True(t, planPerformed)
+	assert.True(t, exec.planCalled, "Executor.Plan should be called when lock succeeds")
+
+	_, applyPerformed, _, err := wrapper.Apply()
+	assert.NoError(t, err)
+	assert.True(t, applyPerformed)
+	assert.True(t, exec.applyCalled, "Executor.Apply should be called when lock succeeds")
+
+	success, err := wrapper.Destroy()
+	assert.NoError(t, err)
+	assert.True(t, success)
+	assert.True(t, exec.destroyCalled, "Executor.Destroy should be called when lock succeeds")
 }


### PR DESCRIPTION
## Problem

When `LockingExecutorWrapper.Plan()`, `Apply()`, or `Destroy()` fail to acquire a lock (`locked == false`), they return a `nil` error. This causes the caller `run()` function in `cli/pkg/digger/digger.go` to silently succeed — the `switch` case falls through to the default `return &execution.DiggerExecutorResult{}, "", nil`, reporting success to CI even though no actual plan/apply/destroy was performed.

This means CI builds pass even when a lock could not be acquired, giving users a false sense that their infrastructure changes were processed.

## Root Cause

In `libs/execution/execution.go`:

- `Plan()` returned `nil, false, false, plan, "", nil` when `locked == false`
- `Apply()` returned `nil, false, "couldn't lock ", nil` when `locked == false`  
- `Destroy()` returned `false, nil` when `locked == false`

All three methods returned `nil` error on lock failure.

## Fix

Return a descriptive `fmt.Errorf("failed to acquire lock for project")` error from all three methods when `locked == false`, so callers can detect and properly report the lock failure.

## Tests

Added 4 new unit tests:
- `TestLockFailurePlanReturnsError` — verifies Plan returns error on lock failure
- `TestLockFailureApplyReturnsError` — verifies Apply returns error on lock failure  
- `TestLockFailureDestroyReturnsError` — verifies Destroy returns error on lock failure
- `TestLockSuccessDelegatesToExecutor` — verifies all three methods delegate correctly when lock succeeds

All tests pass.

Fixes #1366