### PR TITLE
fix: treat terragrunt run --all plan as hasPlanStep to skip single-file terraform show

### DIFF
--- a/libs/execution/execution.go
+++ b/libs/execution/execution.go
@@ -219,8 +219,9 @@ func (d DiggerExecutor) Plan() (*iac_utils.IacSummary, bool, bool, string, strin
 	}
 
 	hasPlanStep := lo.ContainsBy(planSteps, func(step scheduler.Step) bool {
-		return step.Action == "plan"
-	})
+    return step.Action == "plan" ||
+        (step.Action == "run" && strings.Contains(step.Value, "run --all plan"))
+})
 
 	// setting additional env vars for run step
 	if d.RunEnvVars == nil {


### PR DESCRIPTION
Fixes #2552

## Problem
When using `terragrunt run --all plan` via a custom `run` step in the
workflow, `driftctl scan` completes successfully but then fails with:
error running terraform show: exit status 1

## Root Cause
`hasPlanStep` in `libs/execution/execution.go` is only set to `true`
when a step has `action == "plan"`:

```go
hasPlanStep := lo.ContainsBy(planSteps, func(step scheduler.Step) bool {
    return step.Action == "plan"
})
```

With a custom `run` step, `hasPlanStep` stays `false`. After the run
step completes successfully, Digger falls into the `!hasPlanStep` branch
and calls `terraform show` against `LocalPlanFilePath()` — expecting a
single `.tfplan` file. But `terragrunt run --all plan` writes per-module
plan files across subdirectories, not a single file at that path.

## Fix
Extend the `hasPlanStep` check to also treat `run` steps containing
`run --all plan` as a plan step, skipping the single-file
`terraform show` post-processing:

```go
hasPlanStep := lo.ContainsBy(planSteps, func(step scheduler.Step) bool {
    return step.Action == "plan" ||
        (step.Action == "run" && strings.Contains(step.Value, "run --all plan"))
})
```

No new imports required — `strings` is already imported.

## Testing
Existing test suite unchanged. Fix only affects workflows using
`terragrunt run --all plan` via a custom `run` step.