### PR TITLE
fix: drift_exclude_patterns excluding all projects when include is unset

### DIFF
--- a/libs/digger_config/utils.go
+++ b/libs/digger_config/utils.go
@@ -46,7 +46,8 @@ func MatchIncludeExcludePatternsToFile(fileToMatch string, includePatterns []str
 		excludePatterns[i] = NormalizeFileName(excludePatterns[i])
 	}
 
-	matching := false
+	// An empty include list means "match everything"; only the exclude list filters.
+	matching := len(includePatterns) == 0
 	for _, ipattern := range includePatterns {
 		isMatched, err := doublestar.PathMatch(ipattern, fileToMatch)
 		if err != nil {

--- a/libs/digger_config/utils_test.go
+++ b/libs/digger_config/utils_test.go
@@ -20,12 +20,20 @@ func TestMatchIncludeExcludePatternsToFile(t *testing.T) {
 	result = MatchIncludeExcludePatternsToFile("projects/dev/project", includePatterns, excludePatterns)
 	assert.Equal(t, false, result)
 
-	// also checking for uninitialized case which is going to be the scenario when not specified in yaml file
+	// Empty include list means "match everything" (only exclude filters).
 	var ip []string
 	var ep []string
 	result = MatchIncludeExcludePatternsToFile("/projects/dev/test1", ip, ep)
-	assert.Equal(t, false, result)
+	assert.Equal(t, true, result)
 
+	// Exclude-only: every path matches except those hit by an exclude pattern.
+	// Mirrors the drift_exclude_patterns scenario where users provide excludes
+	// without includes.
+	excludeOnly := []string{"projects/dev/project"}
+	result = MatchIncludeExcludePatternsToFile("/projects/dev/test1", nil, excludeOnly)
+	assert.Equal(t, true, result)
+	result = MatchIncludeExcludePatternsToFile("/projects/dev/project", nil, excludeOnly)
+	assert.Equal(t, false, result)
 }
 
 func TestGetPatternsRelativeToRepo(t *testing.T) {


### PR DESCRIPTION
## Summary
- `MatchIncludeExcludePatternsToFile` initialized `matching := false` and only flipped it to `true` when an include pattern matched. Any caller passing an empty include list (e.g. a `digger.yml` with `drift_exclude_patterns` but no `drift_include_patterns`) had every project skipped — both `drift/controllers/drift.go:87` and `cli/pkg/github/github.go:218` treat the `false` return as "excluded."
- Default `matching` to `true` when the include list is empty so the exclude list does the filtering on its own. Matches the natural semantics users expect (mirrors `.gitignore`, GitLab CI `rules`, etc.).
- Existing callers in `digger_config.go` always pass a non-empty include list (either from `GenerateProjectsConfig.Include` or a default `project.Dir/**/*` appended at the call site), so they are unaffected.

## Reproduction
A `digger.yml` like the one in #2650's introduced flow — `drift_exclude_patterns` listed under `generate_projects`, no `drift_include_patterns` — caused the drift controller to log `"Project X dir Y excluded by drift patterns, skipping"` for every project.

## Test plan
- [x] `go test ./...` in `libs/digger_config` passes
- [x] Updated `TestMatchIncludeExcludePatternsToFile` to assert new semantics (empty include = match all)
- [x] Added an exclude-only case mirroring the drift scenario
- [ ] Verify against a real repo configured with `drift_exclude_patterns` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)