### PR TITLE
fix: multi-project auto-merge never triggers (GetImpactedProjectSingle ignores project name)

### DIFF
--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -788,7 +788,15 @@ func (d DiggerController) SetJobStatusForProject(c *gin.Context) {
 			if batch.BatchType == orchestrator_scheduler.DiggerCommandApply {
 				impactedProjectDb.Applied = true
 			}
-			models.DB.GormDB.Save(impactedProjectDb)
+			if err := models.DB.GormDB.Save(impactedProjectDb).Error; err != nil {
+				slog.Error("Failed to persist impacted project status, auto-merge may not trigger",
+					"jobId", jobId,
+					"projectName", job.ProjectName,
+					"commitSha", commitSha,
+					"repoFullName", batch.RepoFullName,
+					"error", err,
+				)
+			}
 		}
 
 		var prCommentId *int64

--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -778,7 +778,7 @@ func (d DiggerController) SetJobStatusForProject(c *gin.Context) {
 		commitSha := batch.CommitSha
 		impactedProjectDb, err := models.DB.GetImpactedProjectSingle(batch.RepoFullName, commitSha, job.ProjectName)
 		if err != nil {
-			slog.Warn("Error fetching impacted project db", "jobId", jobId, "error", err, "commitSha", commitSha, "repoFullName", batch.RepoFullName)
+			slog.Error("Error fetching impacted project db, auto-merge may not trigger", "jobId", jobId, "projectName", job.ProjectName, "error", err, "commitSha", commitSha, "repoFullName", batch.RepoFullName)
 		} else if impactedProjectDb == nil && err == nil {
 			slog.Warn("Impacted project entry not found in db (maybe it was not synced in event start)", "jobId", jobId, "error", err, "commitSha", commitSha, "repoFullName", batch.RepoFullName)
 		} else {

--- a/backend/models/storage.go
+++ b/backend/models/storage.go
@@ -772,12 +772,12 @@ func (db *Database) GetImpactedProjects(repoFullName string, commitSha string) (
 
 func (db *Database) GetImpactedProjectSingle(repoFullName string, commitSha string, projectName string) (*ImpactedProject, error) {
 	var impactedProject ImpactedProject
-	err := db.GormDB.Where("repo_full_name=? AND commit_sha = ?", repoFullName, commitSha).Find(&impactedProject).Error
+	err := db.GormDB.Where("repo_full_name = ? AND commit_sha = ? AND project_name = ?", repoFullName, commitSha, projectName).First(&impactedProject).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		slog.Error("failed to get impacted projects", "error", err, "repoFullName", repoFullName, "commitSha", commitSha)
+		slog.Error("failed to get impacted project", "error", err, "repoFullName", repoFullName, "commitSha", commitSha, "projectName", projectName)
 		return nil, err
 	}
 	return &impactedProject, nil

--- a/backend/models/storage_test.go
+++ b/backend/models/storage_test.go
@@ -268,3 +268,94 @@ func TestDiggerLockFunctionalities(t *testing.T) {
 	assert.Equal(t, "org/repo2#dev", existingLocksAfterDeletion[0].Resource)
 	assert.Equal(t, "org/repo2#prod", existingLocksAfterDeletion[1].Resource)
 }
+
+// setupImpactedSuite provisions an isolated DB migrating only ImpactedProject.
+// It deliberately avoids the shared setupSuite because the Project and
+// ImpactedProject models both declare a gorm index named "idx_org_repo", which
+// collides under SQLite (global index namespace) during a combined AutoMigrate.
+// Production schema is managed by Atlas migrations, not AutoMigrate.
+func setupImpactedSuite(tb testing.TB) (func(tb testing.TB), *Database) {
+	dbName := "database_impacted_test.db"
+	if e := os.Remove(dbName); e != nil && !strings.Contains(e.Error(), "no such file or directory") {
+		panic(e)
+	}
+
+	gdb, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		panic(err)
+	}
+	if err = gdb.AutoMigrate(&ImpactedProject{}); err != nil {
+		panic(err)
+	}
+	database := &Database{GormDB: gdb}
+	DB = database
+	return func(tb testing.TB) {
+		if e := os.Remove(dbName); e != nil {
+			panic(e)
+		}
+	}, database
+}
+
+func TestGetImpactedProjectSingleReturnsRequestedProject(t *testing.T) {
+	teardownSuite, db := setupImpactedSuite(t)
+	defer teardownSuite(t)
+
+	repo := "acme/infra"
+	sha := "abc123"
+	projects := []string{"projectA", "projectB", "projectC"}
+
+	for _, name := range projects {
+		_, err := db.CreateImpactedProject(repo, sha, name, nil, nil)
+		assert.NoError(t, err)
+	}
+
+	for _, name := range projects {
+		ip, err := db.GetImpactedProjectSingle(repo, sha, name)
+		assert.NoError(t, err)
+		assert.NotNil(t, ip)
+		assert.Equal(t, name, ip.ProjectName)
+	}
+}
+
+func TestGetImpactedProjectSingleNotFound(t *testing.T) {
+	teardownSuite, db := setupImpactedSuite(t)
+	defer teardownSuite(t)
+
+	ip, err := db.GetImpactedProjectSingle("acme/infra", "abc123", "missing")
+	assert.NoError(t, err)
+	assert.Nil(t, ip)
+}
+
+// Regression test for multi-project auto_merge: each project's apply must flip its
+// own Applied flag so AllImpactedProjectApplied can reach true for N>1 projects.
+func TestAllImpactedProjectAppliedMultiProject(t *testing.T) {
+	teardownSuite, db := setupImpactedSuite(t)
+	defer teardownSuite(t)
+
+	repo := "acme/infra"
+	sha := "abc123"
+	projects := []string{"projectA", "projectB", "projectC"}
+
+	for _, name := range projects {
+		_, err := db.CreateImpactedProject(repo, sha, name, nil, nil)
+		assert.NoError(t, err)
+	}
+
+	allApplied, _, err := db.AllImpactedProjectApplied(repo, sha)
+	assert.NoError(t, err)
+	assert.False(t, allApplied)
+
+	for _, name := range projects {
+		ip, err := db.GetImpactedProjectSingle(repo, sha, name)
+		assert.NoError(t, err)
+		ip.Applied = true
+		assert.NoError(t, db.GormDB.Save(ip).Error)
+	}
+
+	allApplied, applied, err := db.AllImpactedProjectApplied(repo, sha)
+	assert.NoError(t, err)
+	assert.Len(t, applied, len(projects))
+	assert.True(t, allApplied)
+}


### PR DESCRIPTION
## Current issue

Auto-merge works for single-project PRs but never fires for any PR touching 2+ projects. Closes #2665.

`GetImpactedProjectSingle` (`backend/models/storage.go`) accepts a `projectName` argument but never uses it in the query — it filters only on `repo_full_name` + `commit_sha` and uses `.Find()`, so it returns the *first* impacted-project row regardless of which project was requested.

As a result, when each project's apply job succeeds (`backend/controllers/projects.go`), every handler flips `Applied = true` on the same (first) row. The other projects' rows stay `Applied = false`, so `AllImpactedProjectApplied` never returns `true` and the auto-merge condition is never met.

## Fix

Filter `GetImpactedProjectSingle` by `project_name` and switch `.Find()` → `.First()`, translating `gorm.ErrRecordNotFound` to `(nil, nil)` to preserve the caller's existing not-found contract. Each project's apply now updates its own row, so multi-project PRs auto-merge as intended.

While in this path, two adjacent silent failures are also surfaced (each in its own commit):
- The `Save` of the impacted-project status no longer drops its error.
- A failed impacted-project fetch is now logged at `error` (was `warn`), since it can silently block auto-merge.

## Changes

- `backend/models/storage.go` — `GetImpactedProjectSingle` filters by project name and uses `.First()` with not-found handling (core fix).
- `backend/controllers/projects.go` — log the previously dropped error when persisting impacted-project status.
- `backend/controllers/projects.go` — elevate the impacted-project fetch error from `warn` to `error`, since it can silently block auto-merge.
- `backend/models/storage_test.go` — regression tests (correct-row lookup, not-found, end-to-end multi-project applied). Uses an isolated test DB because `Project` and `ImpactedProject` both declare a gorm index named `idx_org_repo`, which collides under SQLite's global index namespace (production schema is Atlas-managed, so unaffected).

### :brain: **Ai UsageDetails (if applicable):**

This PR was written primarily by Claude Code (claude-opus-4-8). Specifically, the AI:
- Diagnosed the root cause and reproduced it with a failing test before fixing.
- Implemented the core fix to `GetImpactedProjectSingle` plus the regression tests.
- Ran a multi-perspective code review and, based on its findings, applied two additional follow-up fixes for adjacent silent failures in the same code path (the dropped `Save` error and the warn-level fetch error that can block auto-merge), each committed separately.

All changes were reviewed and verified by the author.