### PR TITLE
ui github setup link fix

### DIFF
--- a/ui/src/lib/env.server.ts
+++ b/ui/src/lib/env.server.ts
@@ -10,6 +10,7 @@ export type Env = {
   PUBLIC_HOSTNAME: string
   STATESMAN_BACKEND_URL: string
   WORKOS_REDIRECT_URI: string
+  ORCHESTRATOR_GITHUB_APP_URL: string
   POSTHOG_KEY?: string
   POSTHOG_HOST?: string
 }
@@ -21,6 +22,7 @@ export const getPublicServerConfig = createServerFn({ method: 'GET' })
       PUBLIC_HOSTNAME: process.env.PUBLIC_URL?.replace('https://', '').replace('http://', '') ?? '',
       STATESMAN_BACKEND_URL: process.env.STATESMAN_BACKEND_URL ?? '',
       WORKOS_REDIRECT_URI: process.env.WORKOS_REDIRECT_URI ?? '',
+      ORCHESTRATOR_GITHUB_APP_URL: process.env.ORCHESTRATOR_GITHUB_APP_URL ?? '',
       POSTHOG_KEY: process.env.POSTHOG_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY || process.env.VITE_PUBLIC_POSTHOG_KEY || '',
       POSTHOG_HOST: process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || process.env.VITE_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
     } as Env

--- a/ui/src/routes/_authenticated/_dashboard/dashboard/onboarding.tsx
+++ b/ui/src/routes/_authenticated/_dashboard/dashboard/onboarding.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute(
   loader: async ({ context }) => {
     const { user, organisationId, publicServerConfig } = context
     const publicHostname = publicServerConfig?.PUBLIC_HOSTNAME || ''
-    const githubAppUrl = '/orchestrator/github/setup'
+    const githubAppUrl = publicServerConfig?.ORCHESTRATOR_GITHUB_APP_URL || ''
     return { user, organisationId, publicHostname, githubAppUrl  }
   },
 })


### PR DESCRIPTION
the ui github link should point directly to the github app

/orchestrator/github/setup is incorrect is only applicable for selfhosting opentaco.