### PR TITLE
fix: deduplicate DependencyProjects before graph insertion to prevent "edge already exists" error

### DIFF
--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -404,7 +404,12 @@ func CreateProjectDependencyGraph(projects []Project) (graph.Graph[string, Proje
 				return nil, err
 			}
 		}
+		seen := make(map[string]bool)
 		for _, dependency := range project.DependencyProjects {
+			if seen[dependency] {
+				continue
+			}
+			seen[dependency] = true
 			_, err := g.Vertex(dependency)
 
 			if errors.Is(err, graph.ErrVertexNotFound) {


### PR DESCRIPTION
Fixes #2628

## Problem
When `cascadeDependencies: true` and `dependsOnOrdering: true` are both
enabled, recursive dependency expansion adds the same project into
`DependencyProjects` multiple times — once directly and once transitively.

For example with A → X, A → B, B → X:
- X appears in A's `DependencyProjects` twice
- `g.AddEdge(X, A)` is called twice
- The graph library returns `"edge already exists"` and the scan fails

## Root Cause
`CreateProjectDependencyGraph` in `libs/digger_config/converters.go`
iterates `DependencyProjects` and calls `g.AddEdge()` for each entry
with no duplicate check.

## Fix
Add a `seen` map inside the dependency loop to skip duplicate entries
before they reach `g.AddEdge()`. This is a minimal, safe change — no
new imports required, no behaviour change for non-duplicate cases.

## Testing
Existing test suite unchanged. The fix only affects cases where
`DependencyProjects` contains duplicates.