### PR TITLE
fix(cli): propagate per-project errors from RunJobs to exit message

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -74,6 +74,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 
 	exectorResults := make([]execution.DiggerExecutorResult, len(jobs))
 	appliesPerProject := make(map[string]bool)
+	var firstErr error
 
 	for i, job := range jobs {
 		splits := strings.Split(job.Namespace, "/")
@@ -115,6 +116,9 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 			if err != nil {
 				slog.Error("error while running command for project", "command", command, "projectname", job.ProjectName, "error", err)
 				appliesPerProject[job.ProjectName] = false
+				if firstErr == nil {
+					firstErr = fmt.Errorf("project %v command %v: %w", job.ProjectName, command, err)
+				}
 				if executorResult != nil {
 					exectorResults[i] = *executorResult
 				}
@@ -179,7 +183,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 
 	atLeastOneApply := len(appliesPerProject) > 0
 
-	return allAppliesSuccess, atLeastOneApply, nil
+	return allAppliesSuccess, atLeastOneApply, firstErr
 }
 
 func reportPolicyError(projectName string, command string, requestedBy string, reporter reporting.Reporter) string {


### PR DESCRIPTION
## Problem

We hit exit code 8 in our CI with the message:

```
Failed to run commands. %!s(<nil>)
```

In our case, the underlying failure was `terragrunt show -json` failing during `postProcessPlan()` in a Terragrunt monorepo (~100 projects). The only way to find the actual error was scrolling through thousands of structured log lines looking for the `slog.Error` entry -- the exit message itself gave zero information.

The `%!s(<nil>)` symptom has been seen before (#1538), though that particular instance was caused by OpenTofu JSON parsing (#1545). The error swallowing pattern in `RunJobs()` described below was not addressed.

## Root cause

`RunJobs()` in `cli/pkg/digger/digger.go` logs per-project errors via `slog.Error` but always returns `nil` as its error value:

```go
executorResult, _, err := run(...)
if err != nil {
    slog.Error("error while running command for project", ...)
    appliesPerProject[job.ProjectName] = false
    // error is never collected
}
// ...
return allAppliesSuccess, atLeastOneApply, nil  // always nil
```

The caller in `github.go` formats the nil error with `%s`, producing `%!s(<nil>)`:

```go
usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to run commands. %s", err), 8)
```

## Fix

Track the first error encountered across project runs and return it instead of `nil`:

- Add `var firstErr error` before the job loop
- Capture on first failure: `firstErr = fmt.Errorf("project %v command %v: %w", ...)`
- Return `firstErr` instead of `nil`

This preserves the existing `allAppliesSuccess` flag behavior while giving callers an actionable error message.

## Before / After

- **Before:** `Failed to run commands. %!s(<nil>)` -- no diagnostic value
- **After:** `Failed to run commands. project <name> command <cmd>: <underlying error>` -- identifies which project failed and why

## Regression risk

No behavioral change. All 3 callers (`github.go`, `spec.go`, `manual.go`) already check `!allAppliesSuccess || err != nil`. When `run()` fails, `appliesPerProject` is set to `false`, so `allAppliesSuccess` is already `false` and the failure branch is taken regardless of `err`. The only difference is that `err` now carries the actual message instead of `nil`.

Existing unit tests pass (`go test ./cli/pkg/digger/... -short`).

### :brain: AI disclosure

This PR was authored by an AI agent (Claude/Roo) with human review. The bug was identified by tracing the code path from CI logs showing the `%!s(<nil>)` pattern through `github.go` -> `digger.go` -> `execution.go` -> `terragrunt.go`.
