### PR TITLE
fix: split PR comments exceeding the VCS size limit (#1645)

### DIFF
--- a/cli/pkg/drift/github_issue.go
+++ b/cli/pkg/drift/github_issue.go
@@ -1,56 +1,59 @@
 package drift
 
 import (
-    "fmt"
-    orchestrator "github.com/diggerhq/digger/libs/ci"
-    "github.com/samber/lo"
-    "log"
+	"fmt"
+	"log"
+
+	orchestrator "github.com/diggerhq/digger/libs/ci"
+	"github.com/diggerhq/digger/libs/comment_utils/reporting"
+	"github.com/samber/lo"
 )
 
 type GithubIssueNotification struct {
-    GithubService   *orchestrator.PullRequestService
-    RelatedPrNumber *int64
+	GithubService   *orchestrator.PullRequestService
+	RelatedPrNumber *int64
 }
 
 func (ghi *GithubIssueNotification) SendNotificationForProject(projectName string, repoFullName string, plan string) error {
-    log.Printf("Info: Sending drift notification regarding project: %v", projectName)
-    title := fmt.Sprintf("Drift detected in project: %v", projectName)
-    message := fmt.Sprintf(":bangbang: Drift detected in digger project %v details below: \n\n```\n%v\n```", projectName, plan)
-    const maxLen = 65536
-    const truncMsg = "\n\n> ⚠️ Output truncated: plan exceeds GitHub's 65536 character limit. See job logs for full output."
-    if len(message) > maxLen {
-        message = message[:maxLen-len(truncMsg)] + truncMsg
-    }
-    existingIssues, err := (*ghi.GithubService).ListIssues()
-    if err != nil {
-        log.Printf("failed to retrieve issues: %v", err)
-        return fmt.Errorf("failed to retrieve issues: %v", err)
-    }
+	log.Printf("Info: Sending drift notification regarding project: %v", projectName)
+	title := fmt.Sprintf("Drift detected in project: %v", projectName)
+	message := fmt.Sprintf(":bangbang: Drift detected in digger project %v details below: \n\n```\n%v\n```", projectName, plan)
 
-    theIssue, exists := lo.Find(existingIssues, func(item *orchestrator.Issue) bool {
-        return item.Title == title
-    })
-    if exists {
-        _, err := (*ghi.GithubService).UpdateIssue(theIssue.ID, theIssue.Title, message)
-        if err != nil {
-            log.Printf("error while updating issue: %v", err)
-        }
-        return err
-    } else {
-        labels := []string{"digger"}
-        _, err := (*ghi.GithubService).PublishIssue(title, message, &labels)
-        if err != nil {
-            log.Printf("error while publishing issue: %v", err)
-        }
-        return err
-    }
+	// issue bodies share the comment size limit; an issue cannot be split
+	// into a chain, so cap to a single chunk: SplitComment truncates the
+	// head, keeps the tail with the plan summary and closes any markdown
+	// structure left open at the truncation point
+	message = reporting.SplitComment(message, reporting.CommentMaxSize(*ghi.GithubService), 1)[0]
+
+	existingIssues, err := (*ghi.GithubService).ListIssues()
+	if err != nil {
+		log.Printf("failed to retrieve issues: %v", err)
+		return fmt.Errorf("failed to retrieve issues: %v", err)
+	}
+
+	theIssue, exists := lo.Find(existingIssues, func(item *orchestrator.Issue) bool {
+		return item.Title == title
+	})
+	if exists {
+		_, err := (*ghi.GithubService).UpdateIssue(theIssue.ID, theIssue.Title, message)
+		if err != nil {
+			log.Printf("error while updating issue: %v", err)
+		}
+		return err
+	} else {
+		labels := []string{"digger"}
+		_, err := (*ghi.GithubService).PublishIssue(title, message, &labels)
+		if err != nil {
+			log.Printf("error while publishing issue: %v", err)
+		}
+		return err
+	}
 }
 
 func (ghi *GithubIssueNotification) SendErrorNotificationForProject(projectName string, repoFullName string, err error) error {
-    return nil
+	return nil
 }
 
 func (ghi *GithubIssueNotification) Flush() error {
-    return nil
+	return nil
 }
-

--- a/cli/pkg/drift/github_issue_test.go
+++ b/cli/pkg/drift/github_issue_test.go
@@ -1,0 +1,103 @@
+package drift
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/diggerhq/digger/libs/ci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockIssueService implements only the issue-related methods the drift
+// notification uses; any other call panics via the embedded nil interface.
+type mockIssueService struct {
+	ci.PullRequestService
+	issues    []*ci.Issue
+	published map[string]string
+	updated   map[int64]string
+}
+
+func (m *mockIssueService) ListIssues() ([]*ci.Issue, error) {
+	return m.issues, nil
+}
+
+func (m *mockIssueService) PublishIssue(title string, body string, labels *[]string) (int64, error) {
+	m.published[title] = body
+	return 1, nil
+}
+
+func (m *mockIssueService) UpdateIssue(ID int64, title string, body string) (int64, error) {
+	m.updated[ID] = body
+	return ID, nil
+}
+
+func newMockIssueService(issues ...*ci.Issue) *mockIssueService {
+	return &mockIssueService{
+		issues:    issues,
+		published: map[string]string{},
+		updated:   map[int64]string{},
+	}
+}
+
+// fencesBalanced counts line-anchored code fences the way GitHub renders them
+func fencesBalanced(body string) bool {
+	open := false
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		if len(line)-len(trimmed) <= 3 && strings.HasPrefix(trimmed, "```") {
+			open = !open
+		}
+	}
+	return !open
+}
+
+func TestDriftIssueSmallPlanUnchanged(t *testing.T) {
+	mock := newMockIssueService()
+	var svc ci.PullRequestService = mock
+	ghi := GithubIssueNotification{GithubService: &svc}
+
+	err := ghi.SendNotificationForProject("prod/vpc", "org/repo", "  + resource change")
+	require.NoError(t, err)
+
+	body := mock.published["Drift detected in project: prod/vpc"]
+	assert.Contains(t, body, "  + resource change")
+	assert.NotContains(t, body, "[!WARNING]")
+	assert.True(t, fencesBalanced(body))
+}
+
+func TestDriftIssueOversizedPlanTruncatedKeepingTail(t *testing.T) {
+	mock := newMockIssueService()
+	var svc ci.PullRequestService = mock
+	ghi := GithubIssueNotification{GithubService: &svc}
+
+	tail := "Plan: 7 to add, 3 to change, 1 to destroy."
+	plan := strings.Repeat("  + resource \"aws_instance\" \"drift\" { ami = \"ami-123\" }\n", 2000) + tail // ~110KB
+
+	err := ghi.SendNotificationForProject("prod/vpc", "org/repo", plan)
+	require.NoError(t, err)
+
+	body := mock.published["Drift detected in project: prod/vpc"]
+	require.NotEmpty(t, body)
+	assert.LessOrEqual(t, len(body), 65536, "issue body must fit GitHub's limit")
+	assert.True(t, strings.HasSuffix(body, tail+"\n```"), "plan tail with the summary must survive truncation")
+	assert.Contains(t, body, "[!WARNING]", "truncation must be announced")
+	assert.Truef(t, fencesBalanced(body), "truncated body must keep fences balanced")
+}
+
+func TestDriftIssueOversizedPlanOnExistingIssue(t *testing.T) {
+	existing := &ci.Issue{ID: 42, Title: "Drift detected in project: prod/vpc", Body: "old"}
+	mock := newMockIssueService(existing)
+	var svc ci.PullRequestService = mock
+	ghi := GithubIssueNotification{GithubService: &svc}
+
+	plan := strings.Repeat("  ~ update line\n", 6000) + "Plan: 1 to change." // ~96KB
+	err := ghi.SendNotificationForProject("prod/vpc", "org/repo", plan)
+	require.NoError(t, err)
+
+	body := mock.updated[42]
+	require.NotEmpty(t, body)
+	assert.LessOrEqual(t, len(body), 65536)
+	assert.True(t, fencesBalanced(body))
+	assert.Empty(t, mock.published, "existing issue must be updated, not duplicated")
+}

--- a/cli/pkg/integration/bitbucket_comment_splitting_test.go
+++ b/cli/pkg/integration/bitbucket_comment_splitting_test.go
@@ -1,0 +1,142 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diggerhq/digger/libs/ci/bitbucket"
+	"github.com/diggerhq/digger/libs/comment_utils/reporting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bitbucket twin of the GitHub comment splitting tests. Bitbucket Cloud's
+// 32,768-character limit is small enough to hit genuinely, so no size
+// override is needed — an ~80KB report forces a real split against the real
+// limit. Digger treats Bitbucket as not supporting markdown, so these tests
+// exercise the plain (non-collapsible) formatting path.
+//
+// Required environment variables (tests are skipped when unset):
+//
+//	DIGGER_INTEGRATION_BITBUCKET_TOKEN      repository access token (Bearer)
+//	DIGGER_INTEGRATION_BITBUCKET_WORKSPACE  workspace slug
+//	DIGGER_INTEGRATION_BITBUCKET_REPO       repository name
+//	DIGGER_INTEGRATION_BITBUCKET_PR         an open PR id in that repository
+func setupBitbucketSplittingTest(t *testing.T) (bitbucket.BitbucketAPI, int) {
+	SkipCI(t)
+
+	token := os.Getenv("DIGGER_INTEGRATION_BITBUCKET_TOKEN")
+	workspace := os.Getenv("DIGGER_INTEGRATION_BITBUCKET_WORKSPACE")
+	repo := os.Getenv("DIGGER_INTEGRATION_BITBUCKET_REPO")
+	prStr := os.Getenv("DIGGER_INTEGRATION_BITBUCKET_PR")
+	if token == "" || workspace == "" || repo == "" || prStr == "" {
+		t.Skip("Skipping: DIGGER_INTEGRATION_BITBUCKET_TOKEN, DIGGER_INTEGRATION_BITBUCKET_WORKSPACE, DIGGER_INTEGRATION_BITBUCKET_REPO and DIGGER_INTEGRATION_BITBUCKET_PR must be set")
+	}
+	prNumber, err := strconv.Atoi(prStr)
+	require.NoError(t, err)
+
+	return bitbucket.BitbucketAPI{
+		AuthToken:     token,
+		RepoWorkspace: workspace,
+		RepoName:      repo,
+	}, prNumber
+}
+
+const bitbucketCommentLimit = 32768
+
+func TestBitbucketCommentSplittingMultipleComments(t *testing.T) {
+	svc, prNumber := setupBitbucketSplittingTest(t)
+
+	marker := fmt.Sprintf("digger-1645-bb-multi-%d", time.Now().UnixNano())
+
+	reporter := reporting.CiReporter{
+		CiService:         svc,
+		PrNumber:          prNumber,
+		IsSupportMarkdown: false,
+		ReportStrategy:    reporting.MultipleCommentsStrategy{},
+	}
+
+	plan := fakePlanOutput(marker, 80_000) // ~2.5x the limit
+	_, lastUrl, err := reporter.Report(plan, reporting.GetTerraformOutputAsComment("Plan output"))
+	require.NoError(t, err, "posting an oversized plan must not fail on Bitbucket")
+	assert.NotEmpty(t, lastUrl, "Bitbucket must return the comment url")
+
+	comments, err := svc.GetComments(prNumber)
+	require.NoError(t, err)
+
+	var created []string
+	for _, c := range comments {
+		if c.Body != nil && strings.Contains(*c.Body, marker) {
+			created = append(created, *c.Body)
+		}
+	}
+
+	require.GreaterOrEqual(t, len(created), 3, "80KB plan must be split into at least 3 comments")
+	for i, body := range created {
+		assert.LessOrEqualf(t, len(body), bitbucketCommentLimit, "comment %d exceeds Bitbucket's limit", i)
+	}
+	assert.Contains(t, created[len(created)-1], fmt.Sprintf("Plan: 1 to add, 0 to change, 0 to destroy. [%s]", marker))
+	for i, body := range created[1:] {
+		assert.Containsf(t, body, "[previous comment](https://bitbucket.org/", "comment %d must link back to the previous chunk", i+1)
+	}
+}
+
+func TestBitbucketCommentSplittingPerRunOverflow(t *testing.T) {
+	svc, prNumber := setupBitbucketSplittingTest(t)
+
+	marker := fmt.Sprintf("digger-1645-bb-upsert-%d", time.Now().UnixNano())
+	title := "Digger run report " + marker
+	strategy := reporting.CommentPerRunStrategy{Title: title, TimeOfRun: time.Now()}
+	reporter := reporting.CiReporter{
+		CiService:         svc,
+		PrNumber:          prNumber,
+		IsSupportMarkdown: false,
+		ReportStrategy:    strategy,
+	}
+	formatter := reporting.GetTerraformOutputAsComment("Plan output")
+
+	countTitled := func() []string {
+		comments, err := svc.GetComments(prNumber)
+		require.NoError(t, err)
+		var bodies []string
+		for _, c := range comments {
+			if c.Body != nil && strings.Contains(*c.Body, title) {
+				bodies = append(bodies, *c.Body)
+			}
+		}
+		return bodies
+	}
+
+	// project a fills most of the shared comment
+	_, _, err := reporter.Report(fakePlanOutput(marker+"-project-a", 18_000), formatter)
+	require.NoError(t, err)
+	bodies := countTitled()
+	require.Len(t, bodies, 1)
+
+	// project b does not fit: the shared comment must be left intact and a
+	// continuation created instead of failing
+	_, _, err = reporter.Report(fakePlanOutput(marker+"-project-b", 18_000), formatter)
+	require.NoError(t, err, "overflowing the shared per-run comment must not fail")
+
+	bodies = countTitled()
+	require.Len(t, bodies, 2, "overflow must create a continuation comment")
+	assert.Contains(t, bodies[0], marker+"-project-a")
+	assert.NotContains(t, bodies[0], marker+"-project-b", "existing comment must be left untouched")
+	assert.Contains(t, bodies[1], marker+"-project-b")
+	for i, body := range bodies {
+		assert.LessOrEqualf(t, len(body), bitbucketCommentLimit, "comment %d exceeds Bitbucket's limit", i)
+	}
+
+	// project c is small: it must append to the newest continuation comment
+	_, _, err = reporter.Report("small plan for "+marker+"-project-c", formatter)
+	require.NoError(t, err)
+
+	bodies = countTitled()
+	require.Len(t, bodies, 2, "small report must append, not create another comment")
+	assert.NotContains(t, bodies[0], marker+"-project-c")
+	assert.Contains(t, bodies[1], marker+"-project-c")
+}

--- a/cli/pkg/integration/comment_splitting_test.go
+++ b/cli/pkg/integration/comment_splitting_test.go
@@ -1,0 +1,186 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	dg_github "github.com/diggerhq/digger/libs/ci/github"
+	"github.com/diggerhq/digger/libs/comment_utils/reporting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise comment splitting (issue #1645) against the real
+// GitHub API, which enforces the 65,536-character comment body limit that
+// unit tests cannot reproduce.
+//
+// Required environment variables (the tests are skipped when unset):
+//
+//	GITHUB_TOKEN                   token with write access to the test repo
+//	DIGGER_INTEGRATION_REPO_OWNER  e.g. "my-org"
+//	DIGGER_INTEGRATION_REPO_NAME   a scratch repository name
+//	DIGGER_INTEGRATION_PR          an open PR number in that repository
+func setupCommentSplittingTest(t *testing.T) (dg_github.GithubService, int) {
+	SkipCI(t)
+
+	ghToken := os.Getenv("GITHUB_TOKEN")
+	owner := os.Getenv("DIGGER_INTEGRATION_REPO_OWNER")
+	repo := os.Getenv("DIGGER_INTEGRATION_REPO_NAME")
+	prStr := os.Getenv("DIGGER_INTEGRATION_PR")
+	if ghToken == "" || owner == "" || repo == "" || prStr == "" {
+		t.Skip("Skipping: GITHUB_TOKEN, DIGGER_INTEGRATION_REPO_OWNER, DIGGER_INTEGRATION_REPO_NAME and DIGGER_INTEGRATION_PR must be set")
+	}
+	prNumber, err := strconv.Atoi(prStr)
+	require.NoError(t, err)
+
+	svc, err := dg_github.GithubServiceProviderBasic{}.NewService(ghToken, repo, owner)
+	require.NoError(t, err)
+	return svc, prNumber
+}
+
+// deleteCommentsContaining removes all PR comments carrying marker, so
+// reruns start from a clean slate and the scratch PR does not accumulate
+// megabytes of test output.
+func deleteCommentsContaining(t *testing.T, svc dg_github.GithubService, prNumber int, marker string) {
+	comments, err := svc.GetComments(prNumber)
+	if err != nil {
+		t.Logf("cleanup: could not list comments: %v", err)
+		return
+	}
+	for _, c := range comments {
+		if c.Body != nil && strings.Contains(*c.Body, marker) {
+			if err := svc.DeleteComment(c.Id); err != nil {
+				t.Logf("cleanup: could not delete comment %v: %v", c.Id, err)
+			}
+		}
+	}
+}
+
+// fakePlanOutput builds a synthetic terraform plan of roughly targetSize
+// bytes, tagged with marker on every line and ending with a recognizable
+// plan summary.
+func fakePlanOutput(marker string, targetSize int) string {
+	line := fmt.Sprintf("  + resource \"aws_instance\" \"%s\" { ami = \"ami-0123456789abcdef\" }\n", marker)
+	var sb strings.Builder
+	for sb.Len() < targetSize {
+		sb.WriteString(line)
+	}
+	fmt.Fprintf(&sb, "Plan: 1 to add, 0 to change, 0 to destroy. [%s]", marker)
+	return sb.String()
+}
+
+const githubCommentLimit = 65536
+
+// TestCommentSplittingMultipleCommentsStrategy reproduces the exact failure
+// from issue #1645: a single plan larger than the GitHub comment limit posted
+// through the default (multiple_comments) strategy, formatted the same way
+// cli/pkg/digger reports plan output.
+func TestCommentSplittingMultipleCommentsStrategy(t *testing.T) {
+	svc, prNumber := setupCommentSplittingTest(t)
+
+	marker := fmt.Sprintf("digger-1645-multi-%d", time.Now().UnixNano())
+	defer deleteCommentsContaining(t, svc, prNumber, marker)
+
+	reporter := reporting.CiReporter{
+		CiService:         &svc,
+		PrNumber:          prNumber,
+		IsSupportMarkdown: true,
+		ReportStrategy:    reporting.MultipleCommentsStrategy{},
+	}
+
+	plan := fakePlanOutput(marker, 150_000) // ~2.3x the limit
+	commentId, commentUrl, err := reporter.Report(plan, reporting.GetTerraformOutputAsCollapsibleComment("Plan output", true))
+	require.NoError(t, err, "posting an oversized plan must not fail with 422")
+	assert.NotEmpty(t, commentId)
+	assert.NotEmpty(t, commentUrl)
+
+	comments, err := svc.GetComments(prNumber)
+	require.NoError(t, err)
+
+	var created []string
+	var createdUrls []string
+	for _, c := range comments {
+		if c.Body != nil && strings.Contains(*c.Body, marker) {
+			created = append(created, *c.Body)
+			createdUrls = append(createdUrls, c.Url)
+		}
+	}
+
+	assert.GreaterOrEqual(t, len(created), 3, "150KB plan must be split into at least 3 comments")
+	for i, body := range created {
+		assert.LessOrEqualf(t, len(body), githubCommentLimit, "comment %d exceeds GitHub's limit", i)
+	}
+	// the tail with the plan summary must survive in the last chunk
+	assert.Contains(t, created[len(created)-1], fmt.Sprintf("Plan: 1 to add, 0 to change, 0 to destroy. [%s]", marker))
+	// continuation chunks must link back to the previous chunk's comment
+	for i, body := range created[1:] {
+		assert.Containsf(t, body, fmt.Sprintf("Continued from [previous comment](%s).", createdUrls[i]),
+			"comment %d must link back to the previous chunk", i+1)
+	}
+}
+
+// TestCommentSplittingCommentPerRunOverflow reproduces the append-overflow
+// failure: many projects reporting into a single per-run comment until it
+// cannot hold the next report.
+func TestCommentSplittingCommentPerRunOverflow(t *testing.T) {
+	svc, prNumber := setupCommentSplittingTest(t)
+
+	marker := fmt.Sprintf("digger-1645-upsert-%d", time.Now().UnixNano())
+	defer deleteCommentsContaining(t, svc, prNumber, marker)
+
+	title := "Digger run report " + marker
+	strategy := reporting.CommentPerRunStrategy{Title: title, TimeOfRun: time.Now()}
+	reporter := reporting.CiReporter{
+		CiService:         &svc,
+		PrNumber:          prNumber,
+		IsSupportMarkdown: true,
+		ReportStrategy:    strategy,
+	}
+	formatter := reporting.GetTerraformOutputAsCollapsibleComment("Plan output", false)
+
+	countTitled := func() ([]string, []string) {
+		comments, err := svc.GetComments(prNumber)
+		require.NoError(t, err)
+		var ids, bodies []string
+		for _, c := range comments {
+			if c.Body != nil && strings.Contains(*c.Body, title) {
+				ids = append(ids, c.Id)
+				bodies = append(bodies, *c.Body)
+			}
+		}
+		return ids, bodies
+	}
+
+	// project a fills most of the shared comment
+	_, _, err := reporter.Report(fakePlanOutput(marker+"-project-a", 40_000), formatter)
+	require.NoError(t, err)
+	_, bodies := countTitled()
+	require.Len(t, bodies, 1)
+
+	// project b does not fit any more: before the fix this failed with
+	// "422 Validation Failed: body is too long"
+	_, _, err = reporter.Report(fakePlanOutput(marker+"-project-b", 40_000), formatter)
+	require.NoError(t, err, "overflowing the shared per-run comment must not fail with 422")
+
+	_, bodies = countTitled()
+	require.Len(t, bodies, 2, "overflow must create a continuation comment")
+	assert.Contains(t, bodies[0], marker+"-project-a")
+	assert.NotContains(t, bodies[0], marker+"-project-b", "existing comment must be left untouched")
+	assert.Contains(t, bodies[1], marker+"-project-b")
+	for i, body := range bodies {
+		assert.LessOrEqualf(t, len(body), githubCommentLimit, "comment %d exceeds GitHub's limit", i)
+	}
+
+	// project c is small: it must append to the newest continuation comment
+	_, _, err = reporter.Report("small plan for "+marker+"-project-c", formatter)
+	require.NoError(t, err)
+
+	_, bodies = countTitled()
+	require.Len(t, bodies, 2, "small report must append, not create another comment")
+	assert.NotContains(t, bodies[0], marker+"-project-c")
+	assert.Contains(t, bodies[1], marker+"-project-c")
+}

--- a/cli/pkg/integration/drift_issue_splitting_test.go
+++ b/cli/pkg/integration/drift_issue_splitting_test.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diggerhq/digger/cli/pkg/drift"
+	"github.com/diggerhq/digger/libs/ci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDriftIssueOversizedPlanLive verifies that a drift notification whose
+// plan exceeds GitHub's issue body limit is truncated (tail-preserving,
+// fence-balanced) and accepted by the real API. Reruns update the same
+// issue, so the scratch repo does not accumulate issues.
+func TestDriftIssueOversizedPlanLive(t *testing.T) {
+	svc, _ := setupCommentSplittingTest(t)
+
+	tail := "Plan: 7 to add, 3 to change, 1 to destroy."
+	plan := strings.Repeat("  + resource \"aws_instance\" \"drift\" { ami = \"ami-0123456789abcdef\" }\n", 2000) + tail // ~130KB
+
+	var prService ci.PullRequestService = &svc
+	ghi := drift.GithubIssueNotification{GithubService: &prService}
+	projectName := "integration/drift-test"
+
+	err := ghi.SendNotificationForProject(projectName, "", plan)
+	require.NoError(t, err, "oversized drift plan must not fail to post")
+
+	title := fmt.Sprintf("Drift detected in project: %v", projectName)
+	var found *ci.Issue
+	// the list API lags behind issue creation; poll briefly
+	for attempt := 0; attempt < 5 && found == nil; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
+		issues, err := svc.ListIssues()
+		require.NoError(t, err)
+		for _, issue := range issues {
+			if issue.Title == title {
+				found = issue
+				break
+			}
+		}
+	}
+	require.NotNil(t, found, "drift issue must exist")
+	assert.LessOrEqual(t, len(found.Body), 65536)
+	assert.True(t, strings.HasSuffix(found.Body, tail+"\n```"), "plan summary tail must survive")
+	assert.Contains(t, found.Body, "[!WARNING]")
+}

--- a/cli/pkg/integration/gitlab_comment_splitting_test.go
+++ b/cli/pkg/integration/gitlab_comment_splitting_test.go
@@ -1,0 +1,173 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	dg_gitlab "github.com/diggerhq/digger/libs/ci/gitlab"
+	"github.com/diggerhq/digger/libs/comment_utils/reporting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GitLab twin of the GitHub comment splitting tests. GitLab's real limit is
+// 1,000,000 characters, so instead of posting megabytes the service is
+// wrapped with a small CommentMaxLength override to exercise the split
+// mechanics, the discussions API and backlink URL construction against the
+// real API.
+//
+// Required environment variables (tests are skipped when unset):
+//
+//	GITLAB_TOKEN                            token with api scope
+//	DIGGER_INTEGRATION_GITLAB_PROJECT_ID    numeric project id
+//	DIGGER_INTEGRATION_GITLAB_MR_IID        an open MR iid in that project
+//	DIGGER_INTEGRATION_GITLAB_NAMESPACE     project namespace (group/user path)
+//	DIGGER_INTEGRATION_GITLAB_PROJECT_NAME  project path name
+func setupGitlabSplittingTest(t *testing.T) (*dg_gitlab.GitLabService, int, string) {
+	SkipCI(t)
+
+	token := os.Getenv("GITLAB_TOKEN")
+	projectIdStr := os.Getenv("DIGGER_INTEGRATION_GITLAB_PROJECT_ID")
+	mrIidStr := os.Getenv("DIGGER_INTEGRATION_GITLAB_MR_IID")
+	namespace := os.Getenv("DIGGER_INTEGRATION_GITLAB_NAMESPACE")
+	projectName := os.Getenv("DIGGER_INTEGRATION_GITLAB_PROJECT_NAME")
+	if token == "" || projectIdStr == "" || mrIidStr == "" || namespace == "" || projectName == "" {
+		t.Skip("Skipping: GITLAB_TOKEN, DIGGER_INTEGRATION_GITLAB_PROJECT_ID, DIGGER_INTEGRATION_GITLAB_MR_IID, DIGGER_INTEGRATION_GITLAB_NAMESPACE and DIGGER_INTEGRATION_GITLAB_PROJECT_NAME must be set")
+	}
+
+	projectId, err := strconv.Atoi(projectIdStr)
+	require.NoError(t, err)
+	mrIid, err := strconv.Atoi(mrIidStr)
+	require.NoError(t, err)
+
+	ctx := &dg_gitlab.GitLabContext{
+		ProjectId:        &projectId,
+		MergeRequestIId:  &mrIid,
+		ProjectName:      projectName,
+		ProjectNamespace: namespace,
+		Token:            token,
+	}
+	svc, err := dg_gitlab.NewGitLabService(token, ctx, "")
+	require.NoError(t, err)
+	return svc, mrIid, token
+}
+
+// gitlabServiceWithLimit lowers the comment size limit so tests can force
+// splits without posting megabytes to gitlab.com.
+type gitlabServiceWithLimit struct {
+	*dg_gitlab.GitLabService
+	maxLength int
+}
+
+func (m gitlabServiceWithLimit) CommentMaxLength() int {
+	return m.maxLength
+}
+
+type gitlabNote struct {
+	Id     int    `json:"id"`
+	Body   string `json:"body"`
+	System bool   `json:"system"`
+}
+
+// listMrNotes fetches MR notes via the raw API (GitLabService.GetComments is
+// a stub), oldest first.
+func listMrNotes(t *testing.T, token string, projectId string, mrIid int) []gitlabNote {
+	url := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%d/notes?per_page=100&order_by=created_at&sort=asc", projectId, mrIid)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("PRIVATE-TOKEN", token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var notes []gitlabNote
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&notes))
+	return notes
+}
+
+var notePrevLinkRegex = regexp.MustCompile(`\[previous comment\]\((\S+)#note_(\d+)\)`)
+
+func TestGitlabCommentSplittingMultipleComments(t *testing.T) {
+	svc, mrIid, token := setupGitlabSplittingTest(t)
+	limited := gitlabServiceWithLimit{GitLabService: svc, maxLength: 2500}
+
+	marker := fmt.Sprintf("digger-1645-gitlab-%d", time.Now().UnixNano())
+
+	reporter := reporting.CiReporter{
+		CiService:         limited,
+		PrNumber:          mrIid,
+		IsSupportMarkdown: true,
+		ReportStrategy:    reporting.MultipleCommentsStrategy{},
+	}
+
+	plan := fakePlanOutput(marker, 8_000)
+	_, lastUrl, err := reporter.Report(plan, reporting.GetTerraformOutputAsCollapsibleComment("Plan output", true))
+	require.NoError(t, err)
+	assert.Contains(t, lastUrl, "#note_", "returned url must be a note anchor")
+
+	var created []gitlabNote
+	for _, n := range listMrNotes(t, token, os.Getenv("DIGGER_INTEGRATION_GITLAB_PROJECT_ID"), mrIid) {
+		if !n.System && strings.Contains(n.Body, marker) {
+			created = append(created, n)
+		}
+	}
+
+	require.GreaterOrEqual(t, len(created), 3, "8KB plan with a 2.5KB limit must be split into at least 3 notes")
+	for i, n := range created {
+		assert.LessOrEqualf(t, len(n.Body), 2500, "note %d exceeds the limit", i)
+	}
+	// summary tail survives in the last note
+	assert.Contains(t, created[len(created)-1].Body, fmt.Sprintf("Plan: 1 to add, 0 to change, 0 to destroy. [%s]", marker))
+
+	// continuation notes must link back to the actual previous note
+	expectedUrlPrefix := fmt.Sprintf("https://gitlab.com/%s/%s/-/merge_requests/%d",
+		os.Getenv("DIGGER_INTEGRATION_GITLAB_NAMESPACE"), os.Getenv("DIGGER_INTEGRATION_GITLAB_PROJECT_NAME"), mrIid)
+	for i, n := range created[1:] {
+		m := notePrevLinkRegex.FindStringSubmatch(n.Body)
+		require.NotNilf(t, m, "note %d must contain a previous-comment link", i+1)
+		assert.Equalf(t, expectedUrlPrefix, m[1], "note %d link must point at this MR", i+1)
+		linkedId, err := strconv.Atoi(m[2])
+		require.NoError(t, err)
+		assert.Equalf(t, created[i].Id, linkedId, "note %d must link to its predecessor", i+1)
+	}
+}
+
+func TestGitlabCommentSplittingFreshOversizedPerRunReport(t *testing.T) {
+	svc, mrIid, token := setupGitlabSplittingTest(t)
+	limited := gitlabServiceWithLimit{GitLabService: svc, maxLength: 2500}
+
+	marker := fmt.Sprintf("digger-1645-gitlab-upsert-%d", time.Now().UnixNano())
+	title := "Digger run report " + marker
+	strategy := reporting.CommentPerRunStrategy{Title: title, TimeOfRun: time.Now()}
+	reporter := reporting.CiReporter{
+		CiService:         limited,
+		PrNumber:          mrIid,
+		IsSupportMarkdown: true,
+		ReportStrategy:    strategy,
+	}
+
+	// note: GitLabService.GetComments is currently a stub returning nil, so
+	// on GitLab the per-run strategies always create fresh comments; this
+	// verifies the oversized fresh report splits instead of failing
+	_, _, err := reporter.Report(fakePlanOutput(marker, 8_000), reporting.GetTerraformOutputAsCollapsibleComment("Plan output", false))
+	require.NoError(t, err)
+
+	count := 0
+	for _, n := range listMrNotes(t, token, os.Getenv("DIGGER_INTEGRATION_GITLAB_PROJECT_ID"), mrIid) {
+		if !n.System && strings.Contains(n.Body, marker) {
+			count++
+			assert.Contains(t, n.Body, title, "every chunk must carry the report title")
+			assert.LessOrEqual(t, len(n.Body), 2500)
+		}
+	}
+	require.GreaterOrEqual(t, count, 3)
+}

--- a/docs/ce/features/commentops.mdx
+++ b/docs/ce/features/commentops.mdx
@@ -17,3 +17,14 @@ title: "CommentOps"
 `digger apply/plan`
 
 * **\-p** enables user to run the command for a particular project, e.g. `digger plan -p staging`
+
+#### Large plan outputs
+
+Version control providers limit the size of a comment body (GitHub: 65,536 characters). When a plan or apply output exceeds the limit, Digger splits it into a chain of comments instead of failing:
+
+* Each comment stays under the provider's limit and renders as valid markdown on its own: code blocks and collapsible sections are closed at the end of one comment and reopened at the start of the next.
+* Each continuation comment links back to the previous one, so you can follow the chain even when other comments land in between.
+* With `reporting-strategy: comments_per_run` or `latest_run_comment`, a shared comment that runs out of space is left intact and later project reports continue in new comments under the same title.
+* A single report is split into at most 10 comments. Beyond that, the beginning of the output is dropped with a warning, and the end — including the plan summary, warnings and errors — is kept. The full output is always available in the job logs.
+
+Comment size limits per provider: GitHub 65,536 characters, GitLab 1,000,000, Bitbucket 32,768, Azure DevOps 150,000.

--- a/docs/ce/troubleshooting/comments.mdx
+++ b/docs/ce/troubleshooting/comments.mdx
@@ -2,6 +2,17 @@
 title: "PR Comment Issues"
 ---
 
+## Comment body is too long (422)
+
+Older Digger versions failed the job with exit code 5 when a plan output exceeded GitHub's comment size limit:
+
+```
+error editing comment: PATCH https://api.github.com/repos/.../issues/comments/...:
+422 Validation Failed [{Resource:IssueComment Field:body Code:custom Message:body is too long (maximum is 65536 characters)}]
+```
+
+Upgrade to a version with comment splitting: oversized plan output is posted as a chain of linked comments and the job no longer fails. See [Large plan outputs](/ce/features/commentops#large-plan-outputs). If you still hit this error on a current version, please [open an issue](https://github.com/diggerhq/digger/issues).
+
 ## Links to jobs not working
 
 Sometimes the link to job status leads to the PR instead of the Action job. E.g. if the job has failed, you click on "failed" in the summary comment, but it goes to the same PR.

--- a/libs/ci/azure/azure.go
+++ b/libs/ci/azure/azure.go
@@ -174,6 +174,15 @@ func (a *AzureReposService) GetChangedFiles(prNumber int) ([]string, error) {
 	return changedFiles, nil
 }
 
+// CommentMaxLength implements ci.CommentMaxLengthProvider. Azure DevOps
+// rejects pull request thread comments over 150,000 characters ("A
+// discussion comment cannot be longer than 150000 characters"). Not
+// officially documented; sourced from the API validation error, see e.g.
+// https://github.com/Azure/AzOps/issues/652
+func (a *AzureReposService) CommentMaxLength() int {
+	return 150000
+}
+
 func (a *AzureReposService) PublishComment(prNumber int, comment string) (*ci.Comment, error) {
 	_, err := a.Client.CreateThread(context.Background(), git.CreateThreadArgs{
 		Project:       &a.ProjectName,

--- a/libs/ci/bitbucket/bitbucket.go
+++ b/libs/ci/bitbucket/bitbucket.go
@@ -99,6 +99,16 @@ type BitbucketCommentResponse struct {
 	} `json:"user"`
 }
 
+// CommentMaxLength implements ci.CommentMaxLengthProvider. Bitbucket
+// rejects pull request comments over 32,768 characters. The limit is not
+// officially documented for Cloud; it is the well-known Bitbucket Server
+// limit ("comments more than 32768 characters cannot be posted", e.g.
+// https://github.com/checkmarx-ltd/cx-flow/issues/374) and is used here as
+// a conservative bound for both.
+func (b BitbucketAPI) CommentMaxLength() int {
+	return 32768
+}
+
 func (b BitbucketAPI) PublishComment(prNumber int, comment string) (*ci.Comment, error) {
 	url := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/comments", bitbucketBaseURL, b.RepoWorkspace, b.RepoName, prNumber)
 

--- a/libs/ci/ci.go
+++ b/libs/ci/ci.go
@@ -28,6 +28,13 @@ type PullRequestService interface {
 	SetOutput(prNumber int, key string, value string) error
 }
 
+// CommentMaxLengthProvider is optionally implemented by PullRequestService
+// implementations whose VCS enforces a maximum comment body size. Callers
+// fall back to GitHub's 65,536-character limit when it is not implemented.
+type CommentMaxLengthProvider interface {
+	CommentMaxLength() int
+}
+
 type OrgService interface {
 	GetUserTeams(organisation string, user string) ([]string, error)
 }

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -186,6 +186,16 @@ func (svc GithubService) UpdateIssue(ID int64, title string, body string) (int64
 	return *githubissue.ID, err
 }
 
+// CommentMaxLength implements ci.CommentMaxLengthProvider. GitHub rejects
+// comment bodies over 65,536 characters ("422 Validation Failed: body is
+// too long (maximum is 65536 characters)"), which corresponds to up to
+// 262,144 bytes of UTF-8, see
+// https://github.com/dead-claudia/github-limits#issue-comments
+// Byte-length checks against this value are therefore conservative.
+func (svc GithubService) CommentMaxLength() int {
+	return 65536
+}
+
 func (svc GithubService) PublishComment(prNumber int, comment string) (*ci.Comment, error) {
 	githubComment, _, err := svc.Client.Issues.CreateComment(context.Background(), svc.Owner, svc.RepoName, prNumber, &github.IssueComment{Body: &comment})
 	if err != nil {

--- a/libs/ci/gitlab/gitlab.go
+++ b/libs/ci/gitlab/gitlab.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"fmt"
 	"log/slog"
+	"path"
 	"strconv"
 	"strings"
 
@@ -183,6 +184,49 @@ func (gitlabService GitLabService) GetUserTeams(organisation string, user string
 	return make([]string, 0), nil
 }
 
+// CommentMaxLength implements ci.CommentMaxLengthProvider. GitLab limits
+// comment bodies to ~1 million characters, see "Size of comments and
+// descriptions of issues, merge requests, and epics" in
+// https://docs.gitlab.com/ee/administration/instance_limits.html
+func (gitlabService GitLabService) CommentMaxLength() int {
+	return 1000000
+}
+
+// noteWebURL builds the web URL of a merge request note, e.g.
+// https://gitlab.com/group/subgroup/project/-/merge_requests/7#note_42.
+// Returns "" when the pipeline context lacks the required fields.
+func (gitlabService GitLabService) noteWebURL(
+	mergeRequestIID int,
+	noteID int,
+) string {
+	namespace := gitlabService.Context.ProjectNamespace
+	projectName := gitlabService.Context.ProjectName
+
+	if namespace == "" || projectName == "" {
+		return ""
+	}
+
+	base := *gitlabService.Client.BaseURL() // Copy; don't mutate client state.
+
+	base.RawQuery = ""
+	base.Fragment = fmt.Sprintf("note_%d", noteID)
+
+	// Preserve a possible self-hosted GitLab prefix while removing the API path.
+	webRoot := strings.TrimSuffix(base.Path, "/")
+	webRoot = strings.TrimSuffix(webRoot, "/api/v4")
+
+	base.Path = path.Join(
+		webRoot,
+		namespace,
+		projectName,
+		"-",
+		"merge_requests",
+		strconv.Itoa(mergeRequestIID),
+	)
+
+	return base.String()
+}
+
 func (gitlabService GitLabService) PublishComment(prNumber int, comment string) (*ci.Comment, error) {
 	discussionId := gitlabService.Context.DiscussionID
 	projectId := *gitlabService.Context.ProjectId
@@ -203,14 +247,14 @@ func (gitlabService GitLabService) PublishComment(prNumber int, comment string) 
 		}
 		discussionId = discussion.ID
 		note := discussion.Notes[0]
-		return &ci.Comment{Id: strconv.Itoa(note.ID), DiscussionId: discussionId, Body: &note.Body}, err
+		return &ci.Comment{Id: strconv.Itoa(note.ID), DiscussionId: discussionId, Body: &note.Body, Url: gitlabService.noteWebURL(mergeRequestIID, note.ID)}, err
 	} else {
 		note, _, err := gitlabService.Client.Discussions.AddMergeRequestDiscussionNote(projectId, mergeRequestIID, discussionId, commentOpt)
 		if err != nil {
 			slog.Error("failed to publish comment", "error", err, "mergeRequestIID", mergeRequestIID, "discussionId", discussionId)
 			print(err.Error())
 		}
-		return &ci.Comment{Id: strconv.Itoa(note.ID), DiscussionId: discussionId, Body: &note.Body}, err
+		return &ci.Comment{Id: strconv.Itoa(note.ID), DiscussionId: discussionId, Body: &note.Body, Url: gitlabService.noteWebURL(mergeRequestIID, note.ID)}, err
 	}
 }
 

--- a/libs/comment_utils/reporting/comments.go
+++ b/libs/comment_utils/reporting/comments.go
@@ -28,6 +28,12 @@ func GetTerraformOutputAsComment(summary string) func(string) string {
 	}
 }
 
+// AsCollapsibleComment wraps a comment in a <details> block. The blank line
+// after </summary> is required for markdown (links, bold, fences) to render
+// inside an HTML block, and the content is deliberately not indented: four
+// leading spaces would turn it into a markdown code block, and the
+// strip-and-rewrap cycle in upsertComment accumulates indentation on every
+// appended report.
 func AsCollapsibleComment(summary string, open bool) func(string) string {
 	var openTag string
 	if open {
@@ -37,7 +43,8 @@ func AsCollapsibleComment(summary string, open bool) func(string) string {
 	}
 	return func(comment string) string {
 		return fmt.Sprintf(`<details %v><summary>`+summary+`</summary>
-  `+comment+`
+
+`+comment+`
 </details>`, openTag)
 	}
 }

--- a/libs/comment_utils/reporting/reporting.go
+++ b/libs/comment_utils/reporting/reporting.go
@@ -129,8 +129,58 @@ func (strategy CommentPerRunStrategy) Report(ciService ci.PullRequestService, Pr
 	return commentId, commentUrl, err
 }
 
+// CommentMaxSize returns the comment body size limit for the VCS behind
+// ciService, falling back to GitHub's limit when the service does not say.
+func CommentMaxSize(ciService ci.PullRequestService) int {
+	if provider, ok := ciService.(ci.CommentMaxLengthProvider); ok {
+		return provider.CommentMaxLength()
+	}
+	return defaultCommentMaxSize
+}
+
+// publishWrappedChunks splits report so that each chunk still fits the size
+// limit after being wrapped with the report title, then publishes one comment
+// per chunk. Returns the id and url of the last published comment, which
+// holds the tail of the report (plan summary, warnings, errors).
+func publishWrappedChunks(ciService ci.PullRequestService, PrNumber int, report string, wrap func(string) string, maxSize int) (string, string, error) {
+	chunks := SplitComment(report, reserveUrlRoom(maxSize)-len(wrap("")), maxCommentsPerReport)
+	var lastComment *ci.Comment
+	for i, chunk := range chunks {
+		if i > 0 {
+			prevUrl := ""
+			if lastComment != nil {
+				prevUrl = lastComment.Url
+			}
+			chunk = fillPreviousCommentUrl(chunk, prevUrl)
+		}
+		comment, err := ciService.PublishComment(PrNumber, wrap(chunk))
+		if err != nil {
+			slog.Error("error publishing comment", "error", err, "prNumber", PrNumber)
+			return "", "", fmt.Errorf("error publishing comment: %v", err)
+		}
+		lastComment = comment
+	}
+	// some PullRequestService implementations do not return the created comment
+	if lastComment == nil {
+		return "", "", nil
+	}
+	return fmt.Sprintf("%v", lastComment.Id), lastComment.Url, nil
+}
+
 func upsertComment(ciService ci.PullRequestService, PrNumber int, report string, reportFormatter func(report string) string, comments []ci.Comment, reportTitle string, supportsCollapsible bool) (string, string, error) {
 	report = reportFormatter(report)
+	maxSize := CommentMaxSize(ciService)
+
+	var wrap func(string) string
+	if !supportsCollapsible {
+		wrap = AsComment(reportTitle)
+	} else {
+		wrap = AsCollapsibleComment(reportTitle, false)
+	}
+
+	// target the newest comment carrying the report title, so that once a
+	// comment overflows and a continuation is created, subsequent reports
+	// append to the continuation rather than the full older comment
 	commentIdForThisRun := ""
 	var commentBody string
 	var commentUrl string
@@ -139,23 +189,11 @@ func upsertComment(ciService ci.PullRequestService, PrNumber int, report string,
 			commentIdForThisRun = comment.Id
 			commentBody = *comment.Body
 			commentUrl = comment.Url
-			break
 		}
 	}
 
 	if commentIdForThisRun == "" {
-		var commentMessage string
-		if !supportsCollapsible {
-			commentMessage = AsComment(reportTitle)(report)
-		} else {
-			commentMessage = AsCollapsibleComment(reportTitle, false)(report)
-		}
-		comment, err := ciService.PublishComment(PrNumber, commentMessage)
-		if err != nil {
-			slog.Error("error publishing comment", "error", err, "prNumber", PrNumber)
-			return "", "", fmt.Errorf("error publishing comment: %v", err)
-		}
-		return fmt.Sprintf("%v", comment.Id), comment.Url, nil
+		return publishWrappedChunks(ciService, PrNumber, report, wrap, maxSize)
 	}
 
 	// strip first and last lines
@@ -165,11 +203,15 @@ func upsertComment(ciService ci.PullRequestService, PrNumber int, report string,
 
 	commentBody = commentBody + "\n\n" + report + "\n"
 
-	var completeComment string
-	if !supportsCollapsible {
-		completeComment = AsComment(reportTitle)(commentBody)
-	} else {
-		completeComment = AsCollapsibleComment(reportTitle, false)(commentBody)
+	completeComment := wrap(commentBody)
+
+	if len(completeComment) > maxSize {
+		// the merged comment would exceed the VCS limit: leave the existing
+		// comment untouched and publish the new report as continuation
+		// comment(s) under the same title
+		slog.Info("comment size limit reached, publishing report as new comment",
+			"commentId", commentIdForThisRun, "prNumber", PrNumber, "size", len(completeComment), "maxSize", maxSize)
+		return publishWrappedChunks(ciService, PrNumber, report, wrap, maxSize)
 	}
 
 	err := ciService.EditComment(PrNumber, commentIdForThisRun, completeComment)
@@ -200,10 +242,26 @@ func (strategy LatestRunCommentStrategy) Report(ciService ci.PullRequestService,
 type MultipleCommentsStrategy struct{}
 
 func (strategy MultipleCommentsStrategy) Report(ciService ci.PullRequestService, PrNumber int, report string, reportFormatter func(report string) string, supportsCollapsibleComment bool) (string, string, error) {
-	comment, err := ciService.PublishComment(PrNumber, reportFormatter(report))
-	if err != nil {
-		slog.Error("error publishing comment", "error", err, "prNumber", PrNumber)
-		return "", "", err
+	chunks := SplitComment(reportFormatter(report), reserveUrlRoom(CommentMaxSize(ciService)), maxCommentsPerReport)
+	var lastComment *ci.Comment
+	for i, chunk := range chunks {
+		if i > 0 {
+			prevUrl := ""
+			if lastComment != nil {
+				prevUrl = lastComment.Url
+			}
+			chunk = fillPreviousCommentUrl(chunk, prevUrl)
+		}
+		comment, err := ciService.PublishComment(PrNumber, chunk)
+		if err != nil {
+			slog.Error("error publishing comment", "error", err, "prNumber", PrNumber)
+			return "", "", err
+		}
+		lastComment = comment
 	}
-	return comment.Id, comment.Url, nil
+	// some PullRequestService implementations do not return the created comment
+	if lastComment == nil {
+		return "", "", nil
+	}
+	return lastComment.Id, lastComment.Url, nil
 }

--- a/libs/comment_utils/reporting/reporting_strategies_test.go
+++ b/libs/comment_utils/reporting/reporting_strategies_test.go
@@ -1,0 +1,188 @@
+package reporting
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/diggerhq/digger/libs/ci"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockCiServiceWithLimit wraps MockCiService with a small comment size limit
+// so tests do not need to build 64KB reports.
+type mockCiServiceWithLimit struct {
+	MockCiService
+	maxLength int
+}
+
+func (m mockCiServiceWithLimit) CommentMaxLength() int {
+	return m.maxLength
+}
+
+func newMockCiServiceWithLimit(maxLength int) mockCiServiceWithLimit {
+	return mockCiServiceWithLimit{
+		MockCiService: MockCiService{CommentsPerPr: map[int][]*ci.Comment{}},
+		maxLength:     maxLength,
+	}
+}
+
+func identityFormatter(report string) string {
+	return report
+}
+
+func TestMultipleCommentsStrategyPublishesSingleCommentWhenUnderLimit(t *testing.T) {
+	svc := newMockCiServiceWithLimit(1000)
+	strategy := MultipleCommentsStrategy{}
+
+	_, _, err := strategy.Report(svc, 1, "short report", identityFormatter, true)
+
+	assert.NoError(t, err)
+	assert.Len(t, svc.CommentsPerPr[1], 1)
+	assert.Equal(t, "short report", *svc.CommentsPerPr[1][0].Body)
+}
+
+func TestMultipleCommentsStrategySplitsOversizedReport(t *testing.T) {
+	svc := newMockCiServiceWithLimit(1000)
+	strategy := MultipleCommentsStrategy{}
+
+	report := strings.Repeat("terraform plan line\n", 200) // ~4KB
+
+	commentId, _, err := strategy.Report(svc, 1, report, identityFormatter, true)
+
+	assert.NoError(t, err)
+	comments := svc.CommentsPerPr[1]
+	assert.Greater(t, len(comments), 1)
+	for i, c := range comments {
+		assert.LessOrEqualf(t, len(*c.Body), 1000, "comment %d exceeds limit", i)
+	}
+	// returned id is the last comment, which carries the report's tail
+	assert.Equal(t, comments[len(comments)-1].Id, commentId)
+}
+
+func TestUpsertAppendsToExistingCommentWhenItFits(t *testing.T) {
+	svc := newMockCiServiceWithLimit(10000)
+	strategy := CommentPerRunStrategy{Title: "Digger run report", TimeOfRun: time.Now()}
+
+	_, _, err := strategy.Report(svc, 1, "project a plan", identityFormatter, true)
+	assert.NoError(t, err)
+	_, _, err = strategy.Report(svc, 1, "project b plan", identityFormatter, true)
+	assert.NoError(t, err)
+
+	comments := svc.CommentsPerPr[1]
+	assert.Len(t, comments, 1)
+	assert.Contains(t, *comments[0].Body, "project a plan")
+	assert.Contains(t, *comments[0].Body, "project b plan")
+}
+
+func TestUpsertOverflowCreatesContinuationAndLeavesExistingCommentIntact(t *testing.T) {
+	svc := newMockCiServiceWithLimit(1000)
+	strategy := CommentPerRunStrategy{Title: "Digger run report", TimeOfRun: time.Now()}
+
+	_, _, err := strategy.Report(svc, 1, strings.Repeat("project a plan\n", 40), identityFormatter, true) // ~600 chars
+	assert.NoError(t, err)
+	firstBody := *svc.CommentsPerPr[1][0].Body
+
+	// appending this would exceed the 1000 char limit
+	_, _, err = strategy.Report(svc, 1, strings.Repeat("project b plan\n", 40), identityFormatter, true)
+	assert.NoError(t, err)
+
+	comments := svc.CommentsPerPr[1]
+	assert.Len(t, comments, 2)
+	assert.Equal(t, firstBody, *comments[0].Body, "existing comment must be left untouched on overflow")
+	assert.Contains(t, *comments[1].Body, "project b plan")
+	for i, c := range comments {
+		assert.LessOrEqualf(t, len(*c.Body), 1000, "comment %d exceeds limit", i)
+	}
+}
+
+func TestUpsertAppendsToNewestContinuationComment(t *testing.T) {
+	svc := newMockCiServiceWithLimit(1000)
+	strategy := CommentPerRunStrategy{Title: "Digger run report", TimeOfRun: time.Now()}
+
+	_, _, err := strategy.Report(svc, 1, strings.Repeat("project a plan\n", 40), identityFormatter, true)
+	assert.NoError(t, err)
+	_, _, err = strategy.Report(svc, 1, strings.Repeat("project b plan\n", 40), identityFormatter, true)
+	assert.NoError(t, err)
+	assert.Len(t, svc.CommentsPerPr[1], 2)
+
+	// a small report must append to the newest (continuation) comment, not
+	// re-target the full first comment
+	_, _, err = strategy.Report(svc, 1, "project c plan", identityFormatter, true)
+	assert.NoError(t, err)
+
+	comments := svc.CommentsPerPr[1]
+	assert.Len(t, comments, 2)
+	assert.NotContains(t, *comments[0].Body, "project c plan")
+	assert.Contains(t, *comments[1].Body, "project c plan")
+}
+
+func TestUpsertSplitsOversizedReportOnFreshPr(t *testing.T) {
+	svc := newMockCiServiceWithLimit(1000)
+	strategy := LatestRunCommentStrategy{TimeOfRun: time.Now()}
+
+	report := strings.Repeat("terraform plan line\n", 200) // ~4KB
+	_, _, err := strategy.Report(svc, 1, report, identityFormatter, true)
+	assert.NoError(t, err)
+
+	comments := svc.CommentsPerPr[1]
+	assert.Greater(t, len(comments), 1)
+	for i, c := range comments {
+		assert.LessOrEqualf(t, len(*c.Body), 1000, "comment %d exceeds limit", i)
+		assert.Containsf(t, *c.Body, "Digger latest run report", "comment %d must carry the report title", i)
+	}
+}
+
+func TestMultipleCommentsStrategyLinksContinuationsToPreviousComment(t *testing.T) {
+	svc := newMockCiServiceWithLimit(1200)
+	strategy := MultipleCommentsStrategy{}
+
+	report := strings.Repeat("terraform plan line\n", 200) // ~4KB
+	_, _, err := strategy.Report(svc, 1, report, identityFormatter, true)
+	assert.NoError(t, err)
+
+	comments := svc.CommentsPerPr[1]
+	assert.Greater(t, len(comments), 1)
+	for i, c := range comments[1:] {
+		previousUrl := comments[i].Url
+		assert.Containsf(t, *c.Body, "[previous comment]("+previousUrl+")",
+			"comment %d must link back to the previous chunk", i+1)
+		assert.NotContains(t, *c.Body, prevCommentUrlPlaceholder)
+	}
+}
+
+func TestFillPreviousCommentUrlFallsBackToPlainText(t *testing.T) {
+	chunk := "Continued from [previous comment](" + prevCommentUrlPlaceholder + ").\nrest"
+	assert.Equal(t, "Continued from previous comment.\nrest", fillPreviousCommentUrl(chunk, ""))
+	assert.Equal(t, "Continued from [previous comment](https://x.test/1).\nrest", fillPreviousCommentUrl(chunk, "https://x.test/1"))
+}
+
+func TestUpsertRewrapKeepsMarkdownRenderable(t *testing.T) {
+	svc := newMockCiServiceWithLimit(100000)
+	strategy := CommentPerRunStrategy{Title: "Digger run report", TimeOfRun: time.Now()}
+
+	for i := 0; i < 3; i++ {
+		report := fmt.Sprintf("report %d with [a link](https://x.test/%d)", i, i)
+		_, _, err := strategy.Report(svc, 1, report, identityFormatter, true)
+		assert.NoError(t, err)
+	}
+
+	body := *svc.CommentsPerPr[1][0].Body
+	lines := strings.Split(body, "\n")
+	// a blank line after <summary> is required for markdown (links, bold,
+	// fences) to render inside the details block
+	assert.True(t, strings.HasPrefix(lines[0], "<details"))
+	assert.Equal(t, "", lines[1])
+	// re-wrapping on append must not accumulate indentation: four leading
+	// spaces turn content into a markdown code block
+	for _, line := range lines {
+		assert.Falsef(t, strings.HasPrefix(line, "    "), "line gained code-block indentation: %q", line)
+	}
+}
+
+func TestCommentMaxSizeFallsBackToDefault(t *testing.T) {
+	plain := MockCiService{CommentsPerPr: map[int][]*ci.Comment{}}
+	assert.Equal(t, defaultCommentMaxSize, CommentMaxSize(plain))
+	assert.Equal(t, 1000, CommentMaxSize(newMockCiServiceWithLimit(1000)))
+}

--- a/libs/comment_utils/reporting/reporting_test.go
+++ b/libs/comment_utils/reporting/reporting_test.go
@@ -34,9 +34,14 @@ func (t MockCiService) PublishComment(prNumber int, comment string) (*ci.Comment
 		}
 	}
 
-	t.CommentsPerPr[prNumber] = append(t.CommentsPerPr[prNumber], &ci.Comment{Id: strconv.Itoa(latestId + 1), Body: &comment})
+	newComment := &ci.Comment{
+		Id:   strconv.Itoa(latestId + 1),
+		Body: &comment,
+		Url:  fmt.Sprintf("https://github.com/mock/repo/pull/%v#issuecomment-%v", prNumber, latestId+1),
+	}
+	t.CommentsPerPr[prNumber] = append(t.CommentsPerPr[prNumber], newComment)
 
-	return nil, nil
+	return newComment, nil
 }
 
 func (t MockCiService) ListIssues() ([]*ci.Issue, error) {

--- a/libs/comment_utils/reporting/split.go
+++ b/libs/comment_utils/reporting/split.go
@@ -1,0 +1,374 @@
+package reporting
+
+// Comment splitting for VCS providers that enforce a maximum comment body
+// size (e.g. GitHub's 65,536 character limit).
+//
+// A report larger than the limit is broken into a chain of comments. Each
+// chunk closes whatever markdown structure is open at its boundary (code
+// fence, <details> block) and the next chunk reopens it, so every comment
+// in the chain renders correctly on its own.
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// defaultCommentMaxSize is used when the CI service does not implement
+// ci.CommentMaxLengthProvider. It matches GitHub's documented limit of
+// 65,536 characters. Go len() counts bytes (>= characters), so byte-based
+// checks are conservative and safe.
+const defaultCommentMaxSize = 65536
+
+// maxCommentsPerReport caps how many comments a single report may be split
+// into. Beyond the cap the head of the output is truncated, preserving the
+// tail which holds the plan summary, warnings and errors.
+const maxCommentsPerReport = 10
+
+// sepStartSizeSlack is extra room assumed for the start separator when
+// guessing where a chunk will begin. The guess only needs to land inside the
+// chunk for closure detection; the exact boundary is settled later.
+const sepStartSizeSlack = 50
+
+// prevCommentUrlPlaceholder is embedded in continuation separators and
+// replaced with the previous chunk's comment URL at publish time (the URL
+// only exists once the previous chunk has been posted).
+const prevCommentUrlPlaceholder = "%PREVIOUS_COMMENT_URL%"
+
+// prevCommentUrlReserve is subtracted from the chunk size limit to leave
+// room for the URL being longer than the placeholder after substitution.
+const prevCommentUrlReserve = 256
+
+// fillPreviousCommentUrl substitutes the previous comment's URL into a
+// chunk's continuation header. With no URL available (VCS clients that do
+// not return one), the markdown link degrades to plain text.
+func fillPreviousCommentUrl(chunk string, url string) string {
+	if url == "" {
+		return strings.ReplaceAll(chunk, "[previous comment]("+prevCommentUrlPlaceholder+")", "previous comment")
+	}
+	return strings.ReplaceAll(chunk, prevCommentUrlPlaceholder, url)
+}
+
+// reserveUrlRoom shrinks maxSize by prevCommentUrlReserve so that URL
+// substitution cannot push a published chunk over the VCS limit.
+func reserveUrlRoom(maxSize int) int {
+	if maxSize > 2*prevCommentUrlReserve {
+		return maxSize - prevCommentUrlReserve
+	}
+	return maxSize
+}
+
+// closureType represents the type of markdown closure at a given position
+type closureType int
+
+const (
+	// noClosure means no special closure is needed
+	noClosure closureType = iota
+	// inCodeBlock means we're inside a code block (```)
+	inCodeBlock
+	// inDetailsBlock means we're inside a details block (<details>)
+	inDetailsBlock
+	// inCodeInDetails means we're inside a code block within a details block
+	inCodeInDetails
+	// inInlineCode means we're inside an inline code span (`)
+	inInlineCode
+)
+
+// lineTokenRegex matches, within a single line, backtick runs and details
+// tags (with optional attributes)
+var lineTokenRegex = regexp.MustCompile("(`+)|(<details(?:\\s[^>]*)?>)|(</details>)")
+
+// separatorSet contains the separators for a specific closure type
+type separatorSet struct {
+	sepEnd           string
+	sepStart         string
+	truncationHeader string
+}
+
+// generateSeparatorsFunc allows the separator generation to be overridden in tests
+var generateSeparatorsFunc = generateSeparators
+
+// generateSeparators creates separator sets for different closure types.
+// fence is the marker of the code fence open at the split point (e.g. "```",
+// "````" or "~~~"): closing it must repeat the same character at least as
+// many times, and the reopened fence uses the same marker so that the
+// original closing fence later in the content still terminates it.
+func generateSeparators(fence string) map[closureType]separatorSet {
+	separators := make(map[closureType]separatorSet)
+
+	baseEnd := "\n<br>\n\n**Note:** the output exceeds the maximum comment size. Continued in next comment."
+	baseStart := "Continued from [previous comment](" + prevCommentUrlPlaceholder + ").\n"
+	baseTruncation := "> [!WARNING]\n> The output was too large to fit in the allowed number of comments. Its beginning was dropped; the end, including the summary, is preserved below. See the run logs for the full output.\n"
+
+	closeFence := "\n" + fence + "\n"
+	openFence := fence + "terraform\n"
+	openDetails := "<details><summary>Continued output</summary>\n\n"
+
+	separators[noClosure] = separatorSet{
+		sepEnd:           baseEnd,
+		sepStart:         baseStart,
+		truncationHeader: baseTruncation,
+	}
+
+	separators[inCodeBlock] = separatorSet{
+		sepEnd:           closeFence + baseEnd,
+		sepStart:         baseStart + openFence,
+		truncationHeader: baseTruncation + openFence,
+	}
+
+	separators[inDetailsBlock] = separatorSet{
+		sepEnd:           "\n</details>\n" + baseEnd,
+		sepStart:         baseStart + openDetails,
+		truncationHeader: baseTruncation + openDetails,
+	}
+
+	separators[inCodeInDetails] = separatorSet{
+		sepEnd:           closeFence + "</details>\n" + baseEnd,
+		sepStart:         baseStart + openDetails + openFence,
+		truncationHeader: baseTruncation + openDetails + openFence,
+	}
+
+	separators[inInlineCode] = separatorSet{
+		sepEnd:           "`\n" + baseEnd,
+		sepStart:         baseStart + "`",
+		truncationHeader: baseTruncation + "`",
+	}
+
+	return separators
+}
+
+// runLen returns the length of the run of byte c at the start of s.
+func runLen(s string, c byte) int {
+	i := 0
+	for i < len(s) && s[i] == c {
+		i++
+	}
+	return i
+}
+
+// detectClosureType reports which markdown structures are open at position,
+// along with the marker of the open code fence ("```" when none is open).
+//
+// It follows the fence rules the VCS renderers actually apply: a fence only
+// opens or closes at the start of a line (at most 3 leading spaces), a
+// backtick fence's info string cannot contain further backticks, and a
+// closing fence must repeat the opening character at least as many times
+// with nothing else on the line. Both backtick and tilde fences count.
+// Inline backticks toggle a state local to their line, so a stray unmatched
+// backtick does not leak into the rest of the comment.
+func detectClosureType(comment string, position int) (closureType, string) {
+	text := comment[:position]
+
+	var fenceChar byte
+	fenceLen := 0
+	detailsDepth := 0
+	lineInline := false
+
+	for _, line := range strings.Split(text, "\n") {
+		lineInline = false
+		trimmed := strings.TrimLeft(line, " ")
+		indent := len(line) - len(trimmed)
+
+		if fenceLen > 0 {
+			// inside a fence only a matching closing fence line matters;
+			// everything else, including shorter runs, mid-line markers and
+			// fences of the other character, is content
+			if indent <= 3 {
+				if n := runLen(trimmed, fenceChar); n >= fenceLen && strings.TrimSpace(trimmed[n:]) == "" {
+					fenceChar, fenceLen = 0, 0
+				}
+			}
+			continue
+		}
+
+		if indent <= 3 {
+			if n := runLen(trimmed, '`'); n >= 3 && !strings.Contains(trimmed[n:], "`") {
+				fenceChar, fenceLen = '`', n
+				continue
+			}
+			if n := runLen(trimmed, '~'); n >= 3 {
+				fenceChar, fenceLen = '~', n
+				continue
+			}
+		}
+
+		for _, loc := range lineTokenRegex.FindAllStringIndex(line, -1) {
+			token := line[loc[0]:loc[1]]
+			if token[0] == '`' {
+				lineInline = !lineInline
+			} else if strings.HasPrefix(token, "<details") {
+				if !lineInline {
+					detailsDepth++
+				}
+			} else if token == "</details>" {
+				// prevent the depth from going negative on stray closing tags
+				if !lineInline && detailsDepth > 0 {
+					detailsDepth--
+				}
+			}
+		}
+	}
+
+	fence := "```"
+	if fenceLen > 0 {
+		fence = strings.Repeat(string(fenceChar), fenceLen)
+	}
+
+	switch {
+	case detailsDepth > 0 && fenceLen > 0:
+		return inCodeInDetails, fence
+	case fenceLen > 0:
+		return inCodeBlock, fence
+	case detailsDepth > 0:
+		return inDetailsBlock, fence
+	case lineInline:
+		return inInlineCode, fence
+	}
+	return noClosure, fence
+}
+
+// SplitComment breaks comment into a slice of chunks, each at most maxSize
+// bytes. Chunks that continue in a following comment end with a sepEnd for
+// the markdown structure open at the boundary, and chunks that continue a
+// preceding comment start with the matching sepStart, so each chunk renders
+// as valid markdown on its own.
+//
+// Chunks are carved from the end of the string towards the beginning: the
+// tail of a terraform plan holds the summary, warnings and errors, so it is
+// the part that must never be lost. When maxComments > 0 caps the number of
+// chunks, whatever does not fit is dropped from the beginning and the first
+// surviving chunk is prefixed with a truncation notice.
+func SplitComment(comment string, maxSize int, maxComments int) []string {
+	if len(comment) <= maxSize {
+		return []string{comment}
+	}
+
+	var comments []string
+	upTo := len(comment)
+
+	for upTo > 0 {
+		// once the cap leaves room for only one more chunk, that chunk
+		// becomes the (truncated) head of the chain
+		isLastAllowed := maxComments > 0 && len(comments) == maxComments-1
+
+		// the chunk needs a sepEnd only when a later chunk already exists
+		closureAtEnd, fenceAtEnd := detectClosureType(comment, upTo)
+		endSepSet := generateSeparatorsFunc(fenceAtEnd)[closureAtEnd]
+		endSepLength := 0
+		if len(comments) > 0 {
+			endSepLength = len(endSepSet.sepEnd)
+		}
+
+		// the sepStart depends on the closure state at the chunk start,
+		// which is not known until the start is chosen: probe an estimated
+		// position first, settle the exact boundary below
+		estimatedDownFrom := min(upTo, max(0, upTo-(maxSize-endSepLength-sepStartSizeSlack)))
+		closureAtStart, fenceAtStart := detectClosureType(comment, estimatedDownFrom)
+		startSepSet := generateSeparatorsFunc(fenceAtStart)[closureAtStart]
+
+		startSepLength := len(startSepSet.sepStart)
+		if isLastAllowed {
+			startSepLength = len(startSepSet.truncationHeader)
+		}
+
+		maxContentSize := maxSize - endSepLength - startSepLength
+		if maxContentSize <= 0 {
+			// maxSize cannot even hold the separators: give up on splitting
+			return []string{comment}
+		}
+
+		downFrom := max(0, upTo-maxContentSize)
+
+		// when the remaining head fits into this chunk without a sepStart,
+		// take all of it (impossible when this chunk must truncate)
+		if !isLastAllowed && downFrom > 0 {
+			if upTo <= (maxSize - endSepLength) {
+				downFrom = 0
+			}
+		}
+
+		// move the boundary to the next newline (or space) when one is
+		// near, so chunks break between lines rather than mid-word; moving
+		// forward only shrinks this chunk, which is always safe
+		if downFrom > 0 && downFrom < len(comment) {
+			// bound the scan: far-away whitespace is not worth the walk
+			// through a very large comment
+			const whitespaceForwardSearchWindow = 500
+
+			searchLimit := min(upTo-1, downFrom+whitespaceForwardSearchWindow)
+			foundSpace := -1
+			foundNewline := -1
+
+			for p := downFrom; p < searchLimit; p++ {
+				if comment[p] == '\n' {
+					foundNewline = p
+					break
+				}
+				if comment[p] == ' ' && foundSpace == -1 {
+					foundSpace = p
+				}
+			}
+
+			if foundNewline != -1 {
+				downFrom = foundNewline + 1
+			} else if foundSpace != -1 {
+				downFrom = foundSpace + 1
+			}
+		}
+
+		// the boundary moved since the probe, so the closure state (and with
+		// it the separator size) may have changed: re-check and shrink until
+		// content plus separators fit
+		for {
+			closureAtStart, fenceAtStart = detectClosureType(comment, downFrom)
+			startSepSet = generateSeparatorsFunc(fenceAtStart)[closureAtStart]
+
+			actualStartSepLength := 0
+			if downFrom > 0 {
+				if isLastAllowed {
+					actualStartSepLength = len(startSepSet.truncationHeader)
+				} else {
+					actualStartSepLength = len(startSepSet.sepStart)
+				}
+			}
+
+			currentTotalSize := (upTo - downFrom) + actualStartSepLength + endSepLength
+			if currentTotalSize <= maxSize {
+				break
+			}
+
+			downFrom = min(upTo, downFrom+(currentTotalSize-maxSize))
+		}
+
+		// Never split in the middle of a multi-byte rune: advancing shrinks the
+		// chunk, so the size bound still holds.
+		for downFrom > 0 && downFrom < len(comment) && !utf8.RuneStart(comment[downFrom]) {
+			downFrom++
+		}
+
+		portion := comment[downFrom:upTo]
+
+		if downFrom > 0 {
+			if isLastAllowed {
+				portion = startSepSet.truncationHeader + portion
+			} else {
+				portion = startSepSet.sepStart + portion
+			}
+		}
+
+		if len(comments) > 0 {
+			portion += endSepSet.sepEnd
+		}
+
+		comments = append([]string{portion}, comments...)
+		upTo = downFrom
+
+		// cap reached with content still remaining: the truncation notice on
+		// comments[0] accounts for the dropped head, stop here
+		if isLastAllowed && downFrom > 0 {
+			break
+		}
+	}
+
+	return comments
+}

--- a/libs/comment_utils/reporting/split_test.go
+++ b/libs/comment_utils/reporting/split_test.go
@@ -1,0 +1,407 @@
+package reporting
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// withTestSeparators swaps in short, predictable separators so expected
+// outputs stay readable, restoring the real ones after the test.
+func withTestSeparators(t *testing.T) {
+	original := generateSeparatorsFunc
+	generateSeparatorsFunc = func(fence string) map[closureType]separatorSet {
+		return map[closureType]separatorSet{
+			noClosure: {
+				sepEnd:           "<!-- END -->",
+				sepStart:         "<!-- START -->",
+				truncationHeader: "<!-- TRUNCATED -->",
+			},
+			inCodeBlock: {
+				sepEnd:           "```\n<!-- END -->",
+				sepStart:         "```terraform\n<!-- START -->",
+				truncationHeader: "```terraform\n<!-- TRUNCATED -->",
+			},
+			inDetailsBlock: {
+				sepEnd:           "</details>\n<!-- END -->",
+				sepStart:         "<details><summary>Show Output</summary>\n<!-- START -->",
+				truncationHeader: "<details><summary>Show Output</summary>\n<!-- TRUNCATED -->",
+			},
+			inCodeInDetails: {
+				sepEnd:           "```\n</details>\n<!-- END -->",
+				sepStart:         "<details><summary>Show Output</summary>\n\n```terraform\n<!-- START -->",
+				truncationHeader: "<details><summary>Show Output</summary>\n\n```terraform\n<!-- TRUNCATED -->",
+			},
+			inInlineCode: {
+				sepEnd:           "`\n<!-- END -->",
+				sepStart:         "<!-- START -->`",
+				truncationHeader: "<!-- TRUNCATED -->`",
+			},
+		}
+	}
+	t.Cleanup(func() { generateSeparatorsFunc = original })
+}
+
+// reassemble strips test separators from chunks and joins them back together
+func reassemble(chunks []string) string {
+	startSeps := []string{
+		"<details><summary>Show Output</summary>\n\n```terraform\n<!-- START -->",
+		"<details><summary>Show Output</summary>\n<!-- START -->",
+		"```terraform\n<!-- START -->",
+		"<!-- START -->`",
+		"<!-- START -->",
+	}
+	endSeps := []string{
+		"```\n</details>\n<!-- END -->",
+		"</details>\n<!-- END -->",
+		"```\n<!-- END -->",
+		"`\n<!-- END -->",
+		"<!-- END -->",
+	}
+	var sb strings.Builder
+	for _, chunk := range chunks {
+		for _, sep := range startSeps {
+			if strings.HasPrefix(chunk, sep) {
+				chunk = strings.TrimPrefix(chunk, sep)
+				break
+			}
+		}
+		for _, sep := range endSeps {
+			if strings.HasSuffix(chunk, sep) {
+				chunk = strings.TrimSuffix(chunk, sep)
+				break
+			}
+		}
+		sb.WriteString(chunk)
+	}
+	return sb.String()
+}
+
+func TestSplitComment(t *testing.T) {
+	withTestSeparators(t)
+
+	tests := []struct {
+		name        string
+		comment     string
+		maxSize     int
+		maxComments int
+	}{
+		{
+			name:        "TwoComments",
+			comment:     strings.Repeat("a", 1000),
+			maxSize:     999,
+			maxComments: 0,
+		},
+		{
+			name:        "MultipleComments",
+			comment:     strings.Repeat("a", 1000),
+			maxSize:     300,
+			maxComments: 0,
+		},
+		{
+			name:        "NoClosureText",
+			comment:     "This is a long comment that will be split. " + strings.Repeat("This is additional content to make the comment longer so it will be split. ", 5),
+			maxSize:     70,
+			maxComments: 0,
+		},
+		{
+			name:        "CodeBlock",
+			comment:     "Here's some code:\n```\nterraform plan\noutput here\n```\nAnd more text. " + strings.Repeat("This is additional content to make the comment longer so it will be split. ", 3),
+			maxSize:     200,
+			maxComments: 0,
+		},
+		{
+			name:        "DetailsBlock",
+			comment:     "<details><summary>Show Output</summary>\n\nSome details content here. " + strings.Repeat("This is additional content to make the comment longer so it will be split. ", 4) + "\n</details>",
+			maxSize:     200,
+			maxComments: 0,
+		},
+		{
+			name: "CodeInDetails",
+			comment: "<details><summary>Show Output</summary>\n\n```terraform\n" +
+				strings.Repeat("Line of terraform output\n", 20) +
+				"```\n</details>",
+			maxSize:     220,
+			maxComments: 0,
+		},
+		{
+			name:        "InlineCode",
+			comment:     "Here is text: `" + strings.Repeat("a", 150) + "` end.",
+			maxSize:     100,
+			maxComments: 0,
+		},
+		{
+			name:        "DetailsBlockWithAttributes",
+			comment:     "<details open><summary>Show Output</summary>\n\nSome details content here. " + strings.Repeat("This is additional content to make the comment longer so it will be split. ", 4) + "\n</details>",
+			maxSize:     200,
+			maxComments: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			split := SplitComment(tt.comment, tt.maxSize, tt.maxComments)
+
+			assert.Greater(t, len(split), 1, "comment above maxSize must be split")
+			for i, chunk := range split {
+				assert.LessOrEqualf(t, len(chunk), tt.maxSize, "chunk %d exceeds maxSize", i)
+			}
+			// stripping separators must reassemble the original comment
+			assert.Equal(t, tt.comment, reassemble(split))
+			// every chunk except the last announces a continuation, every
+			// chunk except the first is marked as one
+			for _, chunk := range split[:len(split)-1] {
+				assert.Contains(t, chunk, "<!-- END -->")
+			}
+			for _, chunk := range split[1:] {
+				assert.Contains(t, chunk, "<!-- START -->")
+			}
+		})
+	}
+}
+
+func TestSplitCommentUnderMaxSizeUnchanged(t *testing.T) {
+	withTestSeparators(t)
+	comment := "comment under max size"
+	assert.Equal(t, []string{comment}, SplitComment(comment, 50, 0))
+}
+
+func TestSplitCommentExactOutput(t *testing.T) {
+	withTestSeparators(t)
+
+	// backwards construction: the last chunk is filled first
+	// (sepStart is 14 chars: 14 + 985 = 999), the remainder lands in the
+	// first chunk with sepEnd appended (15 + 12 = 27)
+	split := SplitComment(strings.Repeat("a", 1000), 999, 0)
+
+	assert.Equal(t, []string{
+		strings.Repeat("a", 15) + "<!-- END -->",
+		"<!-- START -->" + strings.Repeat("a", 985),
+	}, split)
+}
+
+func TestSplitCommentTruncationPreservesTail(t *testing.T) {
+	withTestSeparators(t)
+
+	tail := "Plan: 3 to add, 1 to change, 0 to destroy."
+	comment := strings.Repeat("head ", 100) + strings.Repeat("body ", 100) + tail
+	split := SplitComment(comment, 120, 2)
+
+	assert.Len(t, split, 2)
+	assert.Contains(t, split[0], "<!-- TRUNCATED -->")
+	assert.True(t, strings.HasSuffix(split[len(split)-1], tail), "tail of the comment must survive truncation")
+	for i, chunk := range split {
+		assert.LessOrEqualf(t, len(chunk), 120, "chunk %d exceeds maxSize", i)
+	}
+}
+
+func TestSplitCommentRealSeparatorsReopenTerraformFence(t *testing.T) {
+	// real separators: a plan inside <details>...```terraform must reopen the
+	// fence in the continuation chunk
+	comment := "<details open><summary>Plan output</summary>\n\n```terraform\n" +
+		strings.Repeat("  + resource \"aws_instance\" \"example\"\n", 100) +
+		"```\n</details>"
+	maxSize := 1000
+	split := SplitComment(comment, maxSize, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split {
+		assert.LessOrEqualf(t, len(chunk), maxSize, "chunk %d exceeds maxSize", i)
+		// every chunk must close what it opens: even number of ``` fences
+		assert.Equalf(t, 0, strings.Count(chunk, "```")%2, "chunk %d has unbalanced code fences", i)
+	}
+	for _, chunk := range split[1:] {
+		assert.True(t, strings.HasPrefix(chunk, "Continued from [previous comment]("+prevCommentUrlPlaceholder+")."))
+		assert.Contains(t, chunk, "```terraform")
+	}
+	for _, chunk := range split[:len(split)-1] {
+		assert.Contains(t, chunk, "Continued in next comment.")
+	}
+}
+
+func TestSplitCommentDoesNotSplitMidRune(t *testing.T) {
+	// no whitespace at all, multi-byte runes throughout: forces arbitrary
+	// position splits which must back off to rune boundaries
+	comment := strings.Repeat("héllo→wörld🌍", 500)
+	maxSize := 300
+	split := SplitComment(comment, maxSize, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split {
+		assert.LessOrEqualf(t, len(chunk), maxSize, "chunk %d exceeds maxSize", i)
+		assert.Truef(t, utf8.ValidString(chunk), "chunk %d contains invalid UTF-8", i)
+	}
+}
+
+func TestSplitCommentSeparatorsTooLargeForMaxSize(t *testing.T) {
+	comment := strings.Repeat("a", 1000)
+	// smaller than any separator pair: best effort, return unsplit
+	split := SplitComment(comment, 10, 0)
+	assert.Equal(t, []string{comment}, split)
+}
+
+func TestGenerateSeparatorsCoversAllClosureTypes(t *testing.T) {
+	seps := generateSeparators("```")
+	for _, ct := range []closureType{noClosure, inCodeBlock, inDetailsBlock, inCodeInDetails, inInlineCode} {
+		set, ok := seps[ct]
+		assert.Truef(t, ok, "missing separators for closure type %d", ct)
+		assert.NotEmpty(t, set.sepEnd)
+		assert.NotEmpty(t, set.sepStart)
+		assert.NotEmpty(t, set.truncationHeader)
+	}
+}
+
+func TestDetectClosureType(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected closureType
+		fence    string
+	}{
+		{"plain text", "just text", noClosure, "```"},
+		{"open code fence", "text\n```\ncode", inCodeBlock, "```"},
+		{"closed code fence", "text\n```\ncode\n```\n", noClosure, "```"},
+		{"open details", "<details><summary>x</summary>\nbody", inDetailsBlock, "```"},
+		{"closed details", "<details><summary>x</summary>\nbody</details>", noClosure, "```"},
+		{"code in details", "<details><summary>x</summary>\n```\ncode", inCodeInDetails, "```"},
+		{"details with attrs", "<details open><summary>x</summary>\nbody", inDetailsBlock, "```"},
+		{"inline code", "some `inline", inInlineCode, "```"},
+		{"details token inside code fence ignored", "```\n<details>\n", inCodeBlock, "```"},
+		// fences only count at line start: a mid-line ``` is not a fence
+		{"mid-line fence marker is not a fence", "a `x` b `y` ```\ncode", noClosure, "```"},
+		{"mid-line marker inside open fence stays open", "```terraform\n  x = \"use ``` here\"\ncode", inCodeBlock, "```"},
+		{"indented fence up to 3 spaces counts", "   ```\ncode", inCodeBlock, "```"},
+		{"deeply indented fence is content", "    ```\ntext", noClosure, "```"},
+		// a closing fence must be at least as long as the opening one
+		{"longer fence needs longer close", "````\n```\ncode", inCodeBlock, "````"},
+		{"longer fence closed by equal run", "````\n```\n````\ntext", noClosure, "```"},
+		// tilde fences are fences too, and mix with backtick content
+		{"tilde fence", "~~~\ncode", inCodeBlock, "~~~"},
+		{"backtick fence inside tilde fence is content", "~~~\n```\ncode", inCodeBlock, "~~~"},
+		// an unmatched backtick stays local to its line
+		{"stray backtick does not leak to later lines", "a ` stray\nplain", noClosure, "```"},
+		{"backtick fence with info string containing backtick is not a fence", "``` foo ` bar\ntext", noClosure, "```"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ct, fence := detectClosureType(tt.comment, len(tt.comment))
+			assert.Equal(t, tt.expected, ct)
+			assert.Equal(t, tt.fence, fence)
+		})
+	}
+}
+
+// rendererFenceBalanced mimics how the VCS actually parses fences: a fence
+// token only opens or closes a code block when it sits at the start of a
+// line (up to 3 leading spaces).
+func rendererFenceBalanced(chunk string) bool {
+	open := false
+	for _, line := range strings.Split(chunk, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		if len(line)-len(trimmed) <= 3 && strings.HasPrefix(trimmed, "```") {
+			open = !open
+		}
+	}
+	return !open
+}
+
+func TestSplitCommentMidLineBackticksKeepFenceBalanced(t *testing.T) {
+	// regression for the fence desync: a plan whose string value contains a
+	// literal ``` mid-line must not desync the splitter from the renderer
+	var body strings.Builder
+	body.WriteString("  + description = \"use ``` to fence code blocks\"\n")
+	for range 60 {
+		body.WriteString("  + resource line\n")
+	}
+	comment := "<details open><summary>Plan output</summary>\n\n```terraform\n" +
+		body.String() +
+		"```\n</details>"
+
+	split := SplitComment(comment, 700, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split {
+		assert.Truef(t, rendererFenceBalanced(chunk), "chunk %d has unbalanced fences under line-anchored rendering", i)
+	}
+}
+
+func TestSplitCommentReopensLongerFenceMarkers(t *testing.T) {
+	// a ```` fence (which may legitimately contain ``` as content) must be
+	// closed and reopened with the same four-backtick marker
+	var body strings.Builder
+	for range 60 {
+		body.WriteString("content line\n```\nstill the same block\n")
+	}
+	comment := "````\n" + body.String() + "````"
+
+	split := SplitComment(comment, 700, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split[:len(split)-1] {
+		assert.Containsf(t, chunk, "\n````\n", "chunk %d must close with the four-backtick marker", i)
+	}
+	for i, chunk := range split[1:] {
+		assert.Containsf(t, chunk, "````terraform\n", "chunk %d must reopen with the four-backtick marker", i+1)
+	}
+}
+
+func TestSplitCommentReopensTildeFence(t *testing.T) {
+	var body strings.Builder
+	for range 60 {
+		body.WriteString("tilde fenced content line\n")
+	}
+	comment := "~~~\n" + body.String() + "~~~"
+
+	split := SplitComment(comment, 700, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split[:len(split)-1] {
+		assert.Containsf(t, chunk, "\n~~~\n", "chunk %d must close the tilde fence", i)
+	}
+	for i, chunk := range split[1:] {
+		assert.Containsf(t, chunk, "~~~terraform\n", "chunk %d must reopen the tilde fence", i+1)
+	}
+}
+
+func TestSplitCommentDetailsWithoutFenceReopensPlain(t *testing.T) {
+	// splitting inside a <details> block that holds plain text must reopen
+	// only the details block, not inject a code fence that nothing closes
+	var body strings.Builder
+	for range 60 {
+		body.WriteString("plain text line inside details\n")
+	}
+	comment := "<details><summary>Notes</summary>\n\n" + body.String() + "</details>"
+
+	split := SplitComment(comment, 700, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split {
+		assert.NotContainsf(t, chunk, "```", "chunk %d must not contain a code fence", i)
+	}
+	for i, chunk := range split[1:] {
+		assert.Containsf(t, chunk, "<details><summary>Continued output</summary>", "chunk %d must reopen the details block", i+1)
+	}
+}
+
+func TestSplitCommentStrayBacktickDoesNotLeak(t *testing.T) {
+	// an unmatched backtick early in plain text must not make later chunks
+	// open with inline-code separators
+	var body strings.Builder
+	body.WriteString("there is a stray ` backtick here\n")
+	for range 60 {
+		body.WriteString("plain text line\n")
+	}
+
+	split := SplitComment(body.String(), 700, 0)
+
+	assert.Greater(t, len(split), 1)
+	for i, chunk := range split[1:] {
+		assert.Truef(t, strings.HasPrefix(chunk, "Continued from [previous comment]("+prevCommentUrlPlaceholder+").\n"),
+			"chunk %d must use the plain continuation header", i+1)
+		afterHeader := strings.TrimPrefix(chunk, "Continued from [previous comment]("+prevCommentUrlPlaceholder+").\n")
+		assert.Falsef(t, strings.HasPrefix(afterHeader, "`"), "chunk %d must not reopen inline code", i+1)
+	}
+}


### PR DESCRIPTION
## Problem

GitHub rejects comment bodies over 65,536 characters. When a terraform plan output exceeds that, Digger fails the whole job with exit code 5 even though the plan succeeded:

error editing comment: PATCH https://api.github.com/repos/.../issues/comments/...: 422 Validation Failed [{Resource:IssueComment Field:body Code:custom Message:body is too long (maximum is 65536 characters)}]

Setting `reporting-strategy` doesn't help (see #1645 discussion): a single oversized report fails on create with `multiple_comments`, and the per-run strategies keep PATCHing a shared comment until every later project's report is lost — with 20+ projects, everything after the comment fills up fails.

Fixes #1645

## What this does

- **Splits oversized reports into a chain of comments.** A markdown-aware
  splitter closes open structures (code fences, `<details>`) at each chunk
  boundary and reopens them in the next chunk, so every comment renders
  valid on its own. Fence detection is line-anchored and marker-aware
  (` ```` ` vs ` ``` `, `~~~`), matching how renderers actually parse
  fences — a plan containing a literal ` ``` ` inside a string value can't
  desync the splitter.
- **Chunks are carved from the end of the report**, so the tail (plan
  summary, warnings, errors) always survives. A single report is capped at
  10 comments; beyond that the head is truncated with a warning.
- **Per-run strategies** (`comments_per_run`, `latest_run_comment`) leave
  the full existing comment untouched on overflow and continue in new
  comment(s) under the same title; later reports append to the newest
  continuation.
- **Continuation comments link back to their predecessor**, so chains stay
  navigable when parallel projects interleave.
- **Per-VCS limits** via a new optional `ci.CommentMaxLengthProvider`
  interface: GitHub 65,536 / GitLab 1,000,000 / Bitbucket 32,768 / Azure
  DevOps 150,000. No breaking interface changes; behavior for reports under
  the limit is unchanged.
- **Drift issue notifications** reuse the splitter with a single-chunk cap:
  structure-aware truncation that keeps the plan summary instead of cutting
  mid-fence and dropping the tail.
- Fixes a rendering bug in collapsible comments (missing blank line after
  `</summary>` suppressed markdown; re-wrapping on append accumulated
  indentation until content rendered as a code block).

## Testing

- Unit tests for the splitter (fence closure, truncation, unicode
  boundaries, renderer-faithful fence parsing) and all three strategies.
- Env-gated live integration tests against real APIs:
  - GitHub: oversized plan splitting, per-run overflow continuation, drift
    issue truncation at the real 65,536 boundary
  - GitLab: splitting via the discussions API, backlink URL correctness
  - Bitbucket: genuine 32,768 limit, full per-run overflow flow
- End-to-end per CONTRIBUTING, from this branch via
  `uses: GLEF1X/digger@fix/1645-split-long-comments` in no-backend mode:
  https://github.com/GLEF1X/demo-opentofu/pull/2 — a ~230KB OpenTofu plan
  (~4x the limit) posts as a chain of five linked comments plus a
  continuation for the second project, job exits 0. On current Digger this
  exact scenario fails with the 422 above.
- Tested bitbucket and gitlab on my personal test repositories by running integration tests against them.

### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

Some parts of the code, including tests and comments for methods, functions, and constants, etc were generated by Codex. I also used Codex to better understand the codebase and ask questions about it. I reviewed and verified all generated code and manually performed e2e testing in accordance with the contribution guidelines.