### PR TITLE
fix: isBlockedOnlyByDiggerApply should honor required-check status, not just success conclusions

### DIFF
--- a/docs/ce/cloud-providers/authenticating-with-oidc-on-aws.mdx
+++ b/docs/ce/cloud-providers/authenticating-with-oidc-on-aws.mdx
@@ -26,6 +26,7 @@ jobs:
       pull-requests: write # required to post PR comments
       issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
+      checks: read         # required to check mergeability if digger/apply is a required status check
 
     steps:
       - name: digger run

--- a/docs/ce/getting-started/github-actions-+-aws.mdx
+++ b/docs/ce/getting-started/github-actions-+-aws.mdx
@@ -70,6 +70,7 @@ jobs:
       pull-requests: write # required to post PR comments
       issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
+      checks: read         # required to check mergeability if digger/apply is a required status check
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/ce/getting-started/github-actions-and-gcp.mdx
+++ b/docs/ce/getting-started/github-actions-and-gcp.mdx
@@ -70,6 +70,7 @@ jobs:
       pull-requests: write # required to post PR comments
       issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
+      checks: read         # required to check mergeability if digger/apply is a required status check
     steps:
     - uses: actions/checkout@v4
     - name: ${{ fromJSON(github.event.inputs.spec).job_id }}

--- a/docs/ce/getting-started/with-opentofu.mdx
+++ b/docs/ce/getting-started/with-opentofu.mdx
@@ -90,6 +90,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4
@@ -134,6 +135,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
         steps:
         - uses: actions/checkout@v4
         - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
@@ -189,6 +191,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4

--- a/docs/ce/getting-started/with-terraform.mdx
+++ b/docs/ce/getting-started/with-terraform.mdx
@@ -125,6 +125,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4
@@ -169,6 +170,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
         steps:
         - uses: actions/checkout@v4
         - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
@@ -224,6 +226,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4

--- a/docs/ce/getting-started/with-terragrunt.mdx
+++ b/docs/ce/getting-started/with-terragrunt.mdx
@@ -137,6 +137,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4
@@ -180,6 +181,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
         steps:
         - uses: actions/checkout@v4
         - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
@@ -234,6 +236,7 @@ Place it at `.github/workflows/digger_workflow.yml` (name is important!)
           pull-requests: write # required to post PR comments
           issues: read         # required to check if PR number is an issue or not
           statuses: write      # required to validate combined PR status
+          checks: read         # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4

--- a/docs/ce/howto/apply-requirements.mdx
+++ b/docs/ce/howto/apply-requirements.mdx
@@ -45,6 +45,19 @@ the aggregate checks as required:
 These checks only become selectable in this list after they've been posted to the repo at
 least once - trigger a `digger plan` on any PR first if you don't see them yet.
 
+<Note>
+  If you're on a self-hosted backend, see the "Re-installing or replacing the GitHub App"
+  section on [GitHub App Setup](/self-hosting/github-app-setup) before doing a blue/green or
+  other re-installation deployment - a required check pinned to the old installation's app ID
+  will silently block merges after the cutover.
+</Note>
+
+<Note>
+  Mergeability checks use the GitHub GraphQL API. This is confirmed working against
+  github.com; on GitHub Enterprise Server it should work the same way but has not been
+  tested against a real GHES instance.
+</Note>
+
 ### Usage
 
 You can enable the mergeable requirement on the project level:

--- a/docs/ce/howto/apply-requirements.mdx
+++ b/docs/ce/howto/apply-requirements.mdx
@@ -30,6 +30,21 @@ If `digger/apply` is itself a required status check, and the PR is blocked *only
 `skip_merge_check` to do so. `skip_merge_check` remains available below if you want to
 disable the mergeable check entirely for other reasons.
 
+### Requiring apply to pass before merge
+
+Digger posts two kinds of check: an aggregate `digger/plan`/`digger/apply` (covering every
+project touched by the PR) and a per-project `<project-name>/plan`/`<project-name>/apply` for
+each one. To make sure a PR can't merge until Digger has actually applied successfully, add
+the aggregate checks as required:
+
+1. On GitHub, go to **Settings → Branches** and edit (or add) a branch protection rule for
+   your target branch.
+2. Enable **Require status checks to pass before merging**.
+3. Search for and select `digger/plan` and `digger/apply`.
+
+These checks only become selectable in this list after they've been posted to the repo at
+least once - trigger a `digger plan` on any PR first if you don't see them yet.
+
 ### Usage
 
 You can enable the mergeable requirement on the project level:

--- a/docs/ce/howto/apply-requirements.mdx
+++ b/docs/ce/howto/apply-requirements.mdx
@@ -24,13 +24,11 @@ Here is an explanation of each:
 The mergeable requirement will prevent applies unless a pull request is able to be merged.
 In GitHub, if you're not using Protected Branches then all pull requests are mergeable unless there is a conflict.
 
-<Note>
-    If `digger/apply` is itself a required status check, and the PR is blocked *only* by
-    `digger/apply` (every other required check is passing, including any with a `neutral` or
-    `skipped` conclusion), Digger proceeds with the apply anyway - it doesn't require
-    `skip_merge_check` to do so. `skip_merge_check` remains available below if you want to
-    disable the mergeable check entirely for other reasons.
-</Note>
+If `digger/apply` is itself a required status check, and the PR is blocked *only* by
+`digger/apply` (every other required check is passing, including any with a `neutral` or
+`skipped` conclusion), Digger proceeds with the apply anyway - it doesn't require
+`skip_merge_check` to do so. `skip_merge_check` remains available below if you want to
+disable the mergeable check entirely for other reasons.
 
 ### Usage
 

--- a/docs/ce/howto/apply-requirements.mdx
+++ b/docs/ce/howto/apply-requirements.mdx
@@ -25,14 +25,11 @@ The mergeable requirement will prevent applies unless a pull request is able to 
 In GitHub, if you're not using Protected Branches then all pull requests are mergeable unless there is a conflict.
 
 <Note>
-    Setting `digger/apply` as a required status check on GitHub used to conflict with the
-    mergeable requirement (see [#1180](https://github.com/diggerhq/digger/issues/1180)):
-    GitHub reports the PR as blocked until `digger/apply` passes, but `digger/apply` can't
-    pass until apply actually runs. This is now handled automatically - if the PR is blocked
-    *only* by `digger/apply` itself (every other required check, including any with a
-    `neutral` or `skipped` conclusion, is passing), Digger proceeds with the apply anyway. You
-    no longer need `skip_merge_check` to work around this specific case; it remains available
-    below if you want to disable the mergeable check entirely for other reasons.
+    If `digger/apply` is itself a required status check, and the PR is blocked *only* by
+    `digger/apply` (every other required check is passing, including any with a `neutral` or
+    `skipped` conclusion), Digger proceeds with the apply anyway - it doesn't require
+    `skip_merge_check` to do so. `skip_merge_check` remains available below if you want to
+    disable the mergeable check entirely for other reasons.
 </Note>
 
 ### Usage

--- a/docs/ce/howto/apply-requirements.mdx
+++ b/docs/ce/howto/apply-requirements.mdx
@@ -25,10 +25,14 @@ The mergeable requirement will prevent applies unless a pull request is able to 
 In GitHub, if you're not using Protected Branches then all pull requests are mergeable unless there is a conflict.
 
 <Note>
-    There is a [known issue](https://github.com/diggerhq/digger/issues/1180) that would
-    cause the "mergability" check to conflict if you set the digger/apply check as required on github. We are working on a fix and in the meantime you have an option to turn off the mergability check if you want to have this digger/apply check as required. You can turn it off in the workflow configuration
-    by setting the `skip_merge_check` flag as follows (we have to set the other configurations since they are currently required):
-
+    Setting `digger/apply` as a required status check on GitHub used to conflict with the
+    mergeable requirement (see [#1180](https://github.com/diggerhq/digger/issues/1180)):
+    GitHub reports the PR as blocked until `digger/apply` passes, but `digger/apply` can't
+    pass until apply actually runs. This is now handled automatically - if the PR is blocked
+    *only* by `digger/apply` itself (every other required check, including any with a
+    `neutral` or `skipped` conclusion, is passing), Digger proceeds with the apply anyway. You
+    no longer need `skip_merge_check` to work around this specific case; it remains available
+    below if you want to disable the mergeable check entirely for other reasons.
 </Note>
 
 ### Usage

--- a/docs/ce/howto/multiacc-aws.mdx
+++ b/docs/ce/howto/multiacc-aws.mdx
@@ -67,6 +67,7 @@ jobs:
       pull-requests: write # required to post PR comments
       issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
+      checks: read         # required to check mergeability if digger/apply is a required status check
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -208,6 +208,18 @@ workflows:
   status check, leave this `false` - setting it `true` will leave that check permanently
   `in_progress` after a real apply, since Digger won't mark it complete, and the PR will
   never become mergeable.
+
+  Apply-on-comment, with `digger/apply` required (correct):
+  ```yml
+  disable_digger_apply_comment: false
+  disable_digger_apply_status_check: false
+  ```
+
+  Apply-after-merge, no PR left to carry a status check (also correct, but only for this flow):
+  ```yml
+  disable_digger_apply_comment: true
+  disable_digger_apply_status_check: true
+  ```
 </ParamField>
 
 <ParamField path="comment_render_mode" type="string" default="basic">

--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -201,6 +201,13 @@ workflows:
 
 <ParamField path="disable_digger_apply_status_check" type="boolean" default="false">
   Disable the status check that verifies apply was executed.
+
+  This is intended for the [apply-after-merge](/ce/howto/apply-on-merge) flow, where there's
+  no PR left at apply time to carry a status check. If you're using apply-on-comment
+  (applying before merge) and have `digger/apply` configured as a required branch-protection
+  status check, leave this `false` - setting it `true` will leave that check permanently
+  `in_progress` after a real apply, since Digger won't mark it complete, and the PR will
+  never become mergeable.
 </ParamField>
 
 <ParamField path="comment_render_mode" type="string" default="basic">

--- a/docs/ce/self-host/deploy-helm.mdx
+++ b/docs/ce/self-host/deploy-helm.mdx
@@ -288,6 +288,7 @@ description: "Learn how to use Helm chart to install Digger on your Kubernetes c
               pull-requests: write # required to post PR comments
               issues: read         # required to check if PR number is an issue or not
               statuses: write      # required to validate combined PR status
+              checks: read         # required to check mergeability if digger/apply is a required status check
 
             steps:
               - uses: actions/checkout@v4
@@ -331,6 +332,7 @@ description: "Learn how to use Helm chart to install Digger on your Kubernetes c
               pull-requests: write # required to post PR comments
               issues: read         # required to check if PR number is an issue or not
               statuses: write      # required to validate combined PR status
+              checks: read         # required to check mergeability if digger/apply is a required status check
             steps:
             - uses: actions/checkout@v4
             - name: ${{ fromJSON(github.event.inputs.spec).job_id }}
@@ -380,6 +382,7 @@ description: "Learn how to use Helm chart to install Digger on your Kubernetes c
               pull-requests: write # required to post PR comments
               issues: read         # required to check if PR number is an issue or not
               statuses: write      # required to validate combined PR status
+              checks: read         # required to check mergeability if digger/apply is a required status check
 
             steps:
               - uses: actions/checkout@v4

--- a/docs/ce/self-host/self-host-on-azure.mdx
+++ b/docs/ce/self-host/self-host-on-azure.mdx
@@ -160,6 +160,7 @@ jobs:
       pull-requests: write # required to post PR comments
       issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
+      checks: read         # required to check mergeability if digger/apply is a required status check
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/onboarding/configure-pr-automation-workflows.mdx
+++ b/docs/onboarding/configure-pr-automation-workflows.mdx
@@ -66,6 +66,7 @@ description: "Set up and verify PR automation with a minimal OpenTofu project be
           pull-requests: write
           issues: read
           statuses: write
+          checks: read # required to check mergeability if digger/apply is a required status check
 
         steps:
           - uses: actions/checkout@v4

--- a/docs/self-hosting/github-app-setup.mdx
+++ b/docs/self-hosting/github-app-setup.mdx
@@ -47,6 +47,21 @@ This app is required regardless of where services run (Docker Compose, Kubernete
   </Step>
 </Steps>
 
+## Re-installing or replacing the GitHub App (e.g. blue/green backend deployments)
+
+If you ever install a new GitHub App to point at a redeployed or replacement backend (for
+example a blue/green cutover of the orchestrator), note that each installation has its own
+GitHub App ID. If any repository's branch protection has a required status check pinned to a
+specific app (`required_status_checks.checks[].app_id` via the GitHub API, or "Require status
+checks to pass" → a check tied to a specific app in the GitHub UI) for a Digger-posted
+context such as `digger/plan` or `digger/apply`, that pin will silently start blocking merges
+after the cutover - GitHub rejects the check because it was posted by a different app ID than
+the one the rule expects, even though the check itself passed.
+
+Before or immediately after switching installations, check each repository's required status
+checks and clear the `app_id` pin (set it to "any source" / `-1` via the API) on any
+Digger-posted context, so it isn't tied to one specific app installation.
+
 ## Required backend environment variables
 
 - `PUBLIC_BASE_URL`: reachable public URL for orchestrator callback generation

--- a/docs/team/getting-started/gha-aws.mdx
+++ b/docs/team/getting-started/gha-aws.mdx
@@ -61,6 +61,7 @@ jobs:
       pull-requests: write # required to post PR comments
       issues: read         # required to check if PR number is an issue or not
       statuses: write      # required to validate combined PR status
+      checks: read         # required to check mergeability if digger/apply is a required status check
 
     steps:
       - uses: actions/checkout@v4

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -812,8 +812,10 @@ func (svc GithubService) getRequiredCheckContextsForPR(prNumber int) ([]required
 	}
 
 	// GraphQL lives at a different path than the REST base URL (which go-github's Client
-	// already has configured, including for GitHub Enterprise Server): api.github.com/graphql
-	// for github.com, or https://HOSTNAME/api/graphql for GHES (REST base ends .../api/v3/).
+	// already has configured): api.github.com/graphql for github.com, or
+	// https://HOSTNAME/api/graphql for GHES (REST base ends .../api/v3/). The github.com case
+	// is confirmed against a live workflow run; the GHES case follows from the URL structure
+	// but has not been tested against a real GHES instance.
 	graphqlURL := strings.TrimSuffix(svc.Client.BaseURL.String(), "v3/") + "graphql"
 
 	req, err := http.NewRequest("POST", graphqlURL, bytes.NewReader(body))

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -868,6 +868,12 @@ func (svc GithubService) isBlockedOnlyByDiggerApply(prNumber int) (bool, error) 
 		return false, fmt.Errorf("could not get required check contexts for PR %v: %v", prNumber, err)
 	}
 
+	return blockedOnlyByDiggerApply(contexts), nil
+}
+
+// blockedOnlyByDiggerApply is the pure decision logic behind isBlockedOnlyByDiggerApply,
+// separated out so it can be unit tested without a live GitHub API call.
+func blockedOnlyByDiggerApply(contexts []requiredCheckContext) bool {
 	// GitHub's branch protection docs state that a required status check passes with a
 	// "successful, skipped, or neutral" conclusion — not "success" alone:
 	// https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
@@ -895,10 +901,10 @@ func (svc GithubService) isBlockedOnlyByDiggerApply(prNumber int) (bool, error) 
 			continue
 		}
 		slog.Debug("PR blocked by non-digger required check", "check", ctx.Name, "state", ctx.State)
-		return false, nil
+		return false
 	}
 
-	return true, nil
+	return true
 }
 
 func (svc GithubService) IsMerged(prNumber int) (bool, error) {

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -730,8 +730,22 @@ func (svc GithubService) isBlockedOnlyByDiggerApply(headSHA string) (bool, error
 		return false, fmt.Errorf("could not get check runs for commit %v: %v", headSHA, err)
 	}
 
+	// GitHub's branch protection docs state that a required status check passes with a
+	// "successful, skipped, or neutral" conclusion — not "success" alone:
+	// https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
+	// ("Required status checks must have a successful, skipped, or neutral status before
+	// collaborators can make changes to a protected branch."). Matching only "success" here
+	// caused digger/apply to stay blocked even when every other required check had
+	// legitimately concluded "skipped" or "neutral" (e.g. a scanner that doesn't run on this
+	// PR but is still marked required).
+	passingConclusions := map[string]bool{
+		"success": true,
+		"skipped": true,
+		"neutral": true,
+	}
+
 	for _, run := range checkRuns {
-		if run.GetConclusion() == "success" {
+		if passingConclusions[run.GetConclusion()] {
 			continue
 		}
 		if strings.HasPrefix(run.GetName(), "digger/apply") {

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -1,9 +1,12 @@
 package github
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -714,44 +717,184 @@ func (svc GithubService) IsMergeable(prNumber int) (bool, error) {
 	// When the PR is blocked solely because digger/apply is a required check that hasn't
 	// passed yet, allow the apply to proceed — it's the only way to satisfy that check.
 	if strings.ToLower(pr.GetMergeableState()) == "blocked" {
-		return svc.isBlockedOnlyByDiggerApply(pr.GetHead().GetSHA())
+		return svc.isBlockedOnlyByDiggerApply(prNumber)
 	}
 
 	return false, nil
 }
 
-// isBlockedOnlyByDiggerApply returns true if the only non-successful check runs on the
-// commit are digger/apply checks. This breaks the chicken-and-egg problem where digger/apply
-// is a required branch protection check: the apply must run to pass the check, but the
-// mergeability gate would otherwise prevent it from running.
-func (svc GithubService) isBlockedOnlyByDiggerApply(headSHA string) (bool, error) {
-	checkRuns, err := svc.GetCheckRunsForCommit(headSHA)
+// requiredCheckContext is a normalized view of a single statusCheckRollup context, merging
+// GitHub's two distinct context types (CheckRun and the legacy StatusContext) into one shape.
+type requiredCheckContext struct {
+	Name       string
+	State      string // normalized upper-case conclusion/state, e.g. SUCCESS, NEUTRAL, SKIPPED, FAILURE, PENDING
+	IsRequired bool
+}
+
+type statusCheckRollupResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				Commits struct {
+					Nodes []struct {
+						Commit struct {
+							StatusCheckRollup struct {
+								Contexts struct {
+									Nodes []struct {
+										Typename   string `json:"__typename"`
+										Name       string `json:"name"`
+										Conclusion string `json:"conclusion"`
+										Context    string `json:"context"`
+										State      string `json:"state"`
+										IsRequired bool   `json:"isRequired"`
+									} `json:"nodes"`
+								} `json:"contexts"`
+							} `json:"statusCheckRollup"`
+						} `json:"commit"`
+					} `json:"nodes"`
+				} `json:"commits"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// getRequiredCheckContextsForPR fetches the PR's statusCheckRollup via GraphQL. Unlike the
+// REST check-runs list (GetCheckRunsForCommit), which returns every check-run ever posted to
+// a commit with no way to tell which ones actually gate merging, statusCheckRollup carries a
+// per-context isRequired flag — reflecting the same merge-box view any collaborator can
+// already see, not branch-protection configuration itself, so it doesn't need admin-level
+// access the way GET /branches/{branch}/protection or GraphQL's branchProtectionRules do
+// (both confirmed to return 403/FORBIDDEN for a standard token).
+func (svc GithubService) getRequiredCheckContextsForPR(prNumber int) ([]requiredCheckContext, error) {
+	query := `query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first: 100) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    isRequired(pullRequestNumber: $number)
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    isRequired(pullRequestNumber: $number)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	body, err := json.Marshal(map[string]interface{}{
+		"query": query,
+		"variables": map[string]interface{}{
+			"owner":  svc.Owner,
+			"name":   svc.RepoName,
+			"number": prNumber,
+		},
+	})
 	if err != nil {
-		return false, fmt.Errorf("could not get check runs for commit %v: %v", headSHA, err)
+		return nil, fmt.Errorf("could not marshal graphql request: %v", err)
+	}
+
+	// GraphQL lives at a different path than the REST base URL (which go-github's Client
+	// already has configured, including for GitHub Enterprise Server): api.github.com/graphql
+	// for github.com, or https://HOSTNAME/api/graphql for GHES (REST base ends .../api/v3/).
+	graphqlURL := strings.TrimSuffix(svc.Client.BaseURL.String(), "v3/") + "graphql"
+
+	req, err := http.NewRequest("POST", graphqlURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("could not build graphql request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := svc.Client.Client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("graphql request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var parsed statusCheckRollupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("could not decode graphql response: %v", err)
+	}
+	if len(parsed.Errors) > 0 {
+		return nil, fmt.Errorf("graphql errors: %v", parsed.Errors)
+	}
+
+	commitNodes := parsed.Data.Repository.PullRequest.Commits.Nodes
+	if len(commitNodes) == 0 {
+		return nil, nil
+	}
+
+	var contexts []requiredCheckContext
+	for _, n := range commitNodes[0].Commit.StatusCheckRollup.Contexts.Nodes {
+		name := n.Name
+		state := strings.ToUpper(n.Conclusion)
+		if n.Typename == "StatusContext" {
+			name = n.Context
+			state = strings.ToUpper(n.State)
+		}
+		contexts = append(contexts, requiredCheckContext{
+			Name:       name,
+			State:      state,
+			IsRequired: n.IsRequired,
+		})
+	}
+	return contexts, nil
+}
+
+// isBlockedOnlyByDiggerApply returns true if the only *required* status contexts on the PR
+// that aren't passing are digger/apply itself. This breaks the chicken-and-egg problem where
+// digger/apply is a required branch protection check: the apply must run to pass the check,
+// but the mergeability gate would otherwise prevent it from running.
+func (svc GithubService) isBlockedOnlyByDiggerApply(prNumber int) (bool, error) {
+	contexts, err := svc.getRequiredCheckContextsForPR(prNumber)
+	if err != nil {
+		return false, fmt.Errorf("could not get required check contexts for PR %v: %v", prNumber, err)
 	}
 
 	// GitHub's branch protection docs state that a required status check passes with a
 	// "successful, skipped, or neutral" conclusion — not "success" alone:
 	// https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
 	// ("Required status checks must have a successful, skipped, or neutral status before
-	// collaborators can make changes to a protected branch."). Matching only "success" here
-	// caused digger/apply to stay blocked even when every other required check had
-	// legitimately concluded "skipped" or "neutral" (e.g. a scanner that doesn't run on this
-	// PR but is still marked required).
-	passingConclusions := map[string]bool{
-		"success": true,
-		"skipped": true,
-		"neutral": true,
+	// collaborators can make changes to a protected branch.").
+	passingStates := map[string]bool{
+		"SUCCESS": true,
+		"SKIPPED": true,
+		"NEUTRAL": true,
 	}
 
-	for _, run := range checkRuns {
-		if passingConclusions[run.GetConclusion()] {
+	for _, ctx := range contexts {
+		// Only required contexts can block merging at all — matches GitHub's own
+		// mergeable_state calculation. Previously every context on the commit was
+		// evaluated regardless of required-ness, which incorrectly blocked apply on
+		// non-required checks (e.g. our own workflow's native job-status check, or
+		// Digger's own project-scoped status checks).
+		if !ctx.IsRequired {
 			continue
 		}
-		if strings.HasPrefix(run.GetName(), "digger/apply") {
+		if strings.HasPrefix(ctx.Name, "digger/apply") {
 			continue
 		}
-		slog.Debug("PR blocked by non-digger check", "check", run.GetName(), "conclusion", run.GetConclusion())
+		if passingStates[ctx.State] {
+			continue
+		}
+		slog.Debug("PR blocked by non-digger required check", "check", ctx.Name, "state", ctx.State)
 		return false, nil
 	}
 

--- a/libs/ci/github/github_merge_check_test.go
+++ b/libs/ci/github/github_merge_check_test.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockedOnlyByDiggerApply_AllRequiredPassingExceptDiggerApply(t *testing.T) {
+	contexts := []requiredCheckContext{
+		{Name: "Validate Platform Metadata", State: "SUCCESS", IsRequired: true},
+		{Name: "Wiz IaC Scanner", State: "NEUTRAL", IsRequired: true},
+		{Name: "digger/plan", State: "SUCCESS", IsRequired: true},
+		{Name: "digger/apply", State: "", IsRequired: true},
+	}
+
+	assert.True(t, blockedOnlyByDiggerApply(contexts))
+}
+
+func TestBlockedOnlyByDiggerApply_RequiredCheckFailing(t *testing.T) {
+	contexts := []requiredCheckContext{
+		{Name: "Validate Platform Metadata", State: "FAILURE", IsRequired: true},
+		{Name: "digger/apply", State: "", IsRequired: true},
+	}
+
+	assert.False(t, blockedOnlyByDiggerApply(contexts))
+}
+
+func TestBlockedOnlyByDiggerApply_NonRequiredCheckFailingIsIgnored(t *testing.T) {
+	// Reproduces the real scenario hit during testing: our own workflow's native
+	// job-status check ("Digger") and Digger's own project-scoped status check
+	// (e.g. "digger-version-test-poc/apply") both failed, but neither is a required
+	// check, so they must not block apply.
+	contexts := []requiredCheckContext{
+		{Name: "Digger", State: "FAILURE", IsRequired: false},
+		{Name: "digger-version-test-poc/apply", State: "FAILURE", IsRequired: false},
+		{Name: "Wiz IaC Scanner", State: "NEUTRAL", IsRequired: true},
+		{Name: "digger/apply", State: "", IsRequired: true},
+	}
+
+	assert.True(t, blockedOnlyByDiggerApply(contexts))
+}
+
+func TestBlockedOnlyByDiggerApply_SkippedAndNeutralAreAccepted(t *testing.T) {
+	contexts := []requiredCheckContext{
+		{Name: "Validate Platform Metadata", State: "SKIPPED", IsRequired: true},
+		{Name: "Wiz IaC Scanner", State: "NEUTRAL", IsRequired: true},
+		{Name: "digger/apply", State: "", IsRequired: true},
+	}
+
+	assert.True(t, blockedOnlyByDiggerApply(contexts))
+}
+
+func TestBlockedOnlyByDiggerApply_NoContexts(t *testing.T) {
+	assert.True(t, blockedOnlyByDiggerApply(nil))
+}


### PR DESCRIPTION
**Fixes #1180** - # 7 on the community-ranked [Top Issues list](https://github.com/diggerhq/digger/issues/1352).

## Problem

`isBlockedOnlyByDiggerApply` (added in #2661) is meant to let `digger apply` proceed when a
PR's `mergeable_state` is `"blocked"` only because `digger/apply` itself hasn't passed yet.
Trying to productionise this against a repo with several other required checks turned up two
remaining bugs:

1. It only accepted a check-run conclusion of exactly `"success"`. GitHub's docs state
   required checks accept `"success"`, `"skipped"`, or `"neutral"` - a required check
   concluding `neutral` (a valid pass) caused Digger to treat the PR as blocked by more than
   `digger/apply`, and refuse to proceed.
2. It fetched every check-run ever posted to the commit via REST
   (`GET /commits/{sha}/check-runs`), with no way to tell which ones are actually required. A
   calling workflow's own native job-status check, or Digger's own project-scoped check (e.g.
   `myproject/apply`, distinct from the generic `digger/apply`), could each incorrectly block
   apply even though neither is required for merging.

## What this does

- Replaces the REST check-runs list with the PR's `statusCheckRollup` via GraphQL, which
  carries a per-context `isRequired(pullRequestNumber: ...)` flag - the same rolled-up
  merge-box view any collaborator can see, so it doesn't need the branch-protection admin
  scope that `GET /branches/{branch}/protection` or GraphQL's `branchProtectionRules` require
  (confirmed `403`/`FORBIDDEN` for a standard token on both). Only required contexts are now
  considered when deciding if a PR is blocked.
- Accepts `SUCCESS`, `SKIPPED`, and `NEUTRAL` as passing states, matching [GitHub's documented
  required-check spec](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
- Extracts the decision logic into a pure, unit-testable function, `blockedOnlyByDiggerApply`.
- `GetCheckRunsForCommit` (REST) is untouched - it's still used elsewhere for check-run
  *updates*, a different concern.
- Docs:
  - Clarified `disable_digger_apply_status_check`'s interaction with apply-on-comment vs.
    apply-after-merge - it can leave a required `digger/apply` check stuck `in_progress`
    forever if left enabled outside the apply-after-merge flow. Added example config for both
    flows.
  - Added a walkthrough for actually configuring `digger/plan`/`digger/apply` as required
    status checks in GitHub branch protection.
  - Documented a gotcha where a required check pinned to a specific GitHub App ID silently
    blocks merges after a self-hosted backend re-installs its App (e.g. a blue/green deploy).
  - Added the `checks: read` permission (needed to read `statusCheckRollup`) to every example
    workflow permissions block that was missing it.

## Testing

- **Verified via a real deployment**, not just unit tests: built this fix into a backend image
  and deployed it to an actual self-hosted Digger backend. The CLI's prebuilt-binary download
  is hardcoded to fetch from `diggerhq/digger`'s own releases regardless of which repo the
  action is checked out from, so to test the CLI side without patching `action.yml`, the
  calling workflow built the CLI from source from this fork's branch and ran it via the
  existing `local-dev-mode`/`local-dev-cli-path` inputs.
- Exercised end-to-end against live PRs with several other required checks (security
  scanners, a metadata check) plus `digger/apply` itself, with `digger/apply` configured as a
  required branch-protection check: approving the PR and commenting `digger apply` correctly
  dispatched the job and the apply succeeded, creating a real resource - previously this was
  refused before any workflow even ran.
- 5 new unit tests for `blockedOnlyByDiggerApply`, including a case reproducing a
  non-required check failing (a calling workflow's own job-status check and a project-scoped
  check) to confirm it's correctly ignored.
- Not tested: GitHub Enterprise Server. The GraphQL endpoint URL construction should work the
  same way there but hasn't been verified against a real GHES instance.

### :brain: **Ai UsageDetails (if applicable):**

This PR - the code fix, tests, and documentation changes - was written with assistance from Claude
Code, based on my own investigation of the bug and test setup. I reviewed and verified all
generated code and documentation manually, and validated the fix via real deployments with a
self-hosted Digger backend (see Testing above).
