### PR TITLE
fix: include project name in Plan output and Plan summary comment titles

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -315,7 +315,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			return nil, msg, fmt.Errorf("%s", msg)
 		} else if planPerformed {
 			if isNonEmptyPlan {
-				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
+				reportTerraformPlanOutput(reporter, job.ProjectName, plan)
 
 				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, approvalTeams, planJsonOutput)
 				if err != nil {
@@ -356,7 +356,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					if err != nil {
 						slog.Error("Failed to report plan.", "error", err)
 					}
-					reportPlanSummary(reporter, planSummary)
+					reportPlanSummary(reporter, job.ProjectName, planSummary)
 
 					if err := reporting.FormatAndReportExampleCommands(job.ProjectName, reporter); err != nil {
 						slog.Error("Failed to report example commands.", "error", err)
@@ -592,13 +592,14 @@ func reportApplyMergeabilityError(reporter reporting.Reporter) string {
 	return comment
 }
 
-func reportTerraformPlanOutput(reporter reporting.Reporter, projectId string, plan string) {
+func reportTerraformPlanOutput(reporter reporting.Reporter, projectName string, plan string) {
 	var formatter func(string) string
+	summary := fmt.Sprintf("Plan output (%v)", projectName)
 
 	if reporter.SupportsMarkdown() {
-		formatter = reporting.GetTerraformOutputAsCollapsibleComment("Plan output", true)
+		formatter = reporting.GetTerraformOutputAsCollapsibleComment(summary, true)
 	} else {
-		formatter = reporting.GetTerraformOutputAsComment("Plan output")
+		formatter = reporting.GetTerraformOutputAsComment(summary)
 	}
 
 	_, _, err := reporter.Report(plan, formatter)
@@ -607,13 +608,14 @@ func reportTerraformPlanOutput(reporter reporting.Reporter, projectId string, pl
 	}
 }
 
-func reportPlanSummary(reporter reporting.Reporter, summary string) {
+func reportPlanSummary(reporter reporting.Reporter, projectName string, summary string) {
 	var formatter func(string) string
+	title := fmt.Sprintf("Plan summary (%v)", projectName)
 
 	if reporter.SupportsMarkdown() {
-		formatter = reporting.AsCollapsibleComment("Plan summary", false)
+		formatter = reporting.AsCollapsibleComment(title, false)
 	} else {
-		formatter = reporting.AsComment("Plan summary")
+		formatter = reporting.AsComment(title)
 	}
 
 	_, _, err := reporter.Report("\n"+summary, formatter)


### PR DESCRIPTION
## Summary

Fixes #2669.

In backendless mode, when multiple projects are impacted by a single PR, all reports are appended to one "Digger run report" comment (via `CommentPerRunStrategy`). The `Plan output` and `Plan summary` section titles were hardcoded without the project name, while the `Terraform plan validation check` section already included it (`Terraform plan validation check (<project>)`). This made it impossible to tell which `Plan output` / `Plan summary` section belonged to which project when a PR touched more than one project.

This PR makes `Plan output` and `Plan summary` include the project name too, consistent with the validation check section:

```
Plan output (env_dev)
Terraform plan validation check (env_dev)
Plan summary (env_dev)
Instructions
Plan output (env_prd)
Terraform plan validation check (env_prd)
Plan summary (env_prd)
Instructions
```

## Changes

- `reportTerraformPlanOutput` now takes the project name and includes it in the `Plan output (<project>)` title.
- `reportPlanSummary` now takes the project name and includes it in the `Plan summary (<project>)` title.
- Call sites updated to pass `job.ProjectName` (previously `reportTerraformPlanOutput` received `projectLock.LockId()`, which was unused for the title).

## Test plan

- [x] `go build ./...` and `go vet ./pkg/digger/` pass in `cli/`
- [x] `go test ./pkg/digger/...` passes in `cli/`
- [x] Verified end-to-end against a real GitHub PR in backendless mode using a throwaway public repo ([kangaechu/digger-test#1](https://github.com/kangaechu/digger-test/pull/1)) with two `null_resource` projects (`env_dev`, `env_prd`). Confirmed the posted comment shows `Plan output (env_dev)` / `Plan output (env_prd)` and `Plan summary (env_dev)` / `Plan summary (env_prd)` as expected.

### :brain: **Ai UsageDetails (if applicable):**

Used Claude Code to investigate the root cause, implement the fix, and verify it end-to-end against a live test repository. Diff reviewed and verified manually.
