### PR TITLE
feat: add --fail-on-changes flag to digger plan

### DIFF
--- a/cli/cmd/digger/main.go
+++ b/cli/cmd/digger/main.go
@@ -17,6 +17,7 @@ Exit codes:
 6 - failed to process CI event
 7 - failed to convert event to command
 8 - failed to execute command
+9 - plan is not empty (digger plan --fail-on-changes only)
 10 - No CI detected
 */
 

--- a/cli/cmd/digger/main_test.go
+++ b/cli/cmd/digger/main_test.go
@@ -901,7 +901,7 @@ func TestGitHubNewPullRequestContext(t *testing.T) {
 
 	event := context.Event.(github.PullRequestEvent)
 	jobs, _, err := dggithub.ConvertGithubPullRequestEventToJobs(&event, impactedProjects, requestedProject, diggerConfig, false)
-	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "dir")
+	_, _, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "dir")
 
 	assert.NoError(t, err)
 	if err != nil {
@@ -931,7 +931,7 @@ func TestGitHubNewCommentContext(t *testing.T) {
 	backendApi := backendapi.MockBackendApi{}
 
 	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, map[string]configuration.Workflow{}, "prbranch", "", false)
-	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "")
+	_, _, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "")
 	assert.NoError(t, err)
 	if err != nil {
 		log.Println(err)

--- a/cli/pkg/digger/command_flags.go
+++ b/cli/pkg/digger/command_flags.go
@@ -1,0 +1,71 @@
+package digger
+
+import (
+	"fmt"
+	"strings"
+
+	orchestrator "github.com/diggerhq/digger/libs/scheduler"
+)
+
+const FailOnChangesFlag = "--fail-on-changes"
+
+// ParseFailOnChangesFlag returns the command with --fail-on-changes removed and whether it was
+// there, looking only at the first non blank line, which is the command line
+// Leaves non digger commands (a "run ..." step) untouched
+func ParseFailOnChangesFlag(rawCommand string) (string, bool, error) {
+	commandLine := ""
+	for _, line := range strings.Split(rawCommand, "\n") {
+		if strings.TrimSpace(line) != "" {
+			commandLine = strings.TrimSpace(line)
+			break
+		}
+	}
+	if !strings.HasPrefix(strings.ToLower(commandLine), "digger ") {
+		return rawCommand, false, nil
+	}
+
+	fields := strings.Fields(commandLine)
+	kept := make([]string, 0, len(fields))
+	failOnChanges := false
+	for _, field := range fields {
+		name, _, hasValue := strings.Cut(strings.ToLower(field), "=")
+		if name != FailOnChangesFlag && name != strings.TrimPrefix(FailOnChangesFlag, "-") {
+			kept = append(kept, field)
+			continue
+		}
+		if hasValue {
+			return commandLine, false, fmt.Errorf("%v takes no value, drop the '=' part of '%v'", FailOnChangesFlag, field)
+		}
+		failOnChanges = true
+	}
+	if !failOnChanges {
+		return rawCommand, false, nil
+	}
+
+	command := strings.Join(kept, " ")
+	loweredCommand := strings.ToLower(command)
+	if loweredCommand != "digger plan" && !strings.HasPrefix(loweredCommand, "digger plan ") {
+		return command, false, fmt.Errorf("%v is only supported on 'digger plan', got '%v'", FailOnChangesFlag, commandLine)
+	}
+
+	return command, true, nil
+}
+
+// ApplyCommandFlags moves flags off the command strings onto the job itself, so that
+// everything downstream keeps matching bare commands such as "digger plan".
+func ApplyCommandFlags(jobs []orchestrator.Job) error {
+	for i := range jobs {
+		// jobs sharing a workflow share this slice with the digger_config, don't rewrite it
+		commands := make([]string, len(jobs[i].Commands))
+		for j, rawCommand := range jobs[i].Commands {
+			command, failOnChanges, err := ParseFailOnChangesFlag(rawCommand)
+			if err != nil {
+				return err
+			}
+			commands[j] = command
+			jobs[i].FailOnChanges = jobs[i].FailOnChanges || failOnChanges
+		}
+		jobs[i].Commands = commands
+	}
+	return nil
+}

--- a/cli/pkg/digger/command_flags_test.go
+++ b/cli/pkg/digger/command_flags_test.go
@@ -1,0 +1,174 @@
+package digger
+
+import (
+	"testing"
+
+	orchestrator "github.com/diggerhq/digger/libs/scheduler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFailOnChangesFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		rawCommand    string
+		command       string
+		failOnChanges bool
+		wantErr       bool
+	}{
+		{
+			name:       "plan without the flag is untouched",
+			rawCommand: "digger plan",
+			command:    "digger plan",
+		},
+		{
+			name:          "plan with the flag",
+			rawCommand:    "digger plan --fail-on-changes",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			name:          "position within the command does not matter",
+			rawCommand:    "digger --fail-on-changes plan",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			name:          "surrounding whitespace",
+			rawCommand:    "  digger plan --fail-on-changes  ",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			name:          "single dash spelling",
+			rawCommand:    "digger plan -fail-on-changes",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			name:       "a command without the flag is returned byte for byte",
+			rawCommand: "  digger plan  -d 'my  dir'  ",
+			command:    "  digger plan  -d 'my  dir'  ",
+		},
+		{
+			name:          "combined with the project flags a comment can carry",
+			rawCommand:    "digger plan -p dev --fail-on-changes",
+			command:       "digger plan -p dev",
+			failOnChanges: true,
+		},
+		{
+			// the comment path lowercases the command for itself, so the case is left as it was
+			name:          "a capitalised command",
+			rawCommand:    "Digger Plan --fail-on-changes",
+			command:       "Digger Plan",
+			failOnChanges: true,
+		},
+		{
+			name:          "a capitalised flag",
+			rawCommand:    "digger plan --Fail-On-Changes",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			name:          "a comment that carries the flag on its command line",
+			rawCommand:    "digger plan --fail-on-changes\n\nchecking whether dev is clean",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			// the GitHub web UI sends CRLF line endings
+			name:          "a CRLF comment that carries the flag on its command line",
+			rawCommand:    "digger plan --fail-on-changes\r\n\r\nchecking whether dev is clean",
+			command:       "digger plan",
+			failOnChanges: true,
+		},
+		{
+			name:       "a comment that only mentions the flag further down",
+			rawCommand: "digger plan\n\nnote to self: do not use --fail-on-changes here",
+			command:    "digger plan\n\nnote to self: do not use --fail-on-changes here",
+		},
+		{
+			name:       "an apply comment that only mentions the flag further down",
+			rawCommand: "digger apply\n\n(we can't use --fail-on-changes for this one)",
+			command:    "digger apply\n\n(we can't use --fail-on-changes for this one)",
+		},
+		{
+			name:       "flag on a capitalised apply is rejected",
+			rawCommand: "Digger Apply --fail-on-changes",
+			wantErr:    true,
+		},
+		{
+			name:       "an explicit value is rejected rather than ignored",
+			rawCommand: "digger plan --fail-on-changes=true",
+			wantErr:    true,
+		},
+		{
+			name:       "a command that merely starts like plan is rejected",
+			rawCommand: "digger planet --fail-on-changes",
+			wantErr:    true,
+		},
+		{
+			name:       "flag on apply is rejected",
+			rawCommand: "digger apply --fail-on-changes",
+			wantErr:    true,
+		},
+		{
+			name:       "flag on unlock is rejected",
+			rawCommand: "digger unlock --fail-on-changes",
+			wantErr:    true,
+		},
+		{
+			name:       "non digger commands are left alone",
+			rawCommand: "run echo 'hello  world'",
+			command:    "run echo 'hello  world'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, failOnChanges, err := ParseFailOnChangesFlag(tt.rawCommand)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.command, command)
+			assert.Equal(t, tt.failOnChanges, failOnChanges)
+		})
+	}
+}
+
+func TestApplyCommandFlags(t *testing.T) {
+	// every job using the workflow shares this slice with the digger_config
+	workflowCommands := []string{"digger plan --fail-on-changes"}
+	jobs := []orchestrator.Job{
+		{ProjectName: "first", Commands: workflowCommands},
+		{ProjectName: "second", Commands: workflowCommands},
+	}
+
+	err := ApplyCommandFlags(jobs)
+
+	assert.NoError(t, err)
+	for _, job := range jobs {
+		assert.Equal(t, []string{"digger plan"}, job.Commands, job.ProjectName)
+		assert.True(t, job.FailOnChanges, job.ProjectName)
+	}
+	assert.Equal(t, []string{"digger plan --fail-on-changes"}, workflowCommands, "the digger_config slice must not be rewritten")
+}
+
+func TestApplyCommandFlagsWithoutTheFlag(t *testing.T) {
+	jobs := []orchestrator.Job{{ProjectName: "first", Commands: []string{"run echo hello", "digger plan"}}}
+
+	err := ApplyCommandFlags(jobs)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"run echo hello", "digger plan"}, jobs[0].Commands)
+	assert.False(t, jobs[0].FailOnChanges)
+}
+
+func TestApplyCommandFlagsRejectsTheFlagOnApply(t *testing.T) {
+	jobs := []orchestrator.Job{{ProjectName: "first", Commands: []string{"digger apply --fail-on-changes"}}}
+
+	err := ApplyCommandFlags(jobs)
+
+	assert.ErrorContains(t, err, "only supported on 'digger plan'")
+}

--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -65,7 +65,7 @@ func DetectCI() CIName {
 
 }
 
-func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgService ci.OrgService, lock locking2.Lock, reporter reporting.Reporter, planStorage storage.PlanStorage, policyChecker policy.Checker, commentUpdater comment_updater.CommentUpdater, backendApi backendapi.Api, jobId string, reportFinalStatusToBackend bool, reportTerraformOutput bool, prCommentId string, workingDir string) (bool, bool, error) {
+func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgService ci.OrgService, lock locking2.Lock, reporter reporting.Reporter, planStorage storage.PlanStorage, policyChecker policy.Checker, commentUpdater comment_updater.CommentUpdater, backendApi backendapi.Api, jobId string, reportFinalStatusToBackend bool, reportTerraformOutput bool, prCommentId string, workingDir string) (bool, bool, bool, error) {
 	defer reporter.Flush()
 
 	slog.Debug("Variable info", "TF_PLUGIN_CACHE_DIR", os.Getenv("TF_PLUGIN_CACHE_DIR"))
@@ -74,6 +74,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 
 	exectorResults := make([]execution.DiggerExecutorResult, len(jobs))
 	appliesPerProject := make(map[string]bool)
+	failOnChangesTriggered := false
 
 	for i, job := range jobs {
 		splits := strings.Split(job.Namespace, "/")
@@ -100,7 +101,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 			allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, job.PullRequestNumber, job.RequestedBy, teams, approvals, approvalTeams, []string{})
 
 			if err != nil {
-				return false, false, fmt.Errorf("error checking policy: %v", err)
+				return false, false, failOnChangesTriggered, fmt.Errorf("error checking policy: %v", err)
 			}
 
 			if !allowedToPerformCommand {
@@ -122,6 +123,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 				break
 			}
 			exectorResults[i] = *executorResult
+			failOnChangesTriggered = failOnChangesTriggered || planTriggeredFailOnChanges(job, *executorResult)
 
 		}
 	}
@@ -142,7 +144,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 			cmt, cmt_err := prService.PublishComment(*currentJob.PullRequestNumber, fmt.Sprintf(":yellow_circle: Warning: failed to post report for project %v, received error: %v.\n\n you may review details in the job logs", currentJob.ProjectName, err))
 			if cmt_err != nil {
 				slog.Error("Error while posting error comment", "error", err)
-				return false, false, fmt.Errorf("failed to post reporter error comment, aborting. Error: %v", err)
+				return false, false, failOnChangesTriggered, fmt.Errorf("failed to post reporter error comment, aborting. Error: %v", err)
 			}
 			jobPrCommentUrl = cmt.Url
 		}
@@ -161,7 +163,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 		batchResult, err := backendApi.ReportProjectJobStatus(currentJob.Namespace, projectNameForBackendReporting, jobId, "succeeded", time.Now(), &summary, "", jobPrCommentUrl, jobPrCommentId, terraformOutput, iacUtils)
 		if err != nil {
 			slog.Error("error reporting Job status", "error", err)
-			return false, false, fmt.Errorf("error while running command: %v", err)
+			return false, false, failOnChangesTriggered, fmt.Errorf("error while running command: %v", err)
 		}
 
 		// Check if batchResult is nil (can happen with mock backend or when backend is not configured)
@@ -171,7 +173,7 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 			err = commentUpdater.UpdateComment(batchResult.Jobs, prNumber, prService, prCommentId)
 			if err != nil {
 				slog.Error("error Updating status comment", "error", err, "prNumber", prNumber, "jobId", jobId)
-				return false, false, err
+				return false, false, failOnChangesTriggered, err
 			}
 		}
 
@@ -179,7 +181,11 @@ func RunJobs(jobs []orchestrator.Job, prService ci.PullRequestService, orgServic
 
 	atLeastOneApply := len(appliesPerProject) > 0
 
-	return allAppliesSuccess, atLeastOneApply, nil
+	return allAppliesSuccess, atLeastOneApply, failOnChangesTriggered, nil
+}
+
+func planTriggeredFailOnChanges(job orchestrator.Job, result execution.DiggerExecutorResult) bool {
+	return job.FailOnChanges && result.PlanResult != nil && result.PlanResult.IsNonEmptyPlan
 }
 
 func reportPolicyError(projectName string, command string, requestedBy string, reporter reporting.Reporter) string {
@@ -370,8 +376,9 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 				OperationType:   execution.DiggerOparationTypePlan,
 				TerraformOutput: plan,
 				PlanResult: &execution.DiggerExecutorPlanResult{
-					PlanSummary:   *planSummary,
-					TerraformJson: planJsonOutput,
+					PlanSummary:    *planSummary,
+					TerraformJson:  planJsonOutput,
+					IsNonEmptyPlan: isNonEmptyPlan,
 				},
 			}
 			return &result, plan, nil
@@ -644,9 +651,11 @@ func RunJob(
 	backendApi backendapi.Api,
 	driftNotification *core_drift.Notification,
 	workingDir string,
-) error {
+) (bool, error) {
 	SCMOrganisation, SCMrepository := utils.ParseRepoNamespace(repo)
 	slog.Info("Running commands for project", "commands", job.Commands, "project name", job.ProjectName)
+
+	failOnChangesTriggered := false
 
 	// Use teams, approvals, and approval_teams from the job (computed on backend/webhook side)
 	teams := job.Teams
@@ -668,7 +677,7 @@ func RunJob(
 		allowedToPerformCommand, err := policyChecker.CheckAccessPolicy(SCMOrganisation, SCMrepository, job.ProjectName, job.ProjectDir, command, nil, requestedBy, teams, approvals, approvalTeams, []string{})
 
 		if err != nil {
-			return fmt.Errorf("error checking policy: %v", err)
+			return false, fmt.Errorf("error checking policy: %v", err)
 		}
 
 		if !allowedToPerformCommand {
@@ -677,7 +686,7 @@ func RunJob(
 				slog.Error("Error publishing comment.", "error", err)
 			}
 			slog.Error(msg)
-			return errors.New(msg)
+			return false, errors.New(msg)
 		}
 
 		err = job.PopulateAwsCredentialsEnvVarsForJob()
@@ -743,23 +752,24 @@ func RunJob(
 			if err != nil {
 				slog.Error("Failed to send usage report.", "error", err)
 			}
-			_, _, _, _, planJsonOutput, err := diggerExecutor.Plan()
+			_, _, isNonEmptyPlan, _, planJsonOutput, err := diggerExecutor.Plan()
 			if err != nil {
 				msg := fmt.Sprintf("Failed to Run digger plan command. %v", err)
 				slog.Error(msg)
-				return fmt.Errorf("%s", msg)
+				return false, fmt.Errorf("%s", msg)
 			}
+			failOnChangesTriggered = failOnChangesTriggered || (job.FailOnChanges && isNonEmptyPlan)
 			planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, approvalTeams, planJsonOutput)
 			slog.Info(strings.Join(messages, "\n"))
 			if err != nil {
 				msg := fmt.Sprintf("Failed to validate plan %v", err)
 				slog.Error(msg)
-				return fmt.Errorf("%s", msg)
+				return false, fmt.Errorf("%s", msg)
 			}
 			if !planIsAllowed {
 				msg := fmt.Sprintf("Plan is not allowed")
 				slog.Error(msg)
-				return fmt.Errorf("%s", msg)
+				return false, fmt.Errorf("%s", msg)
 			} else {
 			}
 
@@ -772,7 +782,7 @@ func RunJob(
 			if err != nil {
 				msg := fmt.Sprintf("Failed to Run digger apply command. %v", err)
 				slog.Error(msg)
-				return fmt.Errorf("%s", msg)
+				return false, fmt.Errorf("%s", msg)
 			}
 		case "digger destroy":
 			err := usage.SendUsageRecord(requestedBy, job.EventName, "destroy")
@@ -782,18 +792,18 @@ func RunJob(
 			_, err = diggerExecutor.Destroy()
 			if err != nil {
 				slog.Error("Failed to Run digger destroy command.", "error", err)
-				return fmt.Errorf("failed to Run digger apply command. %v", err)
+				return false, fmt.Errorf("failed to Run digger apply command. %v", err)
 			}
 
 		case "digger drift-detect":
 			_, err = runDriftDetection(policyChecker, SCMOrganisation, SCMrepository, job.ProjectName, requestedBy, job.EventName, diggerExecutor, driftNotification)
 			if err != nil {
-				return fmt.Errorf("failed to Run digger drift-detect command. %v", err)
+				return false, fmt.Errorf("failed to Run digger drift-detect command. %v", err)
 			}
 		}
 
 	}
-	return nil
+	return failOnChangesTriggered, nil
 }
 
 func runDriftDetection(policyChecker policy.Checker, SCMOrganisation string, SCMrepository string, projectName string, requestedBy string, eventName string, diggerExecutor execution.Executor, notification *core_drift.Notification) (string, error) {

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -515,3 +515,56 @@ func TestParseWorkspace(t *testing.T) {
 	}
 
 }
+
+func TestPlanTriggeredFailOnChanges(t *testing.T) {
+	nonEmpty := execution.DiggerExecutorResult{PlanResult: &execution.DiggerExecutorPlanResult{IsNonEmptyPlan: true}}
+	empty := execution.DiggerExecutorResult{PlanResult: &execution.DiggerExecutorPlanResult{IsNonEmptyPlan: false}}
+	// a plan that never ran, because the project was locked by another PR
+	skipped := execution.DiggerExecutorResult{}
+
+	tests := []struct {
+		name     string
+		job      orchestrator.Job
+		result   execution.DiggerExecutorResult
+		expected bool
+	}{
+		{
+			name:     "an opted in project has changes",
+			job:      orchestrator.Job{FailOnChanges: true},
+			result:   nonEmpty,
+			expected: true,
+		},
+		{
+			name:     "an opted in project is clean",
+			job:      orchestrator.Job{FailOnChanges: true},
+			result:   empty,
+			expected: false,
+		},
+		{
+			// projects can use different workflows, so only some of them opt in
+			name:     "changes belong to a project that did not opt in",
+			job:      orchestrator.Job{FailOnChanges: false},
+			result:   nonEmpty,
+			expected: false,
+		},
+		{
+			name:     "plan was skipped",
+			job:      orchestrator.Job{FailOnChanges: true},
+			result:   skipped,
+			expected: false,
+		},
+		{
+			// digger apply and the like never produce a plan result
+			name:     "not a plan",
+			job:      orchestrator.Job{FailOnChanges: true},
+			result:   execution.DiggerExecutorResult{ApplyResult: &execution.DiggerExecutorApplyResult{}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, planTriggeredFailOnChanges(tt.job, tt.result))
+		})
+	}
+}

--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -80,6 +80,9 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		os.Setenv("DIGGER_OUT", diggerOutPath)
 	}
 
+	exitCode := 0
+	exitMessage := "Digger finished successfully"
+
 	runningMode := os.Getenv("INPUT_DIGGER_MODE")
 
 	parsedGhActionContext, err := github_models.GetGitHubContext(ghContext)
@@ -141,6 +144,10 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		if command == "" {
 			usage.ReportErrorAndExit(githubActor, "provide 'command' to run in 'manual' mode", 1)
 		}
+		command, failOnChanges, err := digger.ParseFailOnChangesFlag(command)
+		if err != nil {
+			usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Invalid 'command' input. %s", err), 1)
+		}
 		project := os.Getenv("INPUT_DIGGER_PROJECT")
 		if project == "" {
 			usage.ReportErrorAndExit(githubActor, "provide 'project' to run in 'manual' mode", 2)
@@ -190,10 +197,15 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			Namespace:                  ghRepository,
 			StateEnvVars:               stateEnvVars,
 			CommandEnvVars:             commandEnvVars,
+			FailOnChanges:              failOnChanges,
 		}
-		err = digger.RunJob(jobs, ghRepository, githubActor, &githubPrService, policyChecker, planStorage, backendApi, nil, currentDir)
+		failOnChangesTriggered, err := digger.RunJob(jobs, ghRepository, githubActor, &githubPrService, policyChecker, planStorage, backendApi, nil, currentDir)
 		if err != nil {
 			usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to run commands. %s", err), 8)
+		}
+		if failOnChangesTriggered {
+			exitCode = 9
+			exitMessage = fmt.Sprintf("Digger finished successfully, but project %v has a non-empty plan and --fail-on-changes was requested", project)
 		}
 	} else if runningMode == "drift-detection" {
 		blockFiltersStr := os.Getenv("INPUT_DIGGER_BLOCK_FILTERS")
@@ -267,7 +279,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 				CommandRoleArn:             cmdArn,
 			}
 
-			err = digger.RunJob(job, ghRepository, githubActor, &githubPrService, policyChecker, nil, backendApi, &notification, currentDir)
+			_, err = digger.RunJob(job, ghRepository, githubActor, &githubPrService, policyChecker, nil, backendApi, &notification, currentDir)
 			if err != nil {
 				slog.Error("Failed to run commands", "repository", ghRepository, "project", projectConfig.Name, "error", err)
 				notificationErr := notification.SendErrorNotificationForProject(projectConfig.Name, ghRepository, err)
@@ -310,6 +322,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 
 		var jobs []scheduler.Job
 		coversAllImpactedProjects := false
+		failOnChanges := false
 		err = nil
 		if prEvent, ok := ghEvent.(github.PullRequestEvent); ok {
 			jobs, coversAllImpactedProjects, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig, true)
@@ -322,7 +335,12 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			defaultBranch := *commentEvent.Repo.DefaultBranch
 			repoFullName := *commentEvent.Repo.FullName
 			requestedBy := *commentEvent.Sender.Login
-			commentBody := *commentEvent.Comment.Body
+
+			commentBody, commentFailOnChanges, flagErr := digger.ParseFailOnChangesFlag(*commentEvent.Comment.Body)
+			if flagErr != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to convert GitHub event to commands. %s", flagErr), 7)
+			}
+			failOnChanges = commentFailOnChanges
 
 			var impactedProjectsForEvent []digger_config.Project
 			if requestedProject != nil {
@@ -338,6 +356,15 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		if err != nil {
 			usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to convert GitHub event to commands. %s", err), 7)
 		}
+
+		// commands coming from digger.yml may still carry flags such as --fail-on-changes
+		if err := digger.ApplyCommandFlags(jobs); err != nil {
+			usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to convert GitHub event to commands. %s", err), 7)
+		}
+		for i := range jobs {
+			jobs[i].FailOnChanges = jobs[i].FailOnChanges || failOnChanges
+		}
+
 		slog.Info("GitHub event converted to commands successfully")
 		logCommands(jobs)
 
@@ -360,7 +387,7 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 
 		jobs = digger.SortedCommandsByDependency(jobs, &dependencyGraph)
 
-		allAppliesSuccessful, atLeastOneApply, err := digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "", false, false, "0", currentDir)
+		allAppliesSuccessful, atLeastOneApply, failOnChangesTriggered, err := digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "", false, false, "0", currentDir)
 		if !allAppliesSuccessful || err != nil {
 			// aggregate status checks: failure
 			if scheduler.IsPlanJobs(jobs) {
@@ -385,10 +412,15 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			}
 		}
 
+		if failOnChangesTriggered {
+			exitCode = 9
+			exitMessage = "Digger finished successfully, but at least one project has a non-empty plan and --fail-on-changes was requested"
+		}
+
 		slog.Info("Commands executed successfully")
 	}
 
-	usage.ReportErrorAndExit(githubActor, "Digger finished successfully", 0)
+	usage.ReportErrorAndExit(githubActor, exitMessage, exitCode)
 }
 
 // Helper function to search for a project in the configuration

--- a/cli/pkg/integration/integration_test.go
+++ b/cli/pkg/integration/integration_test.go
@@ -419,7 +419,7 @@ func TestHappyPath(t *testing.T) {
 
 	diggerProjectNamespace := repoOwner + "/" + repositoryName
 
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock := &locking.PullRequestLock{
@@ -446,7 +446,7 @@ func TestHappyPath(t *testing.T) {
 	prEvent := ghEvent.(github.PullRequestEvent)
 	jobs, _, err = dg_github.ConvertGithubPullRequestEventToJobs(&prEvent, impactedProjects, requestedProject, *diggerConfig, false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	println("--- digger apply comment ---")
@@ -460,7 +460,7 @@ func TestHappyPath(t *testing.T) {
 
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock = &locking.PullRequestLock{
@@ -483,7 +483,7 @@ func TestHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock = &locking.PullRequestLock{
@@ -572,7 +572,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 		CiService: &githubPrService,
 		PrNumber:  prNumber,
 	}
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock := &locking.PullRequestLock{
@@ -597,7 +597,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	println("--- digger apply comment ---")
@@ -610,7 +610,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock = &locking.PullRequestLock{
@@ -633,7 +633,7 @@ func TestMultiEnvHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, &dynamoDbLock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock = &locking.PullRequestLock{
@@ -791,7 +791,7 @@ workflows:
 		PrNumber:  prNumber,
 	}
 
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock := &locking.PullRequestLock{
@@ -816,7 +816,7 @@ workflows:
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	println("--- digger apply comment ---")
@@ -829,7 +829,7 @@ workflows:
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock = &locking.PullRequestLock{
@@ -851,7 +851,7 @@ workflows:
 	assert.NoError(t, err)
 	jobs, _, err = generic.ConvertIssueCommentEventToJobs("", "", 0, "", impactedProjects, impactedProjects, diggerConfig.Workflows, "prBranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
+	_, _, _, err = digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, nil, comment_updater.NoopCommentUpdater{}, nil, "", false, false, "123", dir)
 	assert.NoError(t, err)
 
 	projectLock = &locking.PullRequestLock{

--- a/cli/pkg/spec/manual.go
+++ b/cli/pkg/spec/manual.go
@@ -136,7 +136,7 @@ func RunSpecManualCommand(
 	commentUpdater := comment_summary.NoopCommentUpdater{}
 	// do not change these placeholders as they are parsed by dgctl to stream logs
 	slog.Info("<========= DIGGER RUNNING IN MANUAL MODE =========>")
-	allAppliesSuccess, _, err := digger.RunJobs(jobs, prService, orgService, lock, reporter, planStorage, policyChecker, commentUpdater, noopBackendApi, spec.JobId, false, false, commentId, currentDir)
+	allAppliesSuccess, _, _, err := digger.RunJobs(jobs, prService, orgService, lock, reporter, planStorage, policyChecker, commentUpdater, noopBackendApi, spec.JobId, false, false, commentId, currentDir)
 	slog.Info("<========= DIGGER COMPLETED =========>")
 	if err != nil || allAppliesSuccess == false {
 		usage.ReportErrorAndExit(spec.VCS.RepoOwner, "Terraform execution failed", 1)

--- a/cli/pkg/spec/spec.go
+++ b/cli/pkg/spec/spec.go
@@ -156,7 +156,7 @@ func RunSpec(
 	}
 
 	reportTerraformOutput := spec.Reporter.ReportTerraformOutput
-	allAppliesSuccess, _, err := digger.RunJobs(jobs, prService, orgService, lock, reporter, planStorage, policyChecker, commentUpdater, backendApi, spec.JobId, true, reportTerraformOutput, commentId, currentDir)
+	allAppliesSuccess, _, _, err := digger.RunJobs(jobs, prService, orgService, lock, reporter, planStorage, policyChecker, commentUpdater, backendApi, spec.JobId, true, reportTerraformOutput, commentId, currentDir)
 	if !allAppliesSuccess || err != nil {
 		serializedBatch, reportingError := backendApi.ReportProjectJobStatus(spec.VCS.RepoName, spec.Job.ProjectName, spec.JobId, "failed", time.Now(), nil, "", "", "", "", nil)
 		if reportingError != nil {

--- a/cli/pkg/usage/usage.go
+++ b/cli/pkg/usage/usage.go
@@ -113,7 +113,7 @@ func init() {
 }
 
 func ReportErrorAndExit(repoOwner string, message string, exitCode int) {
-	if exitCode == 0 {
+	if exitCode == 0 || exitCode == 9 {
 		slog.Info(message)
 	} else {
 		slog.Error(message)

--- a/docs/ce/features/commentops.mdx
+++ b/docs/ce/features/commentops.mdx
@@ -17,3 +17,7 @@ title: "CommentOps"
 `digger apply/plan`
 
 * **\-p** enables user to run the command for a particular project, e.g. `digger plan -p staging`
+
+`digger plan`
+
+* **\--fail-on-changes** makes the job exit non-zero when a project that asked for it has a non-empty plan, e.g. `digger plan --fail-on-changes`. Backendless and manual mode only. See [Fail on changes](/ce/howto/fail-on-changes).

--- a/docs/ce/howto/fail-on-changes.mdx
+++ b/docs/ce/howto/fail-on-changes.mdx
@@ -1,0 +1,101 @@
+---
+title: "Fail on Changes"
+description: "Make digger plan exit non-zero when a project has a non-empty plan, so an outer CI workflow can gate merges on it"
+---
+
+Digger already knows whether a plan came back empty - it's what drives the "No changes in
+terraform output" comment - but nothing outside the run can see it. `digger/plan` reports
+`success` whether or not there were changes, and the process exit code doesn't distinguish
+"no changes" either.
+
+The `--fail-on-changes` flag on `digger plan` surfaces that signal through the process exit
+code, in the same spirit as terraform's `-detailed-exitcode`:
+
+* **0** - every project that asked for the flag has an empty plan
+* **9** - at least one project that asked for the flag has a non-empty plan
+* anything else - the command itself failed
+
+Terraform uses `2` for this, but Digger already returns `2` when it fails to create a lock
+provider, so a dedicated code is used instead to keep "there are changes" distinguishable
+from "something broke".
+
+The flag is purely additive. On a pull request the plan still runs, still comments on the PR,
+still sets the commit status and still persists the plan artifact - only the exit code
+changes. It is not a quiet mode.
+
+<Note>
+  `--fail-on-changes` is only supported on `digger plan` - using it on any other command is
+  an error. It is resolved by the Digger CLI from the command it is given, so it works on
+  GitHub in [backendless mode](/ce/howto/backendless-mode) and in manual mode. It is not part
+  of the job spec the orchestrator backend hands out, so it does not work with the managed
+  backend: a PR comment is rejected (`failed to parse input ...`), and putting it in
+  `digger.yml` there makes the run fail as an unsupported command. Use it in backendless or
+  manual mode.
+</Note>
+
+## Gating merges on "no changes"
+
+You can turn the exit code into a single required status check that only passes when
+re-planning the affected projects at HEAD shows nothing left to do - in other words,
+"everything in this PR has actually been applied, and nothing has drifted". Read the caveats
+below before adopting it: gating this way needs `skip_merge_check: true`, and that has a cost.
+
+Ask for it in `digger.yml` so it applies to every push to the PR:
+
+```yaml
+projects:
+  - name: dev
+    dir: dev
+    workflow: with-merge-gate
+
+workflows:
+  with-merge-gate:
+    workflow_configuration:
+      on_pull_request_pushed: ["digger plan --fail-on-changes"]
+      on_pull_request_closed: [digger unlock]
+      on_commit_to_default: [digger apply]
+      skip_merge_check: true
+```
+
+The Digger job now fails while the PR still has unapplied changes. Make that job a required
+status check in your branch protection rules and the PR can't be merged until an apply has
+brought the projects up to date. Only the projects using this workflow are gated - projects on
+another workflow can have pending changes and the job still exits `0`, so put the flag on every
+workflow you want covered.
+
+The gate runs on push, so a `digger apply` comment does not re-run it - the check stays red
+until the next push. Push again once the apply is done to refresh it; an empty commit
+(`git commit --allow-empty`) is enough.
+
+<Warning>
+  `skip_merge_check: true` is not optional here. Once the gate job goes red, GitHub reports
+  the PR as `blocked`, and `digger apply` refuses to run on a PR that isn't mergeable - which
+  is the only thing that would make the gate green again. Without it the PR is stuck the
+  moment the gate first fails. Note that this also turns off the check that stops you applying
+  a PR with merge conflicts, so you are trading one merge safeguard for another.
+
+  Separately, a project locked by another PR has its plan skipped and reported as successful,
+  so the gate exits `0` without having re-planned it. Set `pr_locks: false` if that matters to
+  you.
+</Warning>
+
+## Asking for it ad hoc
+
+The flag also works as a PR comment, to check the current state on demand:
+
+```
+digger plan --fail-on-changes
+```
+
+and in [manual mode](/ce/reference/action-inputs), through the `command` input:
+
+```yaml
+- uses: diggerhq/digger@vLatest
+  with:
+    mode: manual
+    command: "digger plan --fail-on-changes"
+    project: dev
+  env:
+    GITHUB_CONTEXT: ${{ toJson(github) }}
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/docs/ce/reference/comment-args.mdx
+++ b/docs/ce/reference/comment-args.mdx
@@ -43,3 +43,13 @@ digger plan -p dev_vpc -p staging_vpc
 ```
 digger plan -p dev_vpc -d staging/vpc
 ```
+
+`digger plan` accepts one further flag, `--fail-on-changes`, which is handled by the Digger
+CLI rather than by the parser above and therefore only works in backendless and manual mode.
+It doesn't change what the plan does or what Digger reports - it only makes the job exit
+non-zero when at least one planned project has a non-empty plan, so an outer CI workflow can
+gate on it. See [Fail on changes](/ce/howto/fail-on-changes).
+
+```
+digger plan --fail-on-changes
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -193,6 +193,7 @@
               "ce/howto/apply-on-merge",
               "ce/howto/apply-requirements",
               "ce/howto/auto-merge",
+              "ce/howto/fail-on-changes",
               "ce/howto/custom-commands",
               "ce/howto/draft-prs",
               "ce/howto/codeowners",

--- a/docs/docs.jsonc
+++ b/docs/docs.jsonc
@@ -188,6 +188,7 @@
           "ce/howto/apply-on-merge",
           "ce/howto/apply-requirements",
           "ce/howto/auto-merge",
+          "ce/howto/fail-on-changes",
           "ce/howto/custom-commands",
           "ce/howto/draft-prs",
           "ce/howto/codeowners",

--- a/ee/cli/cmd/digger/main.go
+++ b/ee/cli/cmd/digger/main.go
@@ -19,6 +19,7 @@ Exit codes:
 6 - failed to process CI event
 7 - failed to convert event to command
 8 - failed to execute command
+9 - plan is not empty (digger plan --fail-on-changes only)
 10 - No CI detected
 */
 

--- a/ee/cli/cmd/digger/main_test.go
+++ b/ee/cli/cmd/digger/main_test.go
@@ -905,7 +905,7 @@ func TestGitHubNewPullRequestContext(t *testing.T) {
 		assert.NoError(t, err)
 		log.Println(err)
 	}
-	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "dir")
+	_, _, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "dir")
 
 	assert.NoError(t, err)
 	if err != nil {
@@ -937,7 +937,7 @@ func TestGitHubNewCommentContext(t *testing.T) {
 
 	jobs, _, err := generic.ConvertIssueCommentEventToJobs("", "", 0, "digger plan", impactedProjects, impactedProjects, map[string]configuration.Workflow{}, "prbranch", "main", false)
 	assert.NoError(t, err)
-	_, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "")
+	_, _, _, err = digger.RunJobs(jobs, &prManager, prManager, lock, reporter, &planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "123", false, false, "1", "")
 	assert.NoError(t, err)
 	if err != nil {
 		log.Println(err)

--- a/ee/cli/pkg/gitlab/gitlab.go
+++ b/ee/cli/pkg/gitlab/gitlab.go
@@ -115,7 +115,7 @@ func GitLabCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 				usage.ReportErrorAndExit(repoFullName, fmt.Sprintf("could not get drift notification type: %v", err), 8)
 			}
 
-			err = digger.RunJob(job, repoFullName, actor, prService, policyChecker, nil, backendApi, &notification, currentDir)
+			_, err = digger.RunJob(job, repoFullName, actor, prService, policyChecker, nil, backendApi, &notification, currentDir)
 			if err != nil {
 				usage.ReportErrorAndExit(repoOwner, fmt.Sprintf("Failed to run commands. %s", err), 8)
 			}

--- a/libs/execution/execution.go
+++ b/libs/execution/execution.go
@@ -121,8 +121,9 @@ type DiggerExecutorApplyResult struct {
 }
 
 type DiggerExecutorPlanResult struct {
-	PlanSummary   iac_utils.IacSummary
-	TerraformJson string
+	PlanSummary    iac_utils.IacSummary
+	TerraformJson  string
+	IsNonEmptyPlan bool
 }
 
 func (d DiggerExecutorResult) GetTerraformSummary() iac_utils.IacSummary {

--- a/libs/scheduler/jobs.go
+++ b/libs/scheduler/jobs.go
@@ -41,6 +41,7 @@ type Job struct {
 	CommandRoleArn             string
 	CognitoOidcConfig          *configuration.AwsCognitoOidcConfig
 	SkipMergeCheck             bool
+	FailOnChanges              bool
 	// Policy-related fields computed on backend/webhook side
 	Teams         []string
 	Approvals     []string

--- a/libs/scheduler/json_models_test.go
+++ b/libs/scheduler/json_models_test.go
@@ -49,7 +49,8 @@ func TestAllFieldsInJobAreAlsoInJobJson(t *testing.T) {
 	}
 
 	fmt.Printf("%v ::\n", specFields)
-	fieldsToIgnore := []string{"ProjectWorkflow", "StateEnvProvider", "CommandEnvProvider", "StateRoleArn", "CommandRoleArn", "CognitoOidcConfig", "SkipMergeCheck", "Layer"}
+	// FailOnChanges is resolved by the cli, it is not part of the orchestrator job spec
+	fieldsToIgnore := []string{"ProjectWorkflow", "StateEnvProvider", "CommandEnvProvider", "StateRoleArn", "CommandRoleArn", "CognitoOidcConfig", "SkipMergeCheck", "Layer", "FailOnChanges"}
 	for i := 0; i < nFieldsJob; i++ {
 		field := jobVal.Type().Field(i).Name
 		if slices.Contains(fieldsToIgnore, field) {


### PR DESCRIPTION
Closes #2676

## What

`digger plan --fail-on-changes` makes the run exit non-zero when a planned project has a
non-empty plan, so an outer CI workflow can gate merges on "nothing left to apply".

- `0` — every planned project has an empty plan
- `9` — at least one project that opted in has a non-empty plan
- anything else — the command itself failed

Purely additive: on a pull request the plan still runs, comments, sets the commit status and
persists the artifact. Only the exit code changes.

## Where it works

GitHub, without an orchestrator backend. One parser in `cli/pkg/digger` resolves the flag off
the command string, and the CLI is its only caller, so it works from a PR comment, from
`on_pull_request_pushed` in `digger.yml`, and from the manual-mode `command` input. The flag is
stripped before anything downstream sees it, so `IsPlan()`, the `run()` switch and policy
evaluation keep matching bare `"digger plan"`.

Everything shared with the orchestrator backend is untouched — `libs/ci` has no changes in this
PR and `FailOnChanges` is not part of `JobJson` — so with the managed backend the flag stays
undefined and the comment is rejected by `ParseDiggerCommentFlags` (`failed to parse input
digger plan --fail-on-changes`).

Comment flags being scoped to one mode is already the case here: `-d` / `--layer` /
`--project` only reach `ParseDiggerCommentFlags` on the backend, because backendless comment
parsing goes through the `-p` regex in `ParseProjectName`. Those three are dropped silently and
the command then runs against every impacted project. `--fail-on-changes` errors instead of
being dropped.

## Noticed but not fixed here

`cli/pkg/github/github.go` declares a second `err` inside the issue-comment branch, so every
error out of `ConvertIssueCommentEventToJobs` is discarded and the run carries on with no jobs
— which then sets `digger/plan` to `success`, since `IsPlanJobs([])` is vacuously true. So an
unrelated PR comment can turn that check green. It predates this PR and fixing it properly
needs a graceful path for comments that aren't digger commands, so I left it alone rather than
change existing behaviour here. Happy to open an issue or a follow-up PR.

## Questions for maintainers

1. **Flag vs action input.** The issue proposed a flag. If you'd prefer a `fail-on-changes: true`
   action input instead, `cli/pkg/digger/command_flags.go` and its tests go away along with the
   CLI wiring (~250 lines) — at the cost of per-project granularity.
2. **Exit code.** Terraform uses `2`, but digger already exits `2` for "failed to create lock
   provider", so I took `9`, which was unused in the `main.go` exit-code table.
3. **Merge-check interaction.** A red gate makes GitHub report the PR as `blocked`, and
   `digger apply` refuses to run on a non-mergeable PR — the only thing that would make the
   gate green again. `skip_merge_check: true` breaks the cycle and the docs require it, but it
   also disables the guard against applying a PR with merge conflicts, so users trade one merge
   safeguard for another. Exempting the gate in `isBlockedOnlyByDiggerApply`, or exposing this
   as a `digger/no-changes` commit status instead of an exit code, would avoid that trade.
   Which direction would you prefer?
4. **PR locks.** A project locked by another PR has its plan skipped and reported as
   successful, so the gate exits `0` without having re-planned it. I kept the existing lock
   semantics and documented the caveat.

## Tests & docs

Unit tests for flag parsing and result aggregation in `cli/pkg/digger` — including that changes
in a project that did *not* opt in don't trip the gate, since projects can use different
workflows, and that a plan skipped by a PR lock doesn't either. New
`ce/howto/fail-on-changes` page, plus entries in the comment args reference and the CommentOps
page.

### :brain: **Ai UsageDetails (if applicable):**

Implemented with Claude Code. Scope, design decisions and the final diff reviewed manually.
