### PR TITLE
[follow-up to #2640] feat: add dependency file triggers for terraform projects

### DIFF
--- a/docs/ce/howto/include-exclude-patterns.mdx
+++ b/docs/ce/howto/include-exclude-patterns.mdx
@@ -20,6 +20,8 @@ modules/
 
 If you wanted to trigger plans for all `modules/` folder in both dev and prod projects you would include them in the `include_patterns` key. Similarly you put anything which you want to ignore in the `exclude_patterns` key ( exclude takes precedence over includes).
 
+If you want a narrower, dependency-graph-based trigger instead of a broad `modules/**` glob, you can enable `dependency_file_triggers: true`. For Terraform/OpenTofu this follows local `module` imports and tracks imported module `*.tf*` files recursively. If those imported files belong to another Digger project, Digger also infers the matching project dependency edge so you do not need to duplicate `depends_on` as often. This setting is currently intended for Terraform/OpenTofu projects.
+
 Example using patterns relative to project directory:
 
 ```yml

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -60,6 +60,7 @@ projects:
     layer: 0
     include_patterns: ["../modules/**"]
     exclude_patterns: []
+    dependency_file_triggers: false
     depends_on: []
     aws_role_to_assume:
       aws_role_region: us-east-1
@@ -76,9 +77,11 @@ projects:
     workflow: staging
     include_patterns: ["../modules/**"]
     exclude_patterns: []
+    dependency_file_triggers: false
 generate_projects:
   include: "../projects/**"
   exclude: "../.terraform/**"
+  dependency_file_triggers: false
   terragrunt: false
   blocks:
     - block_name: dev-block
@@ -90,6 +93,7 @@ generate_projects:
       terragrunt: false
       include_patterns: []
       exclude_patterns: []
+      dependency_file_triggers: false
       aws_role_to_assume:
         aws_role_region: us-east-1
         state: arn:aws:iam::123456789012:role/state-role
@@ -321,6 +325,10 @@ Define individual projects using the `projects` array.
   List of directory glob patterns to exclude, e.g., `[".terraform/**"]`. See [Include / Exclude Patterns](/ce/howto/include-exclude-patterns).
 </ParamField>
 
+<ParamField path="dependency_file_triggers" type="boolean" default="false">
+  Automatically derive additional trigger paths from the project dependency graph for Terraform/OpenTofu projects. This follows local `module` sources and watches imported module `*.tf*` files recursively. When imported files belong to another Digger project, this also infers a project dependency edge, reducing the need to duplicate `depends_on`. This augments `include_patterns`; it does not replace them. Currently not supported for Terragrunt or Pulumi projects.
+</ParamField>
+
 <ParamField path="depends_on" type="array" default="[]">
   List of project names that must complete before this project. Does not force terraform run, but affects the order of commands for projects modified in the current PR.
 </ParamField>
@@ -377,6 +385,10 @@ Automatically generate projects from directory structure using the `generate_pro
   Glob pattern to exclude directories from project generation.
 </ParamField>
 
+<ParamField path="dependency_file_triggers" type="boolean" default="false">
+  Enable automatic dependency-based trigger discovery for generated Terraform/OpenTofu projects. If imported files belong to another generated or declared Digger project, Digger also infers the corresponding project dependency edge. This augments any `include_patterns` set on the generated projects. Currently not supported for Terragrunt generation.
+</ParamField>
+
 <ParamField path="terragrunt" type="boolean" default="false">
   Whether to use Terragrunt for generated projects.
 </ParamField>
@@ -419,6 +431,10 @@ Automatically generate projects from directory structure using the `generate_pro
 
     <ParamField path="exclude_patterns" type="array" default="[]">
       List of directory glob patterns to exclude from generated projects.
+    </ParamField>
+
+    <ParamField path="dependency_file_triggers" type="boolean" default="false">
+      Enable automatic dependency-based trigger discovery for Terraform/OpenTofu projects generated from this block. If imported files belong to another Digger project, Digger also infers the corresponding project dependency edge. Currently not supported for Terragrunt blocks.
     </ParamField>
 
     <ParamField path="workflow" type="string" default="default">

--- a/libs/ci/generic/comment_filter.go
+++ b/libs/ci/generic/comment_filter.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"fmt"
 	"github.com/diggerhq/digger/libs/digger_config"
+	"github.com/dominikbraun/graph"
 	"github.com/samber/lo"
 )
 
@@ -19,6 +20,40 @@ func FilterTargetBranchForImpactedProjects(impactedProjects []digger_config.Proj
 		return projectTargetBranch == targetBranch
 	})
 	return impactedProjects
+}
+
+func CreateTargetBranchDependencyGraph(projects []digger_config.Project, defaultBranch string, targetBranch string) (graph.Graph[string, digger_config.Project], error) {
+	filteredProjects := FilterTargetBranchForImpactedProjects(projects, defaultBranch, targetBranch)
+	allowedProjects := make(map[string]struct{}, len(filteredProjects))
+	for _, project := range filteredProjects {
+		allowedProjects[project.Name] = struct{}{}
+	}
+
+	for i := range filteredProjects {
+		project := &filteredProjects[i]
+
+		filteredDependencies := make([]string, 0, len(project.DependencyProjects))
+		for _, dependencyProject := range project.DependencyProjects {
+			if _, ok := allowedProjects[dependencyProject]; ok {
+				filteredDependencies = append(filteredDependencies, dependencyProject)
+			}
+		}
+		project.DependencyProjects = filteredDependencies
+
+		if len(project.InferredDependencyPatternsByProject) == 0 {
+			continue
+		}
+
+		filteredPatternsByProject := make(map[string][]string)
+		for dependencyProject, patterns := range project.InferredDependencyPatternsByProject {
+			if _, ok := allowedProjects[dependencyProject]; ok {
+				filteredPatternsByProject[dependencyProject] = patterns
+			}
+		}
+		project.InferredDependencyPatternsByProject = filteredPatternsByProject
+	}
+
+	return digger_config.CreateProjectDependencyGraph(filteredProjects)
 }
 
 func FilterOutProjectsFromComment(impactedProjects []digger_config.Project, comment string) ([]digger_config.Project, error) {

--- a/libs/ci/generic/events.go
+++ b/libs/ci/generic/events.go
@@ -38,7 +38,7 @@ func ProcessIssueCommentEvent(prNumber int, diggerConfig *digger_config.DiggerCo
 	impactedProjects, impactedProjectsSourceMapping := diggerConfig.GetModifiedProjects(changedFiles)
 
 	if diggerConfig.DependencyConfiguration.Mode == digger_config.DependencyConfigurationHard {
-		impactedProjects, err = FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+		impactedProjects, err = FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, changedFiles)
 		if err != nil {
 			return &ProcessIssueCommentEventResult{}, fmt.Errorf("failed to find all projects dependant on impacted projects")
 		}
@@ -52,7 +52,7 @@ func ProcessIssueCommentEvent(prNumber int, diggerConfig *digger_config.DiggerCo
 
 }
 
-func FindAllProjectsDependantOnImpactedProjects(impactedProjects []digger_config.Project, dependencyGraph graph.Graph[string, digger_config.Project]) ([]digger_config.Project, error) {
+func FindAllProjectsDependantOnImpactedProjects(impactedProjects []digger_config.Project, dependencyGraph graph.Graph[string, digger_config.Project], changedFiles []string) ([]digger_config.Project, error) {
 	impactedProjectsMap := make(map[string]digger_config.Project)
 	for _, project := range impactedProjects {
 		impactedProjectsMap[project.Name] = project
@@ -82,7 +82,7 @@ func FindAllProjectsDependantOnImpactedProjects(impactedProjects []digger_config
 				} else {
 					// if a project was not impacted, check if it has a parent that was impacted and add it to the map of impacted projects
 					for parent := range predecessorMap[node] {
-						if _, ok := impactedProjectsMap[parent]; ok {
+						if _, ok := impactedProjectsMap[parent]; ok && shouldPropagateDependencyImpact(currentProject, parent, changedFiles) {
 							impactedProjectsWithDependantProjects = append(impactedProjectsWithDependantProjects, currentProject)
 							impactedProjectsMap[node] = currentProject
 							visited[node] = true
@@ -98,6 +98,26 @@ func FindAllProjectsDependantOnImpactedProjects(impactedProjects []digger_config
 		}
 	}
 	return impactedProjectsWithDependantProjects, nil
+}
+
+func shouldPropagateDependencyImpact(project digger_config.Project, dependencyProjectName string, changedFiles []string) bool {
+	patterns, ok := project.InferredDependencyPatternsByProject[dependencyProjectName]
+	if !ok {
+		return true
+	}
+
+	excludePatterns := digger_config.ResolvePatternsRelativeToProject(project.Dir, project.ExcludePatterns)
+	for _, changedFile := range changedFiles {
+		if digger_config.MatchIncludeExcludePatternsToFile(
+			changedFile,
+			append([]string(nil), patterns...),
+			append([]string(nil), excludePatterns...),
+		) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func ConvertIssueCommentEventToJobs(repoFullName string, requestedBy string, prNumber int, commentBody string, impactedProjectsForComment []digger_config.Project, allImpactedProjects []digger_config.Project, workflows map[string]digger_config.Workflow, prBranchName string, defaultBranch string, performEnvVarInterpolation bool) ([]scheduler.Job, bool, error) {

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -1154,7 +1154,7 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 		slog.Debug("using hard dependency mode, finding all dependent projects", "prNumber", prNumber)
 		originalCount := len(impactedProjects)
 
-		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, changedFiles)
 		if err != nil {
 			slog.Error("failed to find all projects dependant on impacted projects",
 				"error", err,

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -1154,7 +1154,16 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 		slog.Debug("using hard dependency mode, finding all dependent projects", "prNumber", prNumber)
 		originalCount := len(impactedProjects)
 
-		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, changedFiles)
+		targetBranchDependencyGraph, err := createTargetBranchDependencyGraph(diggerConfig.Projects, defaultBranch, targetBranch)
+		if err != nil {
+			slog.Error("failed to create target branch dependency graph",
+				"error", err,
+				"prNumber", prNumber,
+				"targetBranch", targetBranch)
+			return nil, nil, prNumber, fmt.Errorf("failed to create target branch dependency graph")
+		}
+
+		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, targetBranchDependencyGraph, changedFiles)
 		if err != nil {
 			slog.Error("failed to find all projects dependant on impacted projects",
 				"error", err,
@@ -1169,6 +1178,40 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 	}
 
 	return impactedProjects, impactedProjectsSourceLocations, prNumber, nil
+}
+
+func createTargetBranchDependencyGraph(projects []digger_config.Project, defaultBranch string, targetBranch string) (graph.Graph[string, digger_config.Project], error) {
+	filteredProjects := generic.FilterTargetBranchForImpactedProjects(projects, defaultBranch, targetBranch)
+	allowedProjects := make(map[string]struct{}, len(filteredProjects))
+	for _, project := range filteredProjects {
+		allowedProjects[project.Name] = struct{}{}
+	}
+
+	for i := range filteredProjects {
+		project := &filteredProjects[i]
+
+		filteredDependencies := make([]string, 0, len(project.DependencyProjects))
+		for _, dependencyProject := range project.DependencyProjects {
+			if _, ok := allowedProjects[dependencyProject]; ok {
+				filteredDependencies = append(filteredDependencies, dependencyProject)
+			}
+		}
+		project.DependencyProjects = filteredDependencies
+
+		if len(project.InferredDependencyPatternsByProject) == 0 {
+			continue
+		}
+
+		filteredPatternsByProject := make(map[string][]string)
+		for dependencyProject, patterns := range project.InferredDependencyPatternsByProject {
+			if _, ok := allowedProjects[dependencyProject]; ok {
+				filteredPatternsByProject[dependencyProject] = patterns
+			}
+		}
+		project.InferredDependencyPatternsByProject = filteredPatternsByProject
+	}
+
+	return digger_config.CreateProjectDependencyGraph(filteredProjects)
 }
 
 func ProcessGitHubPushEvent(payload *github.PushEvent, diggerConfig *digger_config.DiggerConfig, dependencyGraph graph.Graph[string, digger_config.Project], ciService ci.PullRequestService) ([]digger_config.Project, map[string]digger_config.ProjectToSourceMapping, *digger_config.Project, int, error) {

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -1154,7 +1154,7 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 		slog.Debug("using hard dependency mode, finding all dependent projects", "prNumber", prNumber)
 		originalCount := len(impactedProjects)
 
-		targetBranchDependencyGraph, err := createTargetBranchDependencyGraph(diggerConfig.Projects, defaultBranch, targetBranch)
+		targetBranchDependencyGraph, err := generic.CreateTargetBranchDependencyGraph(diggerConfig.Projects, defaultBranch, targetBranch)
 		if err != nil {
 			slog.Error("failed to create target branch dependency graph",
 				"error", err,
@@ -1178,40 +1178,6 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 	}
 
 	return impactedProjects, impactedProjectsSourceLocations, prNumber, nil
-}
-
-func createTargetBranchDependencyGraph(projects []digger_config.Project, defaultBranch string, targetBranch string) (graph.Graph[string, digger_config.Project], error) {
-	filteredProjects := generic.FilterTargetBranchForImpactedProjects(projects, defaultBranch, targetBranch)
-	allowedProjects := make(map[string]struct{}, len(filteredProjects))
-	for _, project := range filteredProjects {
-		allowedProjects[project.Name] = struct{}{}
-	}
-
-	for i := range filteredProjects {
-		project := &filteredProjects[i]
-
-		filteredDependencies := make([]string, 0, len(project.DependencyProjects))
-		for _, dependencyProject := range project.DependencyProjects {
-			if _, ok := allowedProjects[dependencyProject]; ok {
-				filteredDependencies = append(filteredDependencies, dependencyProject)
-			}
-		}
-		project.DependencyProjects = filteredDependencies
-
-		if len(project.InferredDependencyPatternsByProject) == 0 {
-			continue
-		}
-
-		filteredPatternsByProject := make(map[string][]string)
-		for dependencyProject, patterns := range project.InferredDependencyPatternsByProject {
-			if _, ok := allowedProjects[dependencyProject]; ok {
-				filteredPatternsByProject[dependencyProject] = patterns
-			}
-		}
-		project.InferredDependencyPatternsByProject = filteredPatternsByProject
-	}
-
-	return digger_config.CreateProjectDependencyGraph(filteredProjects)
 }
 
 func ProcessGitHubPushEvent(payload *github.PushEvent, diggerConfig *digger_config.DiggerConfig, dependencyGraph graph.Graph[string, digger_config.Project], ciService ci.PullRequestService) ([]digger_config.Project, map[string]digger_config.ProjectToSourceMapping, *digger_config.Project, int, error) {

--- a/libs/ci/github/github_test.go
+++ b/libs/ci/github/github_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/diggerhq/digger/libs/digger_config"
+	ghapi "github.com/google/go-github/v61/github"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -241,6 +242,62 @@ projects:
 	projectNames := []string{impactedProjectsWithDependants[0].Name, impactedProjectsWithDependants[1].Name}
 	assert.Contains(t, projectNames, "shared")
 	assert.Contains(t, projectNames, "consumer")
+}
+
+func TestProcessGitHubPullRequestEventDoesNotTraverseAcrossTargetBranchBoundaries(t *testing.T) {
+	tempDir := t.TempDir()
+
+	diggerCfg := `
+dependency_configuration:
+  mode: hard
+projects:
+- name: consumer
+  dir: env/dev
+- name: release_only_downstream
+  dir: env/release
+  branch: release
+  depends_on:
+    - consumer
+- name: main_only_after_release
+  dir: env/final
+  depends_on:
+    - release_only_downstream
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "release"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "final"), 0o755))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "digger.yml"), []byte(diggerCfg), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "dev", "main.tf"), []byte(`resource "null_resource" "consumer" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "release", "main.tf"), []byte(`resource "null_resource" "release" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "final", "main.tf"), []byte(`resource "null_resource" "final" {}`), 0o644))
+
+	config, _, dependencyGraph, _, err := digger_config.LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	payload := &ghapi.PullRequestEvent{
+		Action: ghapi.String("opened"),
+		Repo: &ghapi.Repository{
+			DefaultBranch: ghapi.String("main"),
+		},
+		PullRequest: &ghapi.PullRequest{
+			Number: ghapi.Int(1),
+			Base: &ghapi.PullRequestBranch{
+				Ref: ghapi.String("main"),
+			},
+		},
+	}
+
+	ciService := MockCiService{
+		ChangedFilesPerPr: map[int][]string{
+			1: {"env/dev/main.tf"},
+		},
+	}
+
+	impactedProjects, _, _, err := ProcessGitHubPullRequestEvent(payload, config, dependencyGraph, ciService)
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjects, 1)
+	assert.Equal(t, "consumer", impactedProjects[0].Name)
 }
 
 func TestFindAllChangedFilesOfPR(t *testing.T) {

--- a/libs/ci/github/github_test.go
+++ b/libs/ci/github/github_test.go
@@ -91,7 +91,7 @@ func TestFindAllProjectsDependantOnImpactedProjects(t *testing.T) {
 		},
 	}
 
-	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, nil)
 	if err != nil {
 		return
 	}
@@ -130,26 +130,71 @@ projects:
   dir: env/dev
   dependency_file_triggers: true
   exclude_patterns:
-    - modules/shared/**
+    - modules/shared/outputs.tf
 `
 
 	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
 	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
 	assert.NoError(t, os.WriteFile(path.Join(tempDir, "digger.yml"), []byte(diggerCfg), 0o644))
 	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "main.tf"), []byte(`resource "null_resource" "shared" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "outputs.tf"), []byte(`output "shared" { value = "x" }`), 0o644))
 	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "dev", "main.tf"), []byte(`module "shared" { source = "../../modules/shared" }`), 0o644))
 
 	config, _, dependencyGraph, _, err := digger_config.LoadDiggerConfig(tempDir, true, nil, nil)
 	assert.NoError(t, err)
 
-	impactedProjects, _ := config.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	impactedProjects, _ := config.GetModifiedProjects([]string{"modules/shared/outputs.tf"})
 	assert.Len(t, impactedProjects, 1)
 	assert.Equal(t, "shared", impactedProjects[0].Name)
 
-	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, []string{"modules/shared/outputs.tf"})
 	assert.NoError(t, err)
 	assert.Len(t, impactedProjectsWithDependants, 1)
 	assert.Equal(t, "shared", impactedProjectsWithDependants[0].Name)
+}
+
+func TestFindAllProjectsDependantOnImpactedProjectsOnlyPropagatesMatchingImportedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	diggerCfg := `
+dependency_configuration:
+  mode: hard
+projects:
+- name: shared
+  dir: modules/shared
+- name: consumer
+  dir: env/dev
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "digger.yml"), []byte(diggerCfg), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "main.tf"), []byte(`resource "null_resource" "shared" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "README.md"), []byte(`shared docs`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "dev", "main.tf"), []byte(`module "shared" { source = "../../modules/shared" }`), 0o644))
+
+	config, _, dependencyGraph, _, err := digger_config.LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := config.GetModifiedProjects([]string{"modules/shared/README.md"})
+	assert.Len(t, impactedProjects, 1)
+	assert.Equal(t, "shared", impactedProjects[0].Name)
+
+	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, []string{"modules/shared/README.md"})
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjectsWithDependants, 1)
+	assert.Equal(t, "shared", impactedProjectsWithDependants[0].Name)
+
+	impactedProjects, _ = config.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Len(t, impactedProjects, 2)
+
+	impactedProjectsWithDependants, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, []string{"modules/shared/main.tf"})
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjectsWithDependants, 2)
+	projectNames := []string{impactedProjectsWithDependants[0].Name, impactedProjectsWithDependants[1].Name}
+	assert.Contains(t, projectNames, "shared")
+	assert.Contains(t, projectNames, "consumer")
 }
 
 func TestFindAllChangedFilesOfPR(t *testing.T) {

--- a/libs/ci/github/github_test.go
+++ b/libs/ci/github/github_test.go
@@ -197,6 +197,52 @@ projects:
 	assert.Contains(t, projectNames, "consumer")
 }
 
+func TestFindAllProjectsDependantOnImpactedProjectsNarrowsLegacyManualDependencyUsingInferredPatterns(t *testing.T) {
+	tempDir := t.TempDir()
+
+	diggerCfg := `
+dependency_configuration:
+  mode: hard
+projects:
+- name: shared
+  dir: modules/shared
+- name: consumer
+  dir: env/dev
+  dependency_file_triggers: true
+  depends_on:
+    - shared
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "digger.yml"), []byte(diggerCfg), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "main.tf"), []byte(`resource "null_resource" "shared" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "README.md"), []byte(`shared docs`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "dev", "main.tf"), []byte(`module "shared" { source = "../../modules/shared" }`), 0o644))
+
+	config, _, dependencyGraph, _, err := digger_config.LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := config.GetModifiedProjects([]string{"modules/shared/README.md"})
+	assert.Len(t, impactedProjects, 1)
+	assert.Equal(t, "shared", impactedProjects[0].Name)
+
+	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, []string{"modules/shared/README.md"})
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjectsWithDependants, 1)
+	assert.Equal(t, "shared", impactedProjectsWithDependants[0].Name)
+
+	impactedProjects, _ = config.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Len(t, impactedProjects, 2)
+
+	impactedProjectsWithDependants, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, []string{"modules/shared/main.tf"})
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjectsWithDependants, 2)
+	projectNames := []string{impactedProjectsWithDependants[0].Name, impactedProjectsWithDependants[1].Name}
+	assert.Contains(t, projectNames, "shared")
+	assert.Contains(t, projectNames, "consumer")
+}
+
 func TestFindAllChangedFilesOfPR(t *testing.T) {
 	githubPrService, _ := GithubServiceProviderBasic{}.NewService("", "digger", "diggerhq")
 	files, _ := githubPrService.GetChangedFiles(98)

--- a/libs/ci/github/github_test.go
+++ b/libs/ci/github/github_test.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"github.com/diggerhq/digger/libs/ci/generic"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/diggerhq/digger/libs/digger_config"
@@ -113,6 +115,41 @@ func TestFindAllProjectsDependantOnImpactedProjects(t *testing.T) {
 	assert.Contains(t, projectNames, "m")
 	assert.NotContains(t, projectNames, "k")
 	assert.NotContains(t, projectNames, "b")
+}
+
+func TestFindAllProjectsDependantOnImpactedProjectsRespectsExcludedDependencyFileTriggers(t *testing.T) {
+	tempDir := t.TempDir()
+
+	diggerCfg := `
+dependency_configuration:
+  mode: hard
+projects:
+- name: shared
+  dir: modules/shared
+- name: consumer
+  dir: env/dev
+  dependency_file_triggers: true
+  exclude_patterns:
+    - modules/shared/**
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "digger.yml"), []byte(diggerCfg), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "modules", "shared", "main.tf"), []byte(`resource "null_resource" "shared" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "dev", "main.tf"), []byte(`module "shared" { source = "../../modules/shared" }`), 0o644))
+
+	config, _, dependencyGraph, _, err := digger_config.LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := config.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Len(t, impactedProjects, 1)
+	assert.Equal(t, "shared", impactedProjects[0].Name)
+
+	impactedProjectsWithDependants, err := generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjectsWithDependants, 1)
+	assert.Equal(t, "shared", impactedProjectsWithDependants[0].Name)
 }
 
 func TestFindAllChangedFilesOfPR(t *testing.T) {

--- a/libs/ci/github/mocks.go
+++ b/libs/ci/github/mocks.go
@@ -7,7 +7,8 @@ import (
 )
 
 type MockCiService struct {
-	CommentsPerPr map[int][]*ci.Comment
+	CommentsPerPr     map[int][]*ci.Comment
+	ChangedFilesPerPr map[int][]string
 }
 
 func (t MockCiService) GetUserTeams(organisation string, user string) ([]string, error) {
@@ -19,7 +20,7 @@ func (t MockCiService) GetApprovals(prNumber int) ([]string, error) {
 }
 
 func (t MockCiService) GetChangedFiles(prNumber int) ([]string, error) {
-	return nil, nil
+	return t.ChangedFilesPerPr[prNumber], nil
 }
 func (t MockCiService) PublishComment(prNumber int, comment string) (*ci.Comment, error) {
 

--- a/libs/ci/gitlab/webhooks.go
+++ b/libs/ci/gitlab/webhooks.go
@@ -22,7 +22,7 @@ func ProcessGitlabPullRequestEvent(payload *gitlab.MergeEvent, diggerConfig *dig
 	impactedProjects, impactedProjectsSourceLocations := diggerConfig.GetModifiedProjects(changedFiles)
 
 	if diggerConfig.DependencyConfiguration.Mode == digger_config.DependencyConfigurationHard {
-		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, changedFiles)
 		if err != nil {
 			return nil, nil, prNumber, fmt.Errorf("failed to find all projects dependant on impacted projects")
 		}

--- a/libs/ci/gitlab/webhooks.go
+++ b/libs/ci/gitlab/webhooks.go
@@ -14,15 +14,23 @@ func ProcessGitlabPullRequestEvent(payload *gitlab.MergeEvent, diggerConfig *dig
 	var impactedProjects []digger_config.Project
 	var prNumber int
 	prNumber = payload.ObjectAttributes.IID
+	defaultBranch := payload.Project.DefaultBranch
+	targetBranch := payload.ObjectAttributes.TargetBranch
 	changedFiles, err := ciService.GetChangedFiles(prNumber)
 
 	if err != nil {
 		return nil, nil, prNumber, fmt.Errorf("could not get changed files")
 	}
 	impactedProjects, impactedProjectsSourceLocations := diggerConfig.GetModifiedProjects(changedFiles)
+	impactedProjects = generic.FilterTargetBranchForImpactedProjects(impactedProjects, defaultBranch, targetBranch)
 
 	if diggerConfig.DependencyConfiguration.Mode == digger_config.DependencyConfigurationHard {
-		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph, changedFiles)
+		targetBranchDependencyGraph, err := generic.CreateTargetBranchDependencyGraph(diggerConfig.Projects, defaultBranch, targetBranch)
+		if err != nil {
+			return nil, nil, prNumber, fmt.Errorf("failed to create target branch dependency graph")
+		}
+
+		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, targetBranchDependencyGraph, changedFiles)
 		if err != nil {
 			return nil, nil, prNumber, fmt.Errorf("failed to find all projects dependant on impacted projects")
 		}

--- a/libs/ci/gitlab/webhooks_test.go
+++ b/libs/ci/gitlab/webhooks_test.go
@@ -1,0 +1,61 @@
+package gitlab
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	ci_github "github.com/diggerhq/digger/libs/ci/github"
+	"github.com/diggerhq/digger/libs/digger_config"
+	"github.com/stretchr/testify/assert"
+	gitlabapi "github.com/xanzy/go-gitlab"
+)
+
+func TestProcessGitlabPullRequestEventDoesNotTraverseAcrossTargetBranchBoundaries(t *testing.T) {
+	tempDir := t.TempDir()
+
+	diggerCfg := `
+dependency_configuration:
+  mode: hard
+projects:
+- name: consumer
+  dir: env/dev
+- name: release_only_downstream
+  dir: env/release
+  branch: release
+  depends_on:
+    - consumer
+- name: main_only_after_release
+  dir: env/final
+  depends_on:
+    - release_only_downstream
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "release"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "final"), 0o755))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "digger.yml"), []byte(diggerCfg), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "dev", "main.tf"), []byte(`resource "null_resource" "consumer" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "release", "main.tf"), []byte(`resource "null_resource" "release" {}`), 0o644))
+	assert.NoError(t, os.WriteFile(path.Join(tempDir, "env", "final", "main.tf"), []byte(`resource "null_resource" "final" {}`), 0o644))
+
+	config, _, dependencyGraph, _, err := digger_config.LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	payload := &gitlabapi.MergeEvent{}
+	payload.Project.DefaultBranch = "main"
+	payload.ObjectAttributes.IID = 1
+	payload.ObjectAttributes.TargetBranch = "main"
+	payload.ObjectAttributes.Action = "open"
+
+	ciService := ci_github.MockCiService{
+		ChangedFilesPerPr: map[int][]string{
+			1: {"env/dev/main.tf"},
+		},
+	}
+
+	impactedProjects, _, _, err := ProcessGitlabPullRequestEvent(payload, config, dependencyGraph, ciService)
+	assert.NoError(t, err)
+	assert.Len(t, impactedProjects, 1)
+	assert.Equal(t, "consumer", impactedProjects[0].Name)
+}

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -34,7 +34,7 @@ type DiggerConfig struct {
 }
 
 type ReporterConfig struct {
-	AiSummary bool
+	AiSummary       bool
 	CommentsEnabled bool
 }
 
@@ -49,27 +49,28 @@ type AssumeRoleForProject struct {
 }
 
 type Project struct {
-	BlockName            string // the block name if this is a generated project
-	Name                 string
-	Branch               string
-	Alias                string
-	ApplyRequirements    []string
-	Dir                  string
-	Workspace            string
-	Terragrunt           bool
-	Layer                uint
-	OpenTofu             bool
-	Pulumi               bool
-	Workflow             string
-	WorkflowFile         string
-	IncludePatterns      []string
-	ExcludePatterns      []string
-	DependencyProjects   []string
-	DriftDetection       bool
-	AwsRoleToAssume      *AssumeRoleForProject
-	AwsCognitoOidcConfig *AwsCognitoOidcConfig
-	Generated            bool
-	PulumiStack          string
+	BlockName              string // the block name if this is a generated project
+	Name                   string
+	Branch                 string
+	Alias                  string
+	ApplyRequirements      []string
+	Dir                    string
+	Workspace              string
+	Terragrunt             bool
+	Layer                  uint
+	OpenTofu               bool
+	Pulumi                 bool
+	Workflow               string
+	WorkflowFile           string
+	IncludePatterns        []string
+	ExcludePatterns        []string
+	DependencyFileTriggers bool
+	DependencyProjects     []string
+	DriftDetection         bool
+	AwsRoleToAssume        *AssumeRoleForProject
+	AwsCognitoOidcConfig   *AwsCognitoOidcConfig
+	Generated              bool
+	PulumiStack            string
 }
 
 type Workflow struct {

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -49,28 +49,29 @@ type AssumeRoleForProject struct {
 }
 
 type Project struct {
-	BlockName              string // the block name if this is a generated project
-	Name                   string
-	Branch                 string
-	Alias                  string
-	ApplyRequirements      []string
-	Dir                    string
-	Workspace              string
-	Terragrunt             bool
-	Layer                  uint
-	OpenTofu               bool
-	Pulumi                 bool
-	Workflow               string
-	WorkflowFile           string
-	IncludePatterns        []string
-	ExcludePatterns        []string
-	DependencyFileTriggers bool
-	DependencyProjects     []string
-	DriftDetection         bool
-	AwsRoleToAssume        *AssumeRoleForProject
-	AwsCognitoOidcConfig   *AwsCognitoOidcConfig
-	Generated              bool
-	PulumiStack            string
+	BlockName                           string // the block name if this is a generated project
+	Name                                string
+	Branch                              string
+	Alias                               string
+	ApplyRequirements                   []string
+	Dir                                 string
+	Workspace                           string
+	Terragrunt                          bool
+	Layer                               uint
+	OpenTofu                            bool
+	Pulumi                              bool
+	Workflow                            string
+	WorkflowFile                        string
+	IncludePatterns                     []string
+	ExcludePatterns                     []string
+	DependencyFileTriggers              bool
+	InferredDependencyPatternsByProject map[string][]string
+	DependencyProjects                  []string
+	DriftDetection                      bool
+	AwsRoleToAssume                     *AssumeRoleForProject
+	AwsCognitoOidcConfig                *AwsCognitoOidcConfig
+	Generated                           bool
+	PulumiStack                         string
 }
 
 type Workflow struct {

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -98,6 +98,7 @@ func copyProjects(projects []*ProjectYaml) []Project {
 			workflowFile,
 			p.IncludePatterns,
 			p.ExcludePatterns,
+			p.DependencyFileTriggers,
 			p.DependencyProjects,
 			driftDetection,
 			roleToAssume,

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -99,6 +99,7 @@ func copyProjects(projects []*ProjectYaml) []Project {
 			p.IncludePatterns,
 			p.ExcludePatterns,
 			p.DependencyFileTriggers,
+			nil,
 			p.DependencyProjects,
 			driftDetection,
 			roleToAssume,

--- a/libs/digger_config/dependency_file_triggers.go
+++ b/libs/digger_config/dependency_file_triggers.go
@@ -30,6 +30,10 @@ func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot str
 		if !project.DependencyFileTriggers {
 			continue
 		}
+		existingDependencyProjects := make(map[string]struct{}, len(project.DependencyProjects))
+		for _, dependencyProject := range project.DependencyProjects {
+			existingDependencyProjects[dependencyProject] = struct{}{}
+		}
 
 		patterns, err := getDependencyFileTriggerPatterns(absoluteRepoRoot, *project)
 		if err != nil {
@@ -41,10 +45,20 @@ func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot str
 		}
 
 		project.IncludePatterns = appendUniqueStrings(project.IncludePatterns, patterns...)
-		project.DependencyProjects = appendUniqueStrings(
-			project.DependencyProjects,
-			inferDependencyProjectsFromPatterns(config.Projects, *project, filterDependencyPatternsForProject(*project, patterns))...,
-		)
+		inferredDependencyPatterns := inferDependencyProjectsFromPatterns(config.Projects, *project, patterns)
+		for dependencyProjectName, dependencyPatterns := range inferredDependencyPatterns {
+			project.DependencyProjects = appendUniqueStrings(project.DependencyProjects, dependencyProjectName)
+			if _, hasManualDependency := existingDependencyProjects[dependencyProjectName]; hasManualDependency {
+				continue
+			}
+			if project.InferredDependencyPatternsByProject == nil {
+				project.InferredDependencyPatternsByProject = make(map[string][]string)
+			}
+			project.InferredDependencyPatternsByProject[dependencyProjectName] = appendUniqueStrings(
+				project.InferredDependencyPatternsByProject[dependencyProjectName],
+				dependencyPatterns...,
+			)
+		}
 	}
 }
 
@@ -203,9 +217,9 @@ func appendUniqueStrings(existing []string, values ...string) []string {
 	return result
 }
 
-func inferDependencyProjectsFromPatterns(projects []Project, currentProject Project, patterns []string) []string {
+func inferDependencyProjectsFromPatterns(projects []Project, currentProject Project, patterns []string) map[string][]string {
 	currentProjectDir := normalizeRelativePath(currentProject.Dir)
-	dependencyProjects := make([]string, 0)
+	dependencyProjectPatterns := make(map[string][]string)
 
 	for _, pattern := range patterns {
 		patternDir := normalizeRelativePath(filepath.Dir(pattern))
@@ -221,29 +235,12 @@ func inferDependencyProjectsFromPatterns(projects []Project, currentProject Proj
 			continue
 		}
 
-		dependencyProjects = appendUniqueStrings(dependencyProjects, mostSpecificProjectNames...)
-	}
-
-	sort.Strings(dependencyProjects)
-	return dependencyProjects
-}
-
-func filterDependencyPatternsForProject(project Project, patterns []string) []string {
-	excludePatterns := ResolvePatternsRelativeToProject(project.Dir, project.ExcludePatterns)
-	if len(excludePatterns) == 0 {
-		return patterns
-	}
-
-	filteredPatterns := make([]string, 0, len(patterns))
-	for _, pattern := range patterns {
-		probeFile := filepath.ToSlash(filepath.Join(filepath.Dir(pattern), "main.tf"))
-		if MatchExcludePatternsToFile(probeFile, excludePatterns) {
-			continue
+		for _, dependencyProject := range mostSpecificProjectNames {
+			dependencyProjectPatterns[dependencyProject] = appendUniqueStrings(dependencyProjectPatterns[dependencyProject], pattern)
 		}
-		filteredPatterns = append(filteredPatterns, pattern)
 	}
 
-	return filteredPatterns
+	return dependencyProjectPatterns
 }
 
 func findMostSpecificProjectNamesForDir(projects []Project, currentProjectName string, dependencyDir string) []string {

--- a/libs/digger_config/dependency_file_triggers.go
+++ b/libs/digger_config/dependency_file_triggers.go
@@ -1,0 +1,260 @@
+package digger_config
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+)
+
+var localTerraformModuleSourcePrefixes = []string{
+	"./",
+	"../",
+	".\\",
+	"..\\",
+}
+
+func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot string) {
+	absoluteRepoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		slog.Warn("failed to resolve repository root for dependency file triggers", "repoRoot", repoRoot, "error", err)
+		return
+	}
+
+	for i := range config.Projects {
+		project := &config.Projects[i]
+		if !project.DependencyFileTriggers {
+			continue
+		}
+
+		patterns, err := getDependencyFileTriggerPatterns(absoluteRepoRoot, *project)
+		if err != nil {
+			slog.Warn("failed to discover dependency file triggers for project", "projectName", project.Name, "projectDir", project.Dir, "error", err)
+			continue
+		}
+		if len(patterns) == 0 {
+			continue
+		}
+
+		project.IncludePatterns = appendUniqueStrings(project.IncludePatterns, patterns...)
+		project.DependencyProjects = appendUniqueStrings(project.DependencyProjects, inferDependencyProjectsFromPatterns(config.Projects, *project, patterns)...)
+	}
+}
+
+func getDependencyFileTriggerPatterns(repoRoot string, project Project) ([]string, error) {
+	switch {
+	case project.Pulumi, project.Terragrunt:
+		return nil, nil
+	default:
+		return getTerraformDependencyFileTriggerPatterns(repoRoot, project.Dir)
+	}
+}
+
+func getTerraformDependencyFileTriggerPatterns(repoRoot string, projectDir string) ([]string, error) {
+	absoluteProjectDir := filepath.Join(repoRoot, projectDir)
+	modulePatterns, err := collectLocalTerraformModulePatterns(absoluteProjectDir, map[string]struct{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedProjectDir := normalizeRelativePath(projectDir)
+	patterns := make([]string, 0, len(modulePatterns))
+	for _, modulePattern := range modulePatterns {
+		relativePattern, err := filepath.Rel(repoRoot, modulePattern)
+		if err != nil {
+			return nil, err
+		}
+
+		normalizedPattern := normalizeRelativePath(relativePattern)
+		if isOutsideRepo(normalizedPattern) {
+			continue
+		}
+
+		if isPathInsideProject(normalizedProjectDir, normalizeRelativePath(filepath.Dir(normalizedPattern))) {
+			continue
+		}
+
+		patterns = append(patterns, normalizedPattern)
+	}
+
+	sort.Strings(patterns)
+	return appendUniqueStrings(nil, patterns...), nil
+}
+
+func collectLocalTerraformModulePatterns(moduleDir string, visited map[string]struct{}) ([]string, error) {
+	absoluteModuleDir, err := filepath.Abs(moduleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, seen := visited[absoluteModuleDir]; seen {
+		return nil, nil
+	}
+	visited[absoluteModuleDir] = struct{}{}
+
+	if _, err := os.Stat(absoluteModuleDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	module, diags := tfconfig.LoadModule(absoluteModuleDir)
+	if diags.HasErrors() {
+		return nil, errors.New(diags.Error())
+	}
+
+	patterns := make([]string, 0, len(module.ModuleCalls))
+	seenPatterns := make(map[string]struct{})
+
+	for _, moduleCall := range module.ModuleCalls {
+		if !isLocalTerraformModuleSource(moduleCall.Source) {
+			continue
+		}
+
+		absoluteSourceDir := filepath.Clean(filepath.Join(absoluteModuleDir, moduleCall.Source))
+		if _, err := os.Stat(absoluteSourceDir); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				slog.Debug("skipping missing local terraform module source", "moduleDir", absoluteModuleDir, "source", moduleCall.Source)
+				continue
+			}
+			return nil, err
+		}
+
+		modulePattern := filepath.Join(absoluteSourceDir, "*.tf*")
+		if _, seen := seenPatterns[modulePattern]; !seen {
+			patterns = append(patterns, modulePattern)
+			seenPatterns[modulePattern] = struct{}{}
+		}
+
+		childPatterns, err := collectLocalTerraformModulePatterns(absoluteSourceDir, visited)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, childPattern := range childPatterns {
+			if _, seen := seenPatterns[childPattern]; seen {
+				continue
+			}
+			patterns = append(patterns, childPattern)
+			seenPatterns[childPattern] = struct{}{}
+		}
+	}
+
+	sort.Strings(patterns)
+	return patterns, nil
+}
+
+func isLocalTerraformModuleSource(raw string) bool {
+	for _, prefix := range localTerraformModuleSourcePrefixes {
+		if strings.HasPrefix(raw, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeRelativePath(dir string) string {
+	normalized := filepath.ToSlash(filepath.Clean(dir))
+	if normalized == "" {
+		return "."
+	}
+	return normalized
+}
+
+func isOutsideRepo(dir string) bool {
+	return dir == ".." || strings.HasPrefix(dir, "../")
+}
+
+func isPathInsideProject(projectDir string, candidateDir string) bool {
+	if projectDir == "." {
+		return candidateDir == "."
+	}
+	return candidateDir == projectDir || strings.HasPrefix(candidateDir, projectDir+"/")
+}
+
+func appendUniqueStrings(existing []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	result := make([]string, 0, len(existing)+len(values))
+
+	for _, value := range existing {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	return result
+}
+
+func inferDependencyProjectsFromPatterns(projects []Project, currentProject Project, patterns []string) []string {
+	currentProjectDir := normalizeRelativePath(currentProject.Dir)
+	dependencyProjects := make([]string, 0)
+
+	for _, pattern := range patterns {
+		patternDir := normalizeRelativePath(filepath.Dir(pattern))
+		if isOutsideRepo(patternDir) {
+			continue
+		}
+		if isPathInsideProject(currentProjectDir, patternDir) {
+			continue
+		}
+
+		mostSpecificProjectNames := findMostSpecificProjectNamesForDir(projects, currentProject.Name, patternDir)
+		if len(mostSpecificProjectNames) == 0 {
+			continue
+		}
+
+		dependencyProjects = appendUniqueStrings(dependencyProjects, mostSpecificProjectNames...)
+	}
+
+	sort.Strings(dependencyProjects)
+	return dependencyProjects
+}
+
+func findMostSpecificProjectNamesForDir(projects []Project, currentProjectName string, dependencyDir string) []string {
+	maxSpecificity := -1
+	projectNames := make([]string, 0)
+
+	for _, candidate := range projects {
+		if candidate.Name == currentProjectName {
+			continue
+		}
+
+		candidateDir := normalizeRelativePath(candidate.Dir)
+		if dependencyDir != candidateDir && !strings.HasPrefix(dependencyDir, candidateDir+"/") {
+			continue
+		}
+
+		specificity := len(candidateDir)
+		switch {
+		case specificity > maxSpecificity:
+			maxSpecificity = specificity
+			projectNames = []string{candidate.Name}
+		case specificity == maxSpecificity:
+			projectNames = append(projectNames, candidate.Name)
+		}
+	}
+
+	// Multiple projects can intentionally share a directory via workspaces, so
+	// only infer a dependency when the upstream project is unambiguous.
+	if len(projectNames) > 1 {
+		return nil
+	}
+
+	sort.Strings(projectNames)
+	return projectNames
+}

--- a/libs/digger_config/dependency_file_triggers.go
+++ b/libs/digger_config/dependency_file_triggers.go
@@ -41,7 +41,10 @@ func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot str
 		}
 
 		project.IncludePatterns = appendUniqueStrings(project.IncludePatterns, patterns...)
-		project.DependencyProjects = appendUniqueStrings(project.DependencyProjects, inferDependencyProjectsFromPatterns(config.Projects, *project, patterns)...)
+		project.DependencyProjects = appendUniqueStrings(
+			project.DependencyProjects,
+			inferDependencyProjectsFromPatterns(config.Projects, *project, filterDependencyPatternsForProject(*project, patterns))...,
+		)
 	}
 }
 
@@ -223,6 +226,24 @@ func inferDependencyProjectsFromPatterns(projects []Project, currentProject Proj
 
 	sort.Strings(dependencyProjects)
 	return dependencyProjects
+}
+
+func filterDependencyPatternsForProject(project Project, patterns []string) []string {
+	excludePatterns := ResolvePatternsRelativeToProject(project.Dir, project.ExcludePatterns)
+	if len(excludePatterns) == 0 {
+		return patterns
+	}
+
+	filteredPatterns := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		probeFile := filepath.ToSlash(filepath.Join(filepath.Dir(pattern), "main.tf"))
+		if MatchExcludePatternsToFile(probeFile, excludePatterns) {
+			continue
+		}
+		filteredPatterns = append(filteredPatterns, pattern)
+	}
+
+	return filteredPatterns
 }
 
 func findMostSpecificProjectNamesForDir(projects []Project, currentProjectName string, dependencyDir string) []string {

--- a/libs/digger_config/dependency_file_triggers.go
+++ b/libs/digger_config/dependency_file_triggers.go
@@ -30,10 +30,6 @@ func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot str
 		if !project.DependencyFileTriggers {
 			continue
 		}
-		existingDependencyProjects := make(map[string]struct{}, len(project.DependencyProjects))
-		for _, dependencyProject := range project.DependencyProjects {
-			existingDependencyProjects[dependencyProject] = struct{}{}
-		}
 
 		patterns, err := getDependencyFileTriggerPatterns(absoluteRepoRoot, *project)
 		if err != nil {
@@ -48,9 +44,6 @@ func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot str
 		inferredDependencyPatterns := inferDependencyProjectsFromPatterns(config.Projects, *project, patterns)
 		for dependencyProjectName, dependencyPatterns := range inferredDependencyPatterns {
 			project.DependencyProjects = appendUniqueStrings(project.DependencyProjects, dependencyProjectName)
-			if _, hasManualDependency := existingDependencyProjects[dependencyProjectName]; hasManualDependency {
-				continue
-			}
 			if project.InferredDependencyPatternsByProject == nil {
 				project.InferredDependencyPatternsByProject = make(map[string][]string)
 			}

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -644,6 +644,10 @@ func ValidateDiggerConfigYaml(configYaml *DiggerConfigYaml, fileName string) err
 		}
 	}
 	if configYaml.GenerateProjectsConfig != nil {
+		if err := validateBlockYaml(configYaml.GenerateProjectsConfig.Blocks); err != nil {
+			return err
+		}
+
 		if (configYaml.GenerateProjectsConfig.Terragrunt || configYaml.GenerateProjectsConfig.TerragruntParsingConfig != nil) &&
 			configYaml.GenerateProjectsConfig.DependencyFileTriggers {
 			slog.Error("dependency_file_triggers is not supported for top-level terragrunt project generation")

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -231,6 +231,14 @@ func LoadDiggerConfig(workingDir string, generateProjects bool, changedFiles []s
 		return nil, nil, nil, nil, err
 	}
 
+	enrichProjectsWithDependencyFileTriggers(config, workingDir)
+
+	projectDependencyGraph, err = CreateProjectDependencyGraph(config.Projects)
+	if err != nil {
+		slog.Error("failed to create project dependency graph after dependency file trigger enrichment", "error", err)
+		return nil, configYaml, nil, newAtlantisConfig, err
+	}
+
 	err = ValidateDiggerConfig(config)
 	if err != nil {
 		slog.Warn("digger config validation failed", "error", err)
@@ -271,6 +279,14 @@ func LoadDiggerConfigFromString(yamlString string, terraformDir string) (*Digger
 		return nil, nil, nil, err
 	}
 
+	enrichProjectsWithDependencyFileTriggers(config, terraformDir)
+
+	projectDependencyGraph, err = CreateProjectDependencyGraph(config.Projects)
+	if err != nil {
+		slog.Error("failed to create project dependency graph after dependency file trigger enrichment", "error", err)
+		return nil, configYaml, nil, err
+	}
+
 	err = ValidateDiggerConfig(config)
 	if err != nil {
 		slog.Warn("digger config validation failed", "error", err)
@@ -300,6 +316,10 @@ func validateBlockYaml(blocks []BlockYaml) error {
 			if b.RootDir == nil {
 				slog.Error("terragrunt block missing root_dir", "blockName", b.BlockName)
 				return fmt.Errorf("block %v is a terragrunt block but does not have root_dir specified", b.BlockName)
+			}
+			if b.DependencyFileTriggers {
+				slog.Error("dependency_file_triggers is not supported for terragrunt generation blocks", "blockName", b.BlockName)
+				return fmt.Errorf("dependency_file_triggers is not supported for terragrunt block %v", b.BlockName)
 			}
 		}
 	}
@@ -394,13 +414,14 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string, 
 						"projectName", projectName)
 
 					project := ProjectYaml{
-						Name:                 projectName,
-						Dir:                  dir,
-						Workflow:             defaultWorkflowName,
-						Workspace:            "default",
-						AwsRoleToAssume:      config.GenerateProjectsConfig.AwsRoleToAssume,
-						Generated:            true,
-						AwsCognitoOidcConfig: config.GenerateProjectsConfig.AwsCognitoOidcConfig,
+						Name:                   projectName,
+						Dir:                    dir,
+						Workflow:               defaultWorkflowName,
+						Workspace:              "default",
+						DependencyFileTriggers: config.GenerateProjectsConfig.DependencyFileTriggers,
+						AwsRoleToAssume:        config.GenerateProjectsConfig.AwsRoleToAssume,
+						Generated:              true,
+						AwsCognitoOidcConfig:   config.GenerateProjectsConfig.AwsCognitoOidcConfig,
 					}
 					config.Projects = append(config.Projects, &project)
 				}
@@ -499,17 +520,18 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string, 
 								"projectName", projectName)
 
 							project := ProjectYaml{
-								Name:                 projectName,
-								Dir:                  dir,
-								Workflow:             workflow,
-								Workspace:            workspace,
-								OpenTofu:             b.OpenTofu,
-								AwsRoleToAssume:      b.AwsRoleToAssume,
-								Generated:            true,
-								AwsCognitoOidcConfig: b.AwsCognitoOidcConfig,
-								WorkflowFile:         b.WorkflowFile,
-								IncludePatterns:      b.IncludePatterns,
-								ExcludePatterns:      b.ExcludePatterns,
+								Name:                   projectName,
+								Dir:                    dir,
+								Workflow:               workflow,
+								Workspace:              workspace,
+								OpenTofu:               b.OpenTofu,
+								DependencyFileTriggers: b.DependencyFileTriggers,
+								AwsRoleToAssume:        b.AwsRoleToAssume,
+								Generated:              true,
+								AwsCognitoOidcConfig:   b.AwsCognitoOidcConfig,
+								WorkflowFile:           b.WorkflowFile,
+								IncludePatterns:        b.IncludePatterns,
+								ExcludePatterns:        b.ExcludePatterns,
 							}
 							config.Projects = append(config.Projects, &project)
 						}
@@ -622,6 +644,12 @@ func ValidateDiggerConfigYaml(configYaml *DiggerConfigYaml, fileName string) err
 		}
 	}
 	if configYaml.GenerateProjectsConfig != nil {
+		if (configYaml.GenerateProjectsConfig.Terragrunt || configYaml.GenerateProjectsConfig.TerragruntParsingConfig != nil) &&
+			configYaml.GenerateProjectsConfig.DependencyFileTriggers {
+			slog.Error("dependency_file_triggers is not supported for top-level terragrunt project generation")
+			return fmt.Errorf("dependency_file_triggers is not supported for terragrunt generate_projects")
+		}
+
 		if configYaml.GenerateProjectsConfig.Include != "" &&
 			configYaml.GenerateProjectsConfig.Exclude != "" &&
 			len(configYaml.GenerateProjectsConfig.Blocks) != 0 {
@@ -670,6 +698,18 @@ func validatePulumiProject(project *Project) error {
 	return nil
 }
 
+func validateDependencyFileTriggers(project *Project) error {
+	if project.DependencyFileTriggers && project.Pulumi {
+		slog.Error("dependency_file_triggers is not supported for pulumi projects", "projectName", project.Name)
+		return fmt.Errorf("dependency_file_triggers is not supported for pulumi project %v", project.Name)
+	}
+	if project.DependencyFileTriggers && project.Terragrunt {
+		slog.Error("dependency_file_triggers is not supported for terragrunt projects", "projectName", project.Name)
+		return fmt.Errorf("dependency_file_triggers is not supported for terragrunt project %v", project.Name)
+	}
+	return nil
+}
+
 func ValidateProjects(config *DiggerConfig) error {
 	slog.Debug("validating projects configuration", "projectCount", len(config.Projects))
 
@@ -681,6 +721,11 @@ func ValidateProjects(config *DiggerConfig) error {
 		}
 
 		err = validatePulumiProject(&project)
+		if err != nil {
+			return err
+		}
+
+		err = validateDependencyFileTriggers(&project)
 		if err != nil {
 			return err
 		}

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -1468,6 +1468,422 @@ func TestGetModifiedProjectsReturnsCorrectSourceMappingWithRelativePaths(t *test
 	assert.Equal(t, expectedImpactingLocations["prod"].ImpactingLocations, projectSourceMapping["prod"].ImpactingLocations)
 }
 
+func TestLoadDiggerConfigDoesNotTrackImportedTerraformModulesByDefault(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+- name: prod
+  dir: prod
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "prod"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "network"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "prod", "main.tf"), `
+module "network" {
+  source = "../modules/network"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "network", "main.tf"), `
+resource "null_resource" "network" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 0, len(impactedProjects))
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+  dependency_file_triggers: true
+- name: prod
+  dir: prod
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "prod"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "network"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "prod", "main.tf"), `
+module "network" {
+  source = "../modules/network"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "network", "main.tf"), `
+resource "null_resource" "network" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigTracksNestedImportedTerraformModulesRecursively(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "nested"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+module "nested" {
+  source = "../nested"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "nested", "main.tf"), `
+resource "null_resource" "nested" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/nested/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigInfersProjectDependenciesFromImportedTerraformProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: core
+  dir: core
+  dependency_file_triggers: true
+- name: platform
+  dir: platform
+  dependency_file_triggers: true
+- name: services
+  dir: services
+  depends_on: ["platform"]
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "core"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "platform"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "services"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "core", "main.tf"), `
+resource "null_resource" "core" {}
+`)()
+	defer createFile(path.Join(tempDir, "platform", "main.tf"), `
+module "core" {
+  source = "../core"
+}
+`)()
+	defer createFile(path.Join(tempDir, "services", "main.tf"), `
+resource "null_resource" "services" {}
+`)()
+
+	dg, _, dependencyGraph, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	platformProject := dg.GetProject("platform")
+	if assert.NotNil(t, platformProject) {
+		assert.Equal(t, []string{"core"}, platformProject.DependencyProjects)
+	}
+
+	adjacencyMap, err := dependencyGraph.AdjacencyMap()
+	assert.NoError(t, err)
+	_, hasCoreToPlatformEdge := adjacencyMap["core"]["platform"]
+	assert.True(t, hasCoreToPlatformEdge)
+	_, hasPlatformToServicesEdge := adjacencyMap["platform"]["services"]
+	assert.True(t, hasPlatformToServicesEdge)
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesForGeneratedProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+generate_projects:
+  include: "env/**"
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "env", "dev", "main.tf"), `
+module "shared" {
+  source = "../../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "env_dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesForGeneratedBlockProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+generate_projects:
+  blocks:
+    - block_name: env
+      include: "env/**"
+      dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "env", "dev", "main.tf"), `
+module "shared" {
+  source = "../../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "env_dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigInfersProjectDependenciesForRootProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: root
+  dir: .
+  dependency_file_triggers: true
+- name: shared
+  dir: modules/shared
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "main.tf"), `
+module "shared" {
+  source = "./modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, dependencyGraph, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	rootProject := dg.GetProject("root")
+	if assert.NotNil(t, rootProject) {
+		assert.Equal(t, []string{"shared"}, rootProject.DependencyProjects)
+	}
+
+	adjacencyMap, err := dependencyGraph.AdjacencyMap()
+	assert.NoError(t, err)
+	_, hasSharedToRootEdge := adjacencyMap["shared"]["root"]
+	assert.True(t, hasSharedToRootEdge)
+}
+
+func TestLoadDiggerConfigDoesNotInferAmbiguousWorkspaceDependenciesWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: env
+  workspace: dev
+  dependency_file_triggers: true
+- name: prod
+  dir: env
+  workspace: prod
+  dependency_file_triggers: true
+- name: consumer
+  dir: consumer
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "consumer"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "env", "main.tf"), `
+resource "null_resource" "env" {}
+`)()
+	defer createFile(path.Join(tempDir, "consumer", "main.tf"), `
+module "env" {
+  source = "../env"
+}
+`)()
+
+	dg, _, dependencyGraph, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	consumerProject := dg.GetProject("consumer")
+	if assert.NotNil(t, consumerProject) {
+		assert.Empty(t, consumerProject.DependencyProjects)
+	}
+
+	adjacencyMap, err := dependencyGraph.AdjacencyMap()
+	assert.NoError(t, err)
+	_, hasDevToConsumerEdge := adjacencyMap["dev"]["consumer"]
+	assert.False(t, hasDevToConsumerEdge)
+	_, hasProdToConsumerEdge := adjacencyMap["prod"]["consumer"]
+	assert.False(t, hasProdToConsumerEdge)
+}
+
+func TestLoadDiggerConfigDependencyFileTriggersRespectExcludePatterns(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+  dependency_file_triggers: true
+  exclude_patterns:
+    - modules/shared/**
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 0, len(impactedProjects))
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForPulumiProjects(t *testing.T) {
+	diggerCfg := `
+projects:
+- name: pulumi
+  dir: .
+  pulumi: true
+  pulumi_stack: dev
+  dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for pulumi project pulumi")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntProjects(t *testing.T) {
+	diggerCfg := `
+projects:
+- name: tg
+  dir: .
+  terragrunt: true
+  dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt project tg")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntGenerateProjects(t *testing.T) {
+	diggerCfg := `
+generate_projects:
+  terragrunt: true
+  dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt generate_projects")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntBlocks(t *testing.T) {
+	diggerCfg := `
+generate_projects:
+  blocks:
+    - block_name: tg
+      terragrunt: true
+      root_dir: stack
+      dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt block tg")
+}
+
 func TestCognitoTokenSetFromMinConfig(t *testing.T) {
 	diggerCfg := `
 projects:

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -1828,6 +1828,26 @@ resource "null_resource" "shared" {}
 	assert.Equal(t, 0, len(impactedProjects))
 }
 
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntBlocksWhenGenerationDisabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+generate_projects:
+  blocks:
+    - block_name: tg
+      terragrunt: true
+      root_dir: stack
+      dependency_file_triggers: true
+`
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+
+	_, _, _, _, err := LoadDiggerConfig(tempDir, false, nil, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt block tg")
+}
+
 func TestLoadDiggerConfigRejectsDependencyFileTriggersForPulumiProjects(t *testing.T) {
 	diggerCfg := `
 projects:

--- a/libs/digger_config/utils.go
+++ b/libs/digger_config/utils.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -37,13 +38,45 @@ func GetDirNamesFromPaths(filePaths []string) []string {
 	return res
 }
 
+func ResolvePatternsRelativeToProject(projectDir string, patterns []string) []string {
+	resolvedPatterns := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, ".") {
+			resolvedPatterns = append(resolvedPatterns, filepath.Join(projectDir, pattern))
+		} else {
+			resolvedPatterns = append(resolvedPatterns, pattern)
+		}
+	}
+	return resolvedPatterns
+}
+
+func MatchExcludePatternsToFile(fileToMatch string, excludePatterns []string) bool {
+	fileToMatch = NormalizeFileName(fileToMatch)
+	for i := range excludePatterns {
+		excludePatterns[i] = NormalizeFileName(excludePatterns[i])
+	}
+
+	for _, epattern := range excludePatterns {
+		excluded, err := doublestar.PathMatch(epattern, fileToMatch)
+		if err != nil {
+			slog.Error("failed to match modified files with exclude pattern",
+				"file", fileToMatch,
+				"pattern", epattern,
+				"error", err)
+			panic(err)
+		}
+		if excluded {
+			return true
+		}
+	}
+
+	return false
+}
+
 func MatchIncludeExcludePatternsToFile(fileToMatch string, includePatterns []string, excludePatterns []string) bool {
 	fileToMatch = NormalizeFileName(fileToMatch)
 	for i := range includePatterns {
 		includePatterns[i] = NormalizeFileName(includePatterns[i])
-	}
-	for i := range excludePatterns {
-		excludePatterns[i] = NormalizeFileName(excludePatterns[i])
 	}
 
 	matching := false
@@ -62,19 +95,8 @@ func MatchIncludeExcludePatternsToFile(fileToMatch string, includePatterns []str
 		}
 	}
 
-	for _, epattern := range excludePatterns {
-		excluded, err := doublestar.PathMatch(epattern, fileToMatch)
-		if err != nil {
-			slog.Error("failed to match modified files with exclude pattern",
-				"file", fileToMatch,
-				"pattern", epattern,
-				"error", err)
-			panic(err)
-		}
-		if excluded {
-			matching = false
-			break
-		}
+	if MatchExcludePatternsToFile(fileToMatch, excludePatterns) {
+		matching = false
 	}
 
 	return matching

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -31,7 +31,7 @@ type DiggerConfigYaml struct {
 }
 
 type ReportingConfigYaml struct {
-	AiSummary bool `yaml:"ai_summary"`
+	AiSummary       bool `yaml:"ai_summary"`
 	CommentsEnabled bool `yaml:"comments_enabled"`
 }
 
@@ -44,27 +44,28 @@ const ApplyRequirementsMergeable = "mergeable"
 const ApplyRequirementsUndiverged = "undiverged"
 
 type ProjectYaml struct {
-	BlockName            string                      `yaml:"block_name"`
-	Name                 string                      `yaml:"name"`
-	Alias                string                      `yaml:"alias,omitempty"`
-	ApplyRequirements    []string                    `yaml:"apply_requirements,omitempty"`
-	Dir                  string                      `yaml:"dir"`
-	Workspace            string                      `yaml:"workspace"`
-	Terragrunt           bool                        `yaml:"terragrunt"`
-	Branch               *string                     `yaml:"branch,omitempty"`
-	OpenTofu             bool                        `yaml:"opentofu"`
-	Pulumi               bool                        `yaml:"pulumi"`
-	Workflow             string                      `yaml:"workflow"`
-	WorkflowFile         string                      `yaml:"workflow_file"`
-	IncludePatterns      []string                    `yaml:"include_patterns,omitempty"`
-	Layer                *uint                       `yaml:"layer"`
-	ExcludePatterns      []string                    `yaml:"exclude_patterns,omitempty"`
-	DependencyProjects   []string                    `yaml:"depends_on,omitempty"`
-	DriftDetection       *bool                       `yaml:"drift_detection,omitempty"`
-	AwsRoleToAssume      *AssumeRoleForProjectConfig `yaml:"aws_role_to_assume,omitempty"`
-	Generated            bool                        `yaml:"generated"`
-	AwsCognitoOidcConfig *AwsCognitoOidcConfig       `yaml:"aws_cognito_oidc,omitempty"`
-	PulumiStack          string                      `yaml:"pulumi_stack"`
+	BlockName              string                      `yaml:"block_name"`
+	Name                   string                      `yaml:"name"`
+	Alias                  string                      `yaml:"alias,omitempty"`
+	ApplyRequirements      []string                    `yaml:"apply_requirements,omitempty"`
+	Dir                    string                      `yaml:"dir"`
+	Workspace              string                      `yaml:"workspace"`
+	Terragrunt             bool                        `yaml:"terragrunt"`
+	Branch                 *string                     `yaml:"branch,omitempty"`
+	OpenTofu               bool                        `yaml:"opentofu"`
+	Pulumi                 bool                        `yaml:"pulumi"`
+	Workflow               string                      `yaml:"workflow"`
+	WorkflowFile           string                      `yaml:"workflow_file"`
+	IncludePatterns        []string                    `yaml:"include_patterns,omitempty"`
+	Layer                  *uint                       `yaml:"layer"`
+	ExcludePatterns        []string                    `yaml:"exclude_patterns,omitempty"`
+	DependencyFileTriggers bool                        `yaml:"dependency_file_triggers,omitempty"`
+	DependencyProjects     []string                    `yaml:"depends_on,omitempty"`
+	DriftDetection         *bool                       `yaml:"drift_detection,omitempty"`
+	AwsRoleToAssume        *AssumeRoleForProjectConfig `yaml:"aws_role_to_assume,omitempty"`
+	Generated              bool                        `yaml:"generated"`
+	AwsCognitoOidcConfig   *AwsCognitoOidcConfig       `yaml:"aws_cognito_oidc,omitempty"`
+	PulumiStack            string                      `yaml:"pulumi_stack"`
 }
 
 type WorkflowYaml struct {
@@ -116,10 +117,11 @@ type EnvVarYaml struct {
 
 type BlockYaml struct {
 	// these flags are only for terraform and opentofu
-	Include         string   `yaml:"include"`
-	Exclude         string   `yaml:"exclude"`
-	IncludePatterns []string `yaml:"include_patterns,omitempty"`
-	ExcludePatterns []string `yaml:"exclude_patterns,omitempty"`
+	Include                string   `yaml:"include"`
+	Exclude                string   `yaml:"exclude"`
+	IncludePatterns        []string `yaml:"include_patterns,omitempty"`
+	ExcludePatterns        []string `yaml:"exclude_patterns,omitempty"`
+	DependencyFileTriggers bool     `yaml:"dependency_file_triggers,omitempty"`
 
 	// these flags are only for terragrunt
 	Terragrunt              bool                     `yaml:"terragrunt"`
@@ -154,6 +156,7 @@ type AwsCognitoOidcConfig struct {
 type GenerateProjectsConfigYaml struct {
 	Include                 string                      `yaml:"include"`
 	Exclude                 string                      `yaml:"exclude"`
+	DependencyFileTriggers  bool                        `yaml:"dependency_file_triggers,omitempty"`
 	Terragrunt              bool                        `yaml:"terragrunt"`
 	Blocks                  []BlockYaml                 `yaml:"blocks"`
 	TerragruntParsingConfig *TerragruntParsingConfig    `yaml:"terragrunt_parsing,omitempty"`


### PR DESCRIPTION
Superseded as the first reviewable slice by #2640.

Keeping this PR open only as the follow-up branch for inferred dependency edges and hard dependency propagation behavior. That work reaches into GitHub/GitLab event semantics and is not the current review target.

If you are reviewing the first slice of #791, please use #2640 instead.

## Scope of this follow-up branch
- inferred project dependency edges derived from dependency-file discovery
- hard dependency propagation changes
- GitHub/GitLab event-path semantics

## Status
- not the primary review target right now
- still being refined separately from the smaller matching-only slice in #2640

## AI Disclosure
- This PR was developed with substantial AI assistance via OpenAI Codex/ChatGPT, with human review and iterative fixes for the code, tests, and PR responses.
