### PR TITLE
feat: add dependency file triggers for terraform matching

### DIFF
--- a/docs/ce/howto/include-exclude-patterns.mdx
+++ b/docs/ce/howto/include-exclude-patterns.mdx
@@ -20,6 +20,8 @@ modules/
 
 If you wanted to trigger plans for all `modules/` folder in both dev and prod projects you would include them in the `include_patterns` key. Similarly you put anything which you want to ignore in the `exclude_patterns` key ( exclude takes precedence over includes).
 
+If you want a narrower, dependency-file-based trigger instead of a broad `modules/**` glob, you can enable `dependency_file_triggers: true`. For Terraform/OpenTofu this follows local `module` imports and tracks imported module `*.tf*` files recursively. This augments `include_patterns`; it does not replace them. This setting is currently intended for Terraform/OpenTofu projects.
+
 Example using patterns relative to project directory:
 
 ```yml

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -60,6 +60,7 @@ projects:
     layer: 0
     include_patterns: ["../modules/**"]
     exclude_patterns: []
+    dependency_file_triggers: false
     depends_on: []
     aws_role_to_assume:
       aws_role_region: us-east-1
@@ -76,9 +77,11 @@ projects:
     workflow: staging
     include_patterns: ["../modules/**"]
     exclude_patterns: []
+    dependency_file_triggers: false
 generate_projects:
   include: "../projects/**"
   exclude: "../.terraform/**"
+  dependency_file_triggers: false
   terragrunt: false
   blocks:
     - block_name: dev-block
@@ -90,6 +93,7 @@ generate_projects:
       terragrunt: false
       include_patterns: []
       exclude_patterns: []
+      dependency_file_triggers: false
       aws_role_to_assume:
         aws_role_region: us-east-1
         state: arn:aws:iam::123456789012:role/state-role
@@ -321,6 +325,10 @@ Define individual projects using the `projects` array.
   List of directory glob patterns to exclude, e.g., `[".terraform/**"]`. See [Include / Exclude Patterns](/ce/howto/include-exclude-patterns).
 </ParamField>
 
+<ParamField path="dependency_file_triggers" type="boolean" default="false">
+  Automatically derive additional trigger paths from local Terraform/OpenTofu `module` sources and watch imported module `*.tf*` files recursively. This augments `include_patterns`; it does not replace them. Currently not supported for Terragrunt or Pulumi projects.
+</ParamField>
+
 <ParamField path="depends_on" type="array" default="[]">
   List of project names that must complete before this project. Does not force terraform run, but affects the order of commands for projects modified in the current PR.
 </ParamField>
@@ -377,6 +385,10 @@ Automatically generate projects from directory structure using the `generate_pro
   Glob pattern to exclude directories from project generation.
 </ParamField>
 
+<ParamField path="dependency_file_triggers" type="boolean" default="false">
+  Enable automatic dependency-based trigger discovery for generated Terraform/OpenTofu projects by following local `module` sources and watching imported module `*.tf*` files recursively. This augments any `include_patterns` set on the generated projects. Currently not supported for Terragrunt generation.
+</ParamField>
+
 <ParamField path="terragrunt" type="boolean" default="false">
   Whether to use Terragrunt for generated projects.
 </ParamField>
@@ -419,6 +431,10 @@ Automatically generate projects from directory structure using the `generate_pro
 
     <ParamField path="exclude_patterns" type="array" default="[]">
       List of directory glob patterns to exclude from generated projects.
+    </ParamField>
+
+    <ParamField path="dependency_file_triggers" type="boolean" default="false">
+      Enable automatic dependency-based trigger discovery for Terraform/OpenTofu projects generated from this block by following local `module` sources and watching imported module `*.tf*` files recursively. Currently not supported for Terragrunt blocks.
     </ParamField>
 
     <ParamField path="workflow" type="string" default="default">

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -34,7 +34,7 @@ type DiggerConfig struct {
 }
 
 type ReporterConfig struct {
-	AiSummary bool
+	AiSummary       bool
 	CommentsEnabled bool
 }
 
@@ -49,27 +49,28 @@ type AssumeRoleForProject struct {
 }
 
 type Project struct {
-	BlockName            string // the block name if this is a generated project
-	Name                 string
-	Branch               string
-	Alias                string
-	ApplyRequirements    []string
-	Dir                  string
-	Workspace            string
-	Terragrunt           bool
-	Layer                uint
-	OpenTofu             bool
-	Pulumi               bool
-	Workflow             string
-	WorkflowFile         string
-	IncludePatterns      []string
-	ExcludePatterns      []string
-	DependencyProjects   []string
-	DriftDetection       bool
-	AwsRoleToAssume      *AssumeRoleForProject
-	AwsCognitoOidcConfig *AwsCognitoOidcConfig
-	Generated            bool
-	PulumiStack          string
+	BlockName              string // the block name if this is a generated project
+	Name                   string
+	Branch                 string
+	Alias                  string
+	ApplyRequirements      []string
+	Dir                    string
+	Workspace              string
+	Terragrunt             bool
+	Layer                  uint
+	OpenTofu               bool
+	Pulumi                 bool
+	Workflow               string
+	WorkflowFile           string
+	IncludePatterns        []string
+	ExcludePatterns        []string
+	DependencyFileTriggers bool
+	DependencyProjects     []string
+	DriftDetection         bool
+	AwsRoleToAssume        *AssumeRoleForProject
+	AwsCognitoOidcConfig   *AwsCognitoOidcConfig
+	Generated              bool
+	PulumiStack            string
 }
 
 type Workflow struct {

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -98,6 +98,7 @@ func copyProjects(projects []*ProjectYaml) []Project {
 			workflowFile,
 			p.IncludePatterns,
 			p.ExcludePatterns,
+			p.DependencyFileTriggers,
 			p.DependencyProjects,
 			driftDetection,
 			roleToAssume,

--- a/libs/digger_config/dependency_file_triggers.go
+++ b/libs/digger_config/dependency_file_triggers.go
@@ -1,0 +1,200 @@
+package digger_config
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+)
+
+var localTerraformModuleSourcePrefixes = []string{
+	"./",
+	"../",
+	".\\",
+	"..\\",
+}
+
+func enrichProjectsWithDependencyFileTriggers(config *DiggerConfig, repoRoot string) {
+	absoluteRepoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		slog.Warn("failed to resolve repository root for dependency file triggers", "repoRoot", repoRoot, "error", err)
+		return
+	}
+
+	for i := range config.Projects {
+		project := &config.Projects[i]
+		if !project.DependencyFileTriggers {
+			continue
+		}
+
+		patterns, err := getDependencyFileTriggerPatterns(absoluteRepoRoot, *project)
+		if err != nil {
+			slog.Warn("failed to discover dependency file triggers for project", "projectName", project.Name, "projectDir", project.Dir, "error", err)
+			continue
+		}
+		if len(patterns) == 0 {
+			continue
+		}
+
+		project.IncludePatterns = appendUniqueStrings(project.IncludePatterns, patterns...)
+	}
+}
+
+func getDependencyFileTriggerPatterns(repoRoot string, project Project) ([]string, error) {
+	switch {
+	case project.Pulumi, project.Terragrunt:
+		return nil, nil
+	default:
+		return getTerraformDependencyFileTriggerPatterns(repoRoot, project.Dir)
+	}
+}
+
+func getTerraformDependencyFileTriggerPatterns(repoRoot string, projectDir string) ([]string, error) {
+	absoluteProjectDir := filepath.Join(repoRoot, projectDir)
+	modulePatterns, err := collectLocalTerraformModulePatterns(absoluteProjectDir, map[string]struct{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedProjectDir := normalizeRelativePath(projectDir)
+	patterns := make([]string, 0, len(modulePatterns))
+	for _, modulePattern := range modulePatterns {
+		relativePattern, err := filepath.Rel(repoRoot, modulePattern)
+		if err != nil {
+			return nil, err
+		}
+
+		normalizedPattern := normalizeRelativePath(relativePattern)
+		if isOutsideRepo(normalizedPattern) {
+			continue
+		}
+
+		if isPathInsideProject(normalizedProjectDir, normalizeRelativePath(filepath.Dir(normalizedPattern))) {
+			continue
+		}
+
+		patterns = append(patterns, normalizedPattern)
+	}
+
+	sort.Strings(patterns)
+	return appendUniqueStrings(nil, patterns...), nil
+}
+
+func collectLocalTerraformModulePatterns(moduleDir string, visited map[string]struct{}) ([]string, error) {
+	absoluteModuleDir, err := filepath.Abs(moduleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, seen := visited[absoluteModuleDir]; seen {
+		return nil, nil
+	}
+	visited[absoluteModuleDir] = struct{}{}
+
+	if _, err := os.Stat(absoluteModuleDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	module, diags := tfconfig.LoadModule(absoluteModuleDir)
+	if diags.HasErrors() {
+		return nil, errors.New(diags.Error())
+	}
+
+	patterns := make([]string, 0, len(module.ModuleCalls))
+	seenPatterns := make(map[string]struct{})
+
+	for _, moduleCall := range module.ModuleCalls {
+		if !isLocalTerraformModuleSource(moduleCall.Source) {
+			continue
+		}
+
+		absoluteSourceDir := filepath.Clean(filepath.Join(absoluteModuleDir, moduleCall.Source))
+		if _, err := os.Stat(absoluteSourceDir); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				slog.Debug("skipping missing local terraform module source", "moduleDir", absoluteModuleDir, "source", moduleCall.Source)
+				continue
+			}
+			return nil, err
+		}
+
+		modulePattern := filepath.Join(absoluteSourceDir, "*.tf*")
+		if _, seen := seenPatterns[modulePattern]; !seen {
+			patterns = append(patterns, modulePattern)
+			seenPatterns[modulePattern] = struct{}{}
+		}
+
+		childPatterns, err := collectLocalTerraformModulePatterns(absoluteSourceDir, visited)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, childPattern := range childPatterns {
+			if _, seen := seenPatterns[childPattern]; seen {
+				continue
+			}
+			patterns = append(patterns, childPattern)
+			seenPatterns[childPattern] = struct{}{}
+		}
+	}
+
+	sort.Strings(patterns)
+	return patterns, nil
+}
+
+func isLocalTerraformModuleSource(raw string) bool {
+	for _, prefix := range localTerraformModuleSourcePrefixes {
+		if strings.HasPrefix(raw, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeRelativePath(dir string) string {
+	normalized := filepath.ToSlash(filepath.Clean(dir))
+	if normalized == "" {
+		return "."
+	}
+	return normalized
+}
+
+func isOutsideRepo(dir string) bool {
+	return dir == ".." || strings.HasPrefix(dir, "../")
+}
+
+func isPathInsideProject(projectDir string, candidateDir string) bool {
+	if projectDir == "." {
+		return candidateDir == "."
+	}
+	return candidateDir == projectDir || strings.HasPrefix(candidateDir, projectDir+"/")
+}
+
+func appendUniqueStrings(existing []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(values))
+	result := make([]string, 0, len(existing)+len(values))
+
+	for _, value := range existing {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	return result
+}

--- a/libs/digger_config/digger_config.go
+++ b/libs/digger_config/digger_config.go
@@ -231,6 +231,8 @@ func LoadDiggerConfig(workingDir string, generateProjects bool, changedFiles []s
 		return nil, nil, nil, nil, err
 	}
 
+	enrichProjectsWithDependencyFileTriggers(config, workingDir)
+
 	err = ValidateDiggerConfig(config)
 	if err != nil {
 		slog.Warn("digger config validation failed", "error", err)
@@ -271,6 +273,8 @@ func LoadDiggerConfigFromString(yamlString string, terraformDir string) (*Digger
 		return nil, nil, nil, err
 	}
 
+	enrichProjectsWithDependencyFileTriggers(config, terraformDir)
+
 	err = ValidateDiggerConfig(config)
 	if err != nil {
 		slog.Warn("digger config validation failed", "error", err)
@@ -300,6 +304,10 @@ func validateBlockYaml(blocks []BlockYaml) error {
 			if b.RootDir == nil {
 				slog.Error("terragrunt block missing root_dir", "blockName", b.BlockName)
 				return fmt.Errorf("block %v is a terragrunt block but does not have root_dir specified", b.BlockName)
+			}
+			if b.DependencyFileTriggers {
+				slog.Error("dependency_file_triggers is not supported for terragrunt generation blocks", "blockName", b.BlockName)
+				return fmt.Errorf("dependency_file_triggers is not supported for terragrunt block %v", b.BlockName)
 			}
 		}
 	}
@@ -394,13 +402,14 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string, 
 						"projectName", projectName)
 
 					project := ProjectYaml{
-						Name:                 projectName,
-						Dir:                  dir,
-						Workflow:             defaultWorkflowName,
-						Workspace:            "default",
-						AwsRoleToAssume:      config.GenerateProjectsConfig.AwsRoleToAssume,
-						Generated:            true,
-						AwsCognitoOidcConfig: config.GenerateProjectsConfig.AwsCognitoOidcConfig,
+						Name:                   projectName,
+						Dir:                    dir,
+						Workflow:               defaultWorkflowName,
+						Workspace:              "default",
+						DependencyFileTriggers: config.GenerateProjectsConfig.DependencyFileTriggers,
+						AwsRoleToAssume:        config.GenerateProjectsConfig.AwsRoleToAssume,
+						Generated:              true,
+						AwsCognitoOidcConfig:   config.GenerateProjectsConfig.AwsCognitoOidcConfig,
 					}
 					config.Projects = append(config.Projects, &project)
 				}
@@ -499,17 +508,18 @@ func HandleYamlProjectGeneration(config *DiggerConfigYaml, terraformDir string, 
 								"projectName", projectName)
 
 							project := ProjectYaml{
-								Name:                 projectName,
-								Dir:                  dir,
-								Workflow:             workflow,
-								Workspace:            workspace,
-								OpenTofu:             b.OpenTofu,
-								AwsRoleToAssume:      b.AwsRoleToAssume,
-								Generated:            true,
-								AwsCognitoOidcConfig: b.AwsCognitoOidcConfig,
-								WorkflowFile:         b.WorkflowFile,
-								IncludePatterns:      b.IncludePatterns,
-								ExcludePatterns:      b.ExcludePatterns,
+								Name:                   projectName,
+								Dir:                    dir,
+								Workflow:               workflow,
+								Workspace:              workspace,
+								OpenTofu:               b.OpenTofu,
+								DependencyFileTriggers: b.DependencyFileTriggers,
+								AwsRoleToAssume:        b.AwsRoleToAssume,
+								Generated:              true,
+								AwsCognitoOidcConfig:   b.AwsCognitoOidcConfig,
+								WorkflowFile:           b.WorkflowFile,
+								IncludePatterns:        b.IncludePatterns,
+								ExcludePatterns:        b.ExcludePatterns,
 							}
 							config.Projects = append(config.Projects, &project)
 						}
@@ -622,6 +632,16 @@ func ValidateDiggerConfigYaml(configYaml *DiggerConfigYaml, fileName string) err
 		}
 	}
 	if configYaml.GenerateProjectsConfig != nil {
+		if err := validateBlockYaml(configYaml.GenerateProjectsConfig.Blocks); err != nil {
+			return err
+		}
+
+		if (configYaml.GenerateProjectsConfig.Terragrunt || configYaml.GenerateProjectsConfig.TerragruntParsingConfig != nil) &&
+			configYaml.GenerateProjectsConfig.DependencyFileTriggers {
+			slog.Error("dependency_file_triggers is not supported for top-level terragrunt project generation")
+			return fmt.Errorf("dependency_file_triggers is not supported for terragrunt generate_projects")
+		}
+
 		if configYaml.GenerateProjectsConfig.Include != "" &&
 			configYaml.GenerateProjectsConfig.Exclude != "" &&
 			len(configYaml.GenerateProjectsConfig.Blocks) != 0 {
@@ -670,6 +690,18 @@ func validatePulumiProject(project *Project) error {
 	return nil
 }
 
+func validateDependencyFileTriggers(project *Project) error {
+	if project.DependencyFileTriggers && project.Pulumi {
+		slog.Error("dependency_file_triggers is not supported for pulumi projects", "projectName", project.Name)
+		return fmt.Errorf("dependency_file_triggers is not supported for pulumi project %v", project.Name)
+	}
+	if project.DependencyFileTriggers && project.Terragrunt {
+		slog.Error("dependency_file_triggers is not supported for terragrunt projects", "projectName", project.Name)
+		return fmt.Errorf("dependency_file_triggers is not supported for terragrunt project %v", project.Name)
+	}
+	return nil
+}
+
 func ValidateProjects(config *DiggerConfig) error {
 	slog.Debug("validating projects configuration", "projectCount", len(config.Projects))
 
@@ -681,6 +713,11 @@ func ValidateProjects(config *DiggerConfig) error {
 		}
 
 		err = validatePulumiProject(&project)
+		if err != nil {
+			return err
+		}
+
+		err = validateDependencyFileTriggers(&project)
 		if err != nil {
 			return err
 		}

--- a/libs/digger_config/digger_config_test.go
+++ b/libs/digger_config/digger_config_test.go
@@ -1468,6 +1468,340 @@ func TestGetModifiedProjectsReturnsCorrectSourceMappingWithRelativePaths(t *test
 	assert.Equal(t, expectedImpactingLocations["prod"].ImpactingLocations, projectSourceMapping["prod"].ImpactingLocations)
 }
 
+func TestLoadDiggerConfigDoesNotTrackImportedTerraformModulesByDefault(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+- name: prod
+  dir: prod
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "prod"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "network"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "prod", "main.tf"), `
+module "network" {
+  source = "../modules/network"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "network", "main.tf"), `
+resource "null_resource" "network" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 0, len(impactedProjects))
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+  dependency_file_triggers: true
+- name: prod
+  dir: prod
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "prod"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "network"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "prod", "main.tf"), `
+module "network" {
+  source = "../modules/network"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "network", "main.tf"), `
+resource "null_resource" "network" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigTracksNestedImportedTerraformModulesRecursively(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "nested"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+module "nested" {
+  source = "../nested"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "nested", "main.tf"), `
+resource "null_resource" "nested" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/nested/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesForGeneratedProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+generate_projects:
+  include: "env/**"
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "env", "dev", "main.tf"), `
+module "shared" {
+  source = "../../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "env_dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesForGeneratedBlockProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+generate_projects:
+  blocks:
+    - block_name: env
+      include: "env/**"
+      dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "env", "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "env", "dev", "main.tf"), `
+module "shared" {
+  source = "../../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 1, len(impactedProjects))
+	assert.Equal(t, "env_dev", impactedProjects[0].Name)
+}
+
+func TestLoadDiggerConfigTracksImportedTerraformModulesForRootProjectsWhenDependencyFileTriggersEnabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: root
+  dir: .
+  dependency_file_triggers: true
+- name: shared
+  dir: modules/shared
+  dependency_file_triggers: true
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "main.tf"), `
+module "shared" {
+  source = "./modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 2, len(impactedProjects))
+	projectNames := []string{impactedProjects[0].Name, impactedProjects[1].Name}
+	assert.Contains(t, projectNames, "root")
+	assert.Contains(t, projectNames, "shared")
+}
+
+func TestLoadDiggerConfigDependencyFileTriggersRespectExcludePatterns(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+projects:
+- name: dev
+  dir: dev
+  dependency_file_triggers: true
+  exclude_patterns:
+    - modules/shared/**
+`
+
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "dev"), 0o755))
+	assert.NoError(t, os.MkdirAll(path.Join(tempDir, "modules", "shared"), 0o755))
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+	defer createFile(path.Join(tempDir, "dev", "main.tf"), `
+module "shared" {
+  source = "../modules/shared"
+}
+`)()
+	defer createFile(path.Join(tempDir, "modules", "shared", "main.tf"), `
+resource "null_resource" "shared" {}
+`)()
+
+	dg, _, _, _, err := LoadDiggerConfig(tempDir, true, nil, nil)
+	assert.NoError(t, err)
+
+	impactedProjects, _ := dg.GetModifiedProjects([]string{"modules/shared/main.tf"})
+	assert.Equal(t, 0, len(impactedProjects))
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntBlocksWhenGenerationDisabled(t *testing.T) {
+	tempDir, teardown := setUp()
+	defer teardown()
+
+	diggerCfg := `
+generate_projects:
+  blocks:
+    - block_name: tg
+      terragrunt: true
+      root_dir: stack
+      dependency_file_triggers: true
+`
+
+	defer createFile(path.Join(tempDir, "digger.yml"), diggerCfg)()
+
+	_, _, _, _, err := LoadDiggerConfig(tempDir, false, nil, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt block tg")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForPulumiProjects(t *testing.T) {
+	diggerCfg := `
+projects:
+- name: pulumi
+  dir: .
+  pulumi: true
+  pulumi_stack: dev
+  dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for pulumi project pulumi")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntProjects(t *testing.T) {
+	diggerCfg := `
+projects:
+- name: tg
+  dir: .
+  terragrunt: true
+  dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt project tg")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntGenerateProjects(t *testing.T) {
+	diggerCfg := `
+generate_projects:
+  terragrunt: true
+  dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt generate_projects")
+}
+
+func TestLoadDiggerConfigRejectsDependencyFileTriggersForTerragruntBlocks(t *testing.T) {
+	diggerCfg := `
+generate_projects:
+  blocks:
+    - block_name: tg
+      terragrunt: true
+      root_dir: stack
+      dependency_file_triggers: true
+`
+
+	_, _, _, err := LoadDiggerConfigFromString(diggerCfg, "./")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency_file_triggers is not supported for terragrunt block tg")
+}
+
 func TestCognitoTokenSetFromMinConfig(t *testing.T) {
 	diggerCfg := `
 projects:

--- a/libs/digger_config/utils.go
+++ b/libs/digger_config/utils.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -37,13 +38,45 @@ func GetDirNamesFromPaths(filePaths []string) []string {
 	return res
 }
 
+func ResolvePatternsRelativeToProject(projectDir string, patterns []string) []string {
+	resolvedPatterns := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, ".") {
+			resolvedPatterns = append(resolvedPatterns, filepath.Join(projectDir, pattern))
+		} else {
+			resolvedPatterns = append(resolvedPatterns, pattern)
+		}
+	}
+	return resolvedPatterns
+}
+
+func MatchExcludePatternsToFile(fileToMatch string, excludePatterns []string) bool {
+	fileToMatch = NormalizeFileName(fileToMatch)
+	for i := range excludePatterns {
+		excludePatterns[i] = NormalizeFileName(excludePatterns[i])
+	}
+
+	for _, epattern := range excludePatterns {
+		excluded, err := doublestar.PathMatch(epattern, fileToMatch)
+		if err != nil {
+			slog.Error("failed to match modified files with exclude pattern",
+				"file", fileToMatch,
+				"pattern", epattern,
+				"error", err)
+			panic(err)
+		}
+		if excluded {
+			return true
+		}
+	}
+
+	return false
+}
+
 func MatchIncludeExcludePatternsToFile(fileToMatch string, includePatterns []string, excludePatterns []string) bool {
 	fileToMatch = NormalizeFileName(fileToMatch)
 	for i := range includePatterns {
 		includePatterns[i] = NormalizeFileName(includePatterns[i])
-	}
-	for i := range excludePatterns {
-		excludePatterns[i] = NormalizeFileName(excludePatterns[i])
 	}
 
 	matching := false
@@ -62,19 +95,8 @@ func MatchIncludeExcludePatternsToFile(fileToMatch string, includePatterns []str
 		}
 	}
 
-	for _, epattern := range excludePatterns {
-		excluded, err := doublestar.PathMatch(epattern, fileToMatch)
-		if err != nil {
-			slog.Error("failed to match modified files with exclude pattern",
-				"file", fileToMatch,
-				"pattern", epattern,
-				"error", err)
-			panic(err)
-		}
-		if excluded {
-			matching = false
-			break
-		}
+	if MatchExcludePatternsToFile(fileToMatch, excludePatterns) {
+		matching = false
 	}
 
 	return matching

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -31,7 +31,7 @@ type DiggerConfigYaml struct {
 }
 
 type ReportingConfigYaml struct {
-	AiSummary bool `yaml:"ai_summary"`
+	AiSummary       bool `yaml:"ai_summary"`
 	CommentsEnabled bool `yaml:"comments_enabled"`
 }
 
@@ -44,27 +44,28 @@ const ApplyRequirementsMergeable = "mergeable"
 const ApplyRequirementsUndiverged = "undiverged"
 
 type ProjectYaml struct {
-	BlockName            string                      `yaml:"block_name"`
-	Name                 string                      `yaml:"name"`
-	Alias                string                      `yaml:"alias,omitempty"`
-	ApplyRequirements    []string                    `yaml:"apply_requirements,omitempty"`
-	Dir                  string                      `yaml:"dir"`
-	Workspace            string                      `yaml:"workspace"`
-	Terragrunt           bool                        `yaml:"terragrunt"`
-	Branch               *string                     `yaml:"branch,omitempty"`
-	OpenTofu             bool                        `yaml:"opentofu"`
-	Pulumi               bool                        `yaml:"pulumi"`
-	Workflow             string                      `yaml:"workflow"`
-	WorkflowFile         string                      `yaml:"workflow_file"`
-	IncludePatterns      []string                    `yaml:"include_patterns,omitempty"`
-	Layer                *uint                       `yaml:"layer"`
-	ExcludePatterns      []string                    `yaml:"exclude_patterns,omitempty"`
-	DependencyProjects   []string                    `yaml:"depends_on,omitempty"`
-	DriftDetection       *bool                       `yaml:"drift_detection,omitempty"`
-	AwsRoleToAssume      *AssumeRoleForProjectConfig `yaml:"aws_role_to_assume,omitempty"`
-	Generated            bool                        `yaml:"generated"`
-	AwsCognitoOidcConfig *AwsCognitoOidcConfig       `yaml:"aws_cognito_oidc,omitempty"`
-	PulumiStack          string                      `yaml:"pulumi_stack"`
+	BlockName              string                      `yaml:"block_name"`
+	Name                   string                      `yaml:"name"`
+	Alias                  string                      `yaml:"alias,omitempty"`
+	ApplyRequirements      []string                    `yaml:"apply_requirements,omitempty"`
+	Dir                    string                      `yaml:"dir"`
+	Workspace              string                      `yaml:"workspace"`
+	Terragrunt             bool                        `yaml:"terragrunt"`
+	Branch                 *string                     `yaml:"branch,omitempty"`
+	OpenTofu               bool                        `yaml:"opentofu"`
+	Pulumi                 bool                        `yaml:"pulumi"`
+	Workflow               string                      `yaml:"workflow"`
+	WorkflowFile           string                      `yaml:"workflow_file"`
+	IncludePatterns        []string                    `yaml:"include_patterns,omitempty"`
+	Layer                  *uint                       `yaml:"layer"`
+	ExcludePatterns        []string                    `yaml:"exclude_patterns,omitempty"`
+	DependencyFileTriggers bool                        `yaml:"dependency_file_triggers,omitempty"`
+	DependencyProjects     []string                    `yaml:"depends_on,omitempty"`
+	DriftDetection         *bool                       `yaml:"drift_detection,omitempty"`
+	AwsRoleToAssume        *AssumeRoleForProjectConfig `yaml:"aws_role_to_assume,omitempty"`
+	Generated              bool                        `yaml:"generated"`
+	AwsCognitoOidcConfig   *AwsCognitoOidcConfig       `yaml:"aws_cognito_oidc,omitempty"`
+	PulumiStack            string                      `yaml:"pulumi_stack"`
 }
 
 type WorkflowYaml struct {
@@ -116,10 +117,11 @@ type EnvVarYaml struct {
 
 type BlockYaml struct {
 	// these flags are only for terraform and opentofu
-	Include         string   `yaml:"include"`
-	Exclude         string   `yaml:"exclude"`
-	IncludePatterns []string `yaml:"include_patterns,omitempty"`
-	ExcludePatterns []string `yaml:"exclude_patterns,omitempty"`
+	Include                string   `yaml:"include"`
+	Exclude                string   `yaml:"exclude"`
+	IncludePatterns        []string `yaml:"include_patterns,omitempty"`
+	ExcludePatterns        []string `yaml:"exclude_patterns,omitempty"`
+	DependencyFileTriggers bool     `yaml:"dependency_file_triggers,omitempty"`
 
 	// these flags are only for terragrunt
 	Terragrunt              bool                     `yaml:"terragrunt"`
@@ -154,6 +156,7 @@ type AwsCognitoOidcConfig struct {
 type GenerateProjectsConfigYaml struct {
 	Include                 string                      `yaml:"include"`
 	Exclude                 string                      `yaml:"exclude"`
+	DependencyFileTriggers  bool                        `yaml:"dependency_file_triggers,omitempty"`
 	Terragrunt              bool                        `yaml:"terragrunt"`
 	Blocks                  []BlockYaml                 `yaml:"blocks"`
 	TerragruntParsingConfig *TerragruntParsingConfig    `yaml:"terragrunt_parsing,omitempty"`


### PR DESCRIPTION
## Summary

This PR is the new first reviewable slice of #791.

It adds an opt-in `dependency_file_triggers` feature for Terraform/OpenTofu projects that narrows changed-file matching by following local `module` imports recursively and adding the imported module `*.tf*` files to each project's trigger patterns.

## Scope

This PR intentionally stays within `docs/` and `libs/digger_config/`.

Included here:
- YAML/config support for `dependency_file_triggers`
- trigger-pattern discovery for local Terraform/OpenTofu modules
- generated-project support for Terraform/OpenTofu generation paths
- validation for unsupported Terragrunt/Pulumi usage
- docs and regression tests

Explicitly not included here:
- inferred project dependency edges
- hard dependency propagation changes
- GitHub/GitLab event semantics
- Terragrunt trigger discovery or hardening

## Safety

- the feature is opt-in via `dependency_file_triggers: true`
- existing `include_patterns` / `exclude_patterns` behavior remains in place
- `exclude_patterns` still take precedence over derived trigger paths
- generated Terraform/OpenTofu projects can opt in
- Terragrunt and Pulumi reject `dependency_file_triggers` explicitly in this slice

## Validation

- `cd libs && env GOTOOLCHAIN=local GOTELEMETRY=off GOCACHE=/tmp/digger-go-cache GOMODCACHE=/tmp/digger-go-modcache /opt/homebrew/opt/go@1.25/bin/go test ./digger_config/...`

## Docs

- updated the config reference for `dependency_file_triggers`
- updated the include/exclude patterns guide with the narrower dependency-file-based triggering option

## Follow-up

The inferred dependency-edge / hard-mode propagation behavior is being kept as a separate follow-up PR because that is where the recent review feedback and CI-semantic risk has been concentrated.

## AI disclosure

This PR was prepared with assistance from Codex (OpenAI).
