### PR TITLE
Persist optional plan lock file artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,10 @@ inputs:
   upload-plan-destination:
     description: Destination to upload the plan to. azure, gcp, github and aws are currently supported.
     required: false
+  upload-plan-lock-file:
+    description: Optional dependency lock file to store and restore with plan artifacts, relative to each project directory. For Terraform use .terraform.lock.hcl.
+    required: false
+    default: ""
   upload-plan-destination-s3-bucket:
     description: Name of the destination bucket for AWS S3. Should be provided if destination == aws
     required: false
@@ -504,6 +508,7 @@ runs:
       shell: bash
       env:
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        PLAN_UPLOAD_LOCK_FILE: ${{ inputs.upload-plan-lock-file }}
         PLAN_UPLOAD_S3_ENCRYPTION_ENABLED: ${{ inputs.upload-plan-destination-s3-encryption-enabled }}
         PLAN_UPLOAD_S3_ENCRYPTION_TYPE: ${{ inputs.upload-plan-destination-s3-encryption-type }}
         PLAN_UPLOAD_S3_ENCRYPTION_KMS_ID: ${{ inputs.upload-plan-destination-s3-encryption-kms-key-id }}
@@ -559,6 +564,7 @@ runs:
         DIGGER_OS: ${{ inputs.digger-os }}
         DIGGER_ARCH: ${{ inputs.digger-arch }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        PLAN_UPLOAD_LOCK_FILE: ${{ inputs.upload-plan-lock-file }}
         PLAN_UPLOAD_S3_ENCRYPTION_ENABLED: ${{ inputs.upload-plan-destination-s3-encryption-enabled }}
         PLAN_UPLOAD_S3_ENCRYPTION_TYPE: ${{ inputs.upload-plan-destination-s3-encryption-type }}
         PLAN_UPLOAD_S3_ENCRYPTION_KMS_ID: ${{ inputs.upload-plan-destination-s3-encryption-kms-key-id }}
@@ -646,6 +652,7 @@ runs:
       env:
         DIGGER_VERSION: ${{ github.action_ref }}
         PLAN_UPLOAD_DESTINATION: ${{ inputs.upload-plan-destination }}
+        PLAN_UPLOAD_LOCK_FILE: ${{ inputs.upload-plan-lock-file }}
         PLAN_UPLOAD_S3_ENCRYPTION_ENABLED: ${{ inputs.upload-plan-destination-s3-encryption-enabled }}
         PLAN_UPLOAD_S3_ENCRYPTION_TYPE: ${{ inputs.upload-plan-destination-s3-encryption-type }}
         PLAN_UPLOAD_S3_ENCRYPTION_KMS_ID: ${{ inputs.upload-plan-destination-s3-encryption-kms-key-id }}

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -546,6 +546,17 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			if err != nil {
 				slog.Error("failed to delete stored plan file", "stored plan file path", planPathProvider.StoredPlanFilePath(), "error", err)
 			}
+			if planLockFilePath := execution.PlanLockFilePath(); planLockFilePath != "" {
+				if err := execution.ValidatePlanLockFilePath(planLockFilePath); err != nil {
+					slog.Error("failed to delete stored plan lock file", "error", err)
+				} else {
+					storedPlanLockFilePath := planPathProvider.StoredPlanLockFilePath(planLockFilePath)
+					err = planStorage.DeleteStoredPlan(storedPlanLockFilePath, storedPlanLockFilePath)
+					if err != nil {
+						slog.Error("failed to delete stored plan lock file", "stored plan lock file path", storedPlanLockFilePath, "error", err)
+					}
+				}
+			}
 		}
 	case "digger lock":
 		err := usage.SendUsageRecord(requestedBy, job.EventName, "lock")

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -214,17 +214,23 @@ func (m *MockZipper) GetFileFromZip(zipFile string, filename string) (string, er
 }
 
 type MockPlanStorage struct {
-	Commands []RunInfo
+	Commands          []RunInfo
+	RetrievePlanPaths map[string]string
 }
 
 func (m *MockPlanStorage) StorePlanFile(fileContents []byte, artifactName string, fileName string) error {
-	m.Commands = append(m.Commands, RunInfo{"StorePlanFile", artifactName, time.Now()})
+	m.Commands = append(m.Commands, RunInfo{"StorePlanFile", artifactName + " " + fileName, time.Now()})
 	return nil
 }
 
 func (m *MockPlanStorage) RetrievePlan(localPlanFilePath string, artifactName string, storedPlanFilePath string) (*string, error) {
-	m.Commands = append(m.Commands, RunInfo{"RetrievePlan", localPlanFilePath, time.Now()})
-	return nil, nil
+	m.Commands = append(m.Commands, RunInfo{"RetrievePlan", artifactName + " " + storedPlanFilePath, time.Now()})
+	if m.RetrievePlanPaths != nil {
+		if retrievedPlanPath, ok := m.RetrievePlanPaths[storedPlanFilePath]; ok {
+			return &retrievedPlanPath, nil
+		}
+	}
+	return &localPlanFilePath, nil
 }
 
 func (m *MockPlanStorage) DeleteStoredPlan(artifactName string, storedPlanFilePath string) error {
@@ -242,18 +248,23 @@ type MockPlanPathProvider struct {
 }
 
 func (m MockPlanPathProvider) ArtifactName() string {
-	m.Commands = append(m.Commands, RunInfo{"ArtifactName", "", time.Now()})
 	return "plan"
 }
 
 func (m MockPlanPathProvider) StoredPlanFilePath() string {
-	m.Commands = append(m.Commands, RunInfo{"StoredPlanFilePath", "", time.Now()})
 	return "plan"
 }
 
 func (m MockPlanPathProvider) LocalPlanFilePath() string {
-	m.Commands = append(m.Commands, RunInfo{"LocalPlanFilePath", "", time.Now()})
 	return "plan"
+}
+
+func (m MockPlanPathProvider) LocalPlanLockFilePath(lockFilePath string) string {
+	return lockFilePath
+}
+
+func (m MockPlanPathProvider) StoredPlanLockFilePath(lockFilePath string) string {
+	return "plan." + strings.TrimPrefix(lockFilePath, ".")
 }
 
 func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
@@ -303,7 +314,74 @@ func TestCorrectCommandExecutionWhenApplying(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage, planPathProvider)
 
-	assert.Equal(t, []string{"RetrievePlan plan", "Init ", "Apply ", "PublishComment 1 <details ><summary>Apply output</summary>\n\n```terraform\n\n```\n</details>", "Run   echo"}, commandStrings)
+	assert.Equal(t, []string{"RetrievePlan plan plan", "Init ", "Apply plan", "PublishComment 1 <details ><summary>Apply output</summary>\n\n```terraform\n\n```\n</details>", "Run   echo"}, commandStrings)
+}
+
+func TestCorrectCommandExecutionWhenApplyingWithPlanLockFile(t *testing.T) {
+	t.Setenv("PLAN_UPLOAD_LOCK_FILE", ".terraform.lock.hcl")
+
+	commandRunner := &MockCommandRunner{}
+	terraformExecutor := &MockTerraformExecutor{}
+	prManager := &MockPRManager{}
+	lock := &MockProjectLock{}
+	retrievedLockFile, err := os.CreateTemp("", "digger-lock-*")
+	assert.NoError(t, err)
+	defer os.Remove(retrievedLockFile.Name())
+	_, err = retrievedLockFile.WriteString("lock file contents")
+	assert.NoError(t, err)
+	assert.NoError(t, retrievedLockFile.Close())
+	defer os.Remove(".terraform.lock.hcl")
+
+	planStorage := &MockPlanStorage{
+		RetrievePlanPaths: map[string]string{
+			"plan.terraform.lock.hcl": retrievedLockFile.Name(),
+		},
+	}
+	reporter := &reporting.CiReporter{
+		CiService:         prManager,
+		PrNumber:          1,
+		ReportStrategy:    &reporting.MultipleCommentsStrategy{},
+		IsSupportMarkdown: true,
+	}
+	planPathProvider := &MockPlanPathProvider{}
+	executor := execution.DiggerExecutor{
+		ApplyStage: &orchestrator.Stage{
+			Steps: []orchestrator.Step{
+				{
+					Action:    "init",
+					ExtraArgs: nil,
+					Value:     "",
+				},
+				{
+					Action:    "apply",
+					ExtraArgs: nil,
+					Value:     "",
+				},
+			},
+		},
+		PlanStage:         &orchestrator.Stage{},
+		CommandRunner:     commandRunner,
+		TerraformExecutor: terraformExecutor,
+		Reporter:          reporter,
+		PlanStorage:       planStorage,
+		PlanPathProvider:  planPathProvider,
+		IacUtils:          iac_utils.TerraformUtils{},
+	}
+
+	executor.Apply()
+	restoredLockFile, err := os.ReadFile(".terraform.lock.hcl")
+	assert.NoError(t, err)
+	assert.Equal(t, "lock file contents", string(restoredLockFile))
+
+	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage, planPathProvider)
+
+	assert.Equal(t, []string{
+		"RetrievePlan plan plan",
+		"RetrievePlan plan.terraform.lock.hcl plan.terraform.lock.hcl",
+		"Init ",
+		"Apply plan",
+		"PublishComment 1 <details ><summary>Apply output</summary>\n\n```terraform\n\n```\n</details>",
+	}, commandStrings)
 }
 
 func TestCorrectCommandExecutionWhenDestroying(t *testing.T) {
@@ -396,7 +474,63 @@ func TestCorrectCommandExecutionWhenPlanning(t *testing.T) {
 
 	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage, planPathProvider)
 
-	assert.Equal(t, []string{"Init ", "Plan ", "Show ", "StorePlanFile plan", "Run   echo"}, commandStrings)
+	assert.Equal(t, []string{"Init ", "Plan ", "Show ", "StorePlanFile plan plan", "Run   echo"}, commandStrings)
+}
+
+func TestCorrectCommandExecutionWhenPlanningWithPlanLockFile(t *testing.T) {
+	t.Setenv("PLAN_UPLOAD_LOCK_FILE", ".terraform.lock.hcl")
+
+	commandRunner := &MockCommandRunner{}
+	terraformExecutor := &MockTerraformExecutor{}
+	prManager := &MockPRManager{}
+	lock := &MockProjectLock{}
+	planStorage := &MockPlanStorage{}
+	reporter := &reporting.CiReporter{
+		CiService: prManager,
+		PrNumber:  1,
+	}
+	planPathProvider := &MockPlanPathProvider{}
+
+	executor := execution.DiggerExecutor{
+		ApplyStage: &orchestrator.Stage{},
+		PlanStage: &orchestrator.Stage{
+			Steps: []orchestrator.Step{
+				{
+					Action:    "init",
+					ExtraArgs: nil,
+					Value:     "",
+				},
+				{
+					Action:    "plan",
+					ExtraArgs: nil,
+					Value:     "",
+				},
+			},
+		},
+		CommandRunner:     commandRunner,
+		TerraformExecutor: terraformExecutor,
+		Reporter:          reporter,
+		PlanStorage:       planStorage,
+		PlanPathProvider:  planPathProvider,
+		IacUtils:          iac_utils.TerraformUtils{},
+	}
+
+	os.WriteFile(planPathProvider.LocalPlanFilePath(), []byte{123}, 0644)
+	defer os.Remove(planPathProvider.LocalPlanFilePath())
+	os.WriteFile(planPathProvider.LocalPlanLockFilePath(".terraform.lock.hcl"), []byte{123}, 0644)
+	defer os.Remove(planPathProvider.LocalPlanLockFilePath(".terraform.lock.hcl"))
+
+	executor.Plan()
+
+	commandStrings := allCommandsInOrderWithParams(terraformExecutor, commandRunner, prManager, lock, planStorage, planPathProvider)
+
+	assert.Equal(t, []string{
+		"Init ",
+		"Plan ",
+		"Show ",
+		"StorePlanFile plan plan",
+		"StorePlanFile plan.terraform.lock.hcl plan.terraform.lock.hcl",
+	}, commandStrings)
 }
 
 func allCommandsInOrderWithParams(terraformExecutor *MockTerraformExecutor, commandRunner *MockCommandRunner, prManager *MockPRManager, lock *MockProjectLock, planStorage *MockPlanStorage, planPathProvider *MockPlanPathProvider) []string {

--- a/docs/ce/howto/plan-artifacts.mdx
+++ b/docs/ce/howto/plan-artifacts.mdx
@@ -5,6 +5,21 @@ title: "Plan artifacts"
 Digger can be used to store plan artifacts during the plan phase and make them available for use during the apply phase. Once plan artifacts are configured and uploaded during the plan phase
 they will automatically be used during the apply phase. Once one of the below artifacts is configured successfully there is no additional configuration needed on your end to achieve apply-time artifact reuse.
 
+### Optional lock file artifact
+
+When plan artifacts are enabled, Digger can also store a dependency lock file alongside the saved plan and restore it before apply-time plan inspection and apply. This is useful when provider caching is enabled and Terraform or OpenTofu may update a lock file in the plan job that is not present in the later apply job.
+
+For Terraform, set `upload-plan-lock-file` to `.terraform.lock.hcl`:
+
+```
+with:
+    upload-plan-destination: 'aws'
+    upload-plan-destination-s3-bucket: 'terraform-plan-output-1239123'
+    upload-plan-lock-file: '.terraform.lock.hcl'
+```
+
+Outside of the GitHub Action input, set `PLAN_UPLOAD_LOCK_FILE` to the lock file path relative to each project directory. The value defaults to empty, so Digger does not store an additional lock artifact unless you opt in. When this is set, the lock file must exist after the plan step and must be available from plan storage during apply.
+
 ### Github 
 Digger can use Github Artifacts to store `terraform plan` outputs. In order to enable it you can set the following argument in digger_workflow.yml:
 
@@ -15,10 +30,6 @@ upload-plan-destination: github
 <Warning>
     Github plan artifacts as a destination is currently deprecated due to a change in Github API. For more information see [this issue](https://github.com/diggerhq/digger/issues/1702).
 </Warning>
-
-<Alert>
-    sadfasdf
-</Alert>
 
 ### GCP 
 You can also configure plan outputs to be uploaded to GCP Buckets instead. This is handy in case you want your plan outputs to stay within your organisation's approved storage providers for security or compliance reasons.

--- a/docs/ce/reference/action-inputs.mdx
+++ b/docs/ce/reference/action-inputs.mdx
@@ -86,6 +86,10 @@ inputs:
   upload-plan-destination:
     description: Destination to upload the plan to. azure, gcp, github and aws are currently supported.
     required: false
+  upload-plan-lock-file:
+    description: Optional dependency lock file to store and restore with plan artifacts, relative to each project directory. For Terraform use .terraform.lock.hcl.
+    required: false
+    default: ''
   upload-plan-destination-s3-bucket:
     description: Name of the destination bucket for AWS S3. Should be provided if destination == aws
     required: false

--- a/docs/ce/reference/terraform.lock.mdx
+++ b/docs/ce/reference/terraform.lock.mdx
@@ -4,10 +4,12 @@ title: "handling terraform.lock file"
 
 The `.terraform.lock.hcl` file is an important part of Terraform's dependency management system.
 Digger does not currently take opinions on how you manage .terraform.lock files however please be aware that since digger runs terraform
- within ephemeral jobs that if terraform.lock file gets updated within a job its not going to be commited back to the PR.
+ within ephemeral jobs that if terraform.lock file gets updated within a job its not going to be committed back to the PR.
  Having said that, digger does not pass any `-upgrade` flag during init flag currently. Therefore it is recommended that you use semantic versions
- in your terraform providers and commit .terraform.local file manually. Then when updating versions of providers you can run another `terraform init -upgrade` file to update the file again,
+ in your terraform providers and commit `.terraform.lock.hcl` manually. Then when updating versions of providers you can run another `terraform init -upgrade` file to update the file again,
  then commit it to the PR where you are upgrading provider versions.
+
+ If you use plan artifact storage and need Digger to carry a generated lock file from the plan job into the apply job, set the `upload-plan-lock-file` action input or the `PLAN_UPLOAD_LOCK_FILE` environment variable to the lock file path, for example `.terraform.lock.hcl`. The setting defaults to empty, so Digger only stores lock files when you opt in. When this is enabled, Digger expects the file to exist after plan and to be restorable before apply.
 
  Here are some general best practices for working with this file:
 

--- a/libs/execution/execution.go
+++ b/libs/execution/execution.go
@@ -137,7 +137,9 @@ func (d DiggerExecutorResult) GetTerraformSummary() iac_utils.IacSummary {
 
 type PlanPathProvider interface {
 	LocalPlanFilePath() string
+	LocalPlanLockFilePath(lockFilePath string) string
 	StoredPlanFilePath() string
+	StoredPlanLockFilePath(lockFilePath string) string
 	ArtifactName() string
 }
 
@@ -179,6 +181,10 @@ func (d DiggerExecutor) RetrievePlanJson() (string, error) {
 		storedPlanPath, err := planStorage.RetrievePlan(planPathProvider.LocalPlanFilePath(), planPathProvider.ArtifactName(), planPathProvider.StoredPlanFilePath())
 		if err != nil {
 			return "", fmt.Errorf("failed to retrieve stored plan path. %v", err)
+		}
+		err = executor.retrievePlanLockFile()
+		if err != nil {
+			return "", err
 		}
 
 		// Running terraform init to load provider
@@ -339,6 +345,11 @@ func (d DiggerExecutor) postProcessPlan(stdout string) (string, string, *iac_uti
 			return "", "", nil, false, fmt.Errorf("error storing artifact file: %v", err)
 
 		}
+
+		err = d.storePlanLockFile()
+		if err != nil {
+			return "", "", nil, false, err
+		}
 	}
 
 	// TODO: move this function to iacUtils interface and implement for pulumi
@@ -369,6 +380,10 @@ func (d DiggerExecutor) Apply() (*iac_utils.IacSummary, bool, string, error) {
 		plansFilename, err = d.PlanStorage.RetrievePlan(d.PlanPathProvider.LocalPlanFilePath(), d.PlanPathProvider.ArtifactName(), d.PlanPathProvider.StoredPlanFilePath())
 		if err != nil {
 			return nil, false, "", fmt.Errorf("error retrieving plan: %v", err)
+		}
+		err = d.retrievePlanLockFile()
+		if err != nil {
+			return nil, false, "", err
 		}
 	}
 

--- a/libs/execution/plan_lock_file.go
+++ b/libs/execution/plan_lock_file.go
@@ -1,0 +1,132 @@
+package execution
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const planLockFileEnvVar = "PLAN_UPLOAD_LOCK_FILE"
+
+func (d ProjectPathProvider) LocalPlanLockFilePath(lockFilePath string) string {
+	return filepath.Join(d.ProjectPath, filepath.FromSlash(normalizePlanLockFilePath(lockFilePath)))
+}
+
+func (d ProjectPathProvider) StoredPlanLockFilePath(lockFilePath string) string {
+	storedPlanPath := d.StoredPlanFilePath()
+	storedPlanExtension := path.Ext(storedPlanPath)
+	storedPlanBase := strings.TrimSuffix(storedPlanPath, storedPlanExtension)
+	lockFileName := path.Base(normalizePlanLockFilePath(lockFilePath))
+	lockFileName = strings.TrimLeft(lockFileName, ".")
+	if lockFileName == "" {
+		lockFileName = "lock"
+	}
+	return storedPlanBase + "." + lockFileName
+}
+
+func PlanLockFilePath() string {
+	return normalizePlanLockFilePath(os.Getenv(planLockFileEnvVar))
+}
+
+func ValidatePlanLockFilePath(lockFilePath string) error {
+	lockFilePath = normalizePlanLockFilePath(lockFilePath)
+	if lockFilePath == "" {
+		return nil
+	}
+	if path.IsAbs(lockFilePath) || filepath.IsAbs(lockFilePath) {
+		return fmt.Errorf("%s must be relative to the project directory", planLockFileEnvVar)
+	}
+	if lockFilePath == "." || lockFilePath == ".." || strings.HasPrefix(lockFilePath, "../") {
+		return fmt.Errorf("%s must not escape the project directory", planLockFileEnvVar)
+	}
+	return nil
+}
+
+func normalizePlanLockFilePath(lockFilePath string) string {
+	lockFilePath = strings.TrimSpace(lockFilePath)
+	if lockFilePath == "" {
+		return ""
+	}
+	lockFilePath = strings.ReplaceAll(lockFilePath, "\\", "/")
+	return path.Clean(lockFilePath)
+}
+
+func (d DiggerExecutor) storePlanLockFile() error {
+	lockFilePath := PlanLockFilePath()
+	if lockFilePath == "" {
+		return nil
+	}
+	if err := ValidatePlanLockFilePath(lockFilePath); err != nil {
+		return err
+	}
+
+	localLockFilePath := d.PlanPathProvider.LocalPlanLockFilePath(lockFilePath)
+	fileBytes, err := os.ReadFile(localLockFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading plan lock file %q: %v", localLockFilePath, err)
+	}
+
+	storedPlanLockFilePath := d.PlanPathProvider.StoredPlanLockFilePath(lockFilePath)
+	err = d.PlanStorage.StorePlanFile(fileBytes, storedPlanLockFilePath, storedPlanLockFilePath)
+	if err != nil {
+		return fmt.Errorf("error storing plan lock file %q: %v", storedPlanLockFilePath, err)
+	}
+
+	return nil
+}
+
+func (d DiggerExecutor) retrievePlanLockFile() error {
+	lockFilePath := PlanLockFilePath()
+	if lockFilePath == "" {
+		return nil
+	}
+	if err := ValidatePlanLockFilePath(lockFilePath); err != nil {
+		return err
+	}
+
+	localLockFilePath := d.PlanPathProvider.LocalPlanLockFilePath(lockFilePath)
+	localLockFileDir := filepath.Dir(localLockFilePath)
+	if err := os.MkdirAll(localLockFileDir, 0755); err != nil {
+		return fmt.Errorf("error creating plan lock file directory %q: %v", localLockFileDir, err)
+	}
+
+	storedPlanLockFilePath := d.PlanPathProvider.StoredPlanLockFilePath(lockFilePath)
+	localStoredPlanLockFilePath := localStoredPlanLockFilePath(d.PlanPathProvider, lockFilePath)
+	if err := os.MkdirAll(filepath.Dir(localStoredPlanLockFilePath), 0755); err != nil {
+		return fmt.Errorf("error creating stored plan lock file directory %q: %v", filepath.Dir(localStoredPlanLockFilePath), err)
+	}
+
+	retrievedPlanLockFilePath, err := d.PlanStorage.RetrievePlan(localStoredPlanLockFilePath, storedPlanLockFilePath, storedPlanLockFilePath)
+	if err != nil {
+		return fmt.Errorf("error retrieving plan lock file %q: %v", storedPlanLockFilePath, err)
+	}
+	if retrievedPlanLockFilePath == nil || *retrievedPlanLockFilePath == "" {
+		return fmt.Errorf("error retrieving plan lock file %q: no file was returned", storedPlanLockFilePath)
+	}
+
+	if filepath.Clean(*retrievedPlanLockFilePath) == filepath.Clean(localLockFilePath) {
+		return nil
+	}
+
+	fileBytes, err := os.ReadFile(*retrievedPlanLockFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading retrieved plan lock file %q: %v", *retrievedPlanLockFilePath, err)
+	}
+	if err := os.WriteFile(localLockFilePath, fileBytes, 0644); err != nil {
+		return fmt.Errorf("error writing plan lock file %q: %v", localLockFilePath, err)
+	}
+
+	return nil
+}
+
+func localStoredPlanLockFilePath(planPathProvider PlanPathProvider, lockFilePath string) string {
+	localPlanFilePath := planPathProvider.LocalPlanFilePath()
+	storedPlanFilePath := planPathProvider.StoredPlanFilePath()
+	storedPlanLockFilePath := planPathProvider.StoredPlanLockFilePath(lockFilePath)
+	if strings.HasSuffix(localPlanFilePath, storedPlanFilePath) {
+		return strings.TrimSuffix(localPlanFilePath, storedPlanFilePath) + storedPlanLockFilePath
+	}
+	return filepath.Join(filepath.Dir(localPlanFilePath), storedPlanLockFilePath)
+}

--- a/libs/execution/plan_lock_file_test.go
+++ b/libs/execution/plan_lock_file_test.go
@@ -1,0 +1,32 @@
+package execution
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectPathProviderPlanLockFilePaths(t *testing.T) {
+	prNumber := 123
+	provider := ProjectPathProvider{
+		PRNumber:         &prNumber,
+		ProjectPath:      "projects/app",
+		ProjectNamespace: "prod/aws",
+		ProjectName:      "network",
+	}
+
+	assert.Equal(t, "projects/app/.terraform.lock.hcl", provider.LocalPlanLockFilePath(".terraform.lock.hcl"))
+	assert.Equal(t, "prod-aws-123-network.terraform.lock.hcl", provider.StoredPlanLockFilePath(".terraform.lock.hcl"))
+	assert.Equal(t, "prod-aws-123-network.tofu.lock.hcl", provider.StoredPlanLockFilePath("locks/tofu.lock.hcl"))
+	assert.Equal(t, "projects/app/prod-aws-123-network.terraform.lock.hcl", localStoredPlanLockFilePath(provider, ".terraform.lock.hcl"))
+}
+
+func TestValidatePlanLockFilePath(t *testing.T) {
+	assert.NoError(t, ValidatePlanLockFilePath(".terraform.lock.hcl"))
+	assert.NoError(t, ValidatePlanLockFilePath("locks/tofu.lock.hcl"))
+	assert.Error(t, ValidatePlanLockFilePath("/tmp/.terraform.lock.hcl"))
+	assert.Error(t, ValidatePlanLockFilePath("../.terraform.lock.hcl"))
+	assert.Error(t, ValidatePlanLockFilePath("locks/../../.terraform.lock.hcl"))
+	assert.Error(t, ValidatePlanLockFilePath(`locks\..\..\.terraform.lock.hcl`))
+	assert.Error(t, ValidatePlanLockFilePath(".."))
+}


### PR DESCRIPTION
AI usage: Codex CLI generated code with model GPT-5; separate [AI Review](https://github.com/cursor/plugins/blob/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md) followed by manual review.

## Summary

Closes #2663.

Adds opt-in lock file persistence for stored plan artifacts via the `upload-plan-lock-file` action input and `PLAN_UPLOAD_LOCK_FILE` environment variable.

When configured, Digger now stores the configured lock file after plan artifact upload, restores it before apply-side stored-plan inspection/apply flows, and deletes the sibling lock artifact during stored-plan unlock cleanup. The lock artifact uses a deterministic sibling key separate from the main plan artifact so GitHub artifact storage does not confuse the plan and lock file.

Docs and tests were updated for the new action input/env var.

## Testing

- `go test ./execution`
- `go test ./pkg/digger`
- `go test ./cmd/digger ./pkg/digger ./pkg/drift ./pkg/github ./pkg/usage`
- `go test ./execution ./iac_utils ./storage ./scheduler ./spec ./digger_config ./digger_config/terragrunt/tac`
- `go test ./...` in `ee/cli`
- `npm_config_cache=/tmp/npm-cache-digger npm run build` in `docs`
- `git diff --check`
