### PR TITLE
fix: bump all node20 actions in action.yml to Node 24 versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -325,13 +325,13 @@ runs:
         clean: false
       if: ${{ github.event_name != 'issue_comment' && inputs.configure-checkout == 'true' }}
     - name: Set up Google Auth Using A Service Account Key
-      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         credentials_json: "${{ inputs.google-auth-credentials }}"
       if: ${{ inputs.setup-google-cloud == 'true' && inputs.google-auth-credentials != '' }}
 
     - name: Set up Google Auth Using Workload Identity Federation
-      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         token_format: access_token
         service_account: ${{ inputs.google-service-account }}
@@ -340,11 +340,11 @@ runs:
       if: ${{ inputs.setup-google-cloud == 'true' && inputs.google-workload-identity-provider != '' }}
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       if: inputs.setup-google-cloud == 'true'
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+      uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
@@ -353,7 +353,7 @@ runs:
       if: ${{ inputs.setup-aws == 'true' && inputs.aws-role-to-assume == '' }}
 
     - name: Configure OIDC AWS credentials
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+      uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
       with:
         role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
@@ -362,7 +362,7 @@ runs:
       if: ${{ inputs.setup-aws == 'true' && inputs.aws-role-to-assume != '' }}
 
     - name: Configure OIDC Azure credentials
-      uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+      uses: azure/login@a641126d1b8aa4d1fa005f4f92df94a3a4c4c906 # v3.1.0
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}
@@ -384,7 +384,7 @@ runs:
         echo "TG_PROVIDER_CACHE_DIR=$CACHE_DIR" >> $GITHUB_ENV
         echo "TERRAGRUNT_PROVIDER_CACHE_DIR=$CACHE_DIR" >> $GITHUB_ENV
 
-    - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: restore_cache
       name: restore_cache
       with:
@@ -414,7 +414,7 @@ runs:
 
     # Then terraform setup happens...
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ inputs.terraform-version }}
         terraform_wrapper: false
@@ -433,7 +433,7 @@ runs:
       if: inputs.setup-terragrunt == 'true'
 
     - name: Setup OpenTofu
-      uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
+      uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
       with:
         tofu_version: ${{ inputs.opentofu-version }}
         tofu_wrapper: false
@@ -442,7 +442,7 @@ runs:
       if: inputs.setup-opentofu == 'true'
 
     - name: Setup Pulumi
-      uses: pulumi/actions@a3f382e1242b69ab33854c253c3b580f1226348e # v4.5.1
+      uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
       with:
         tofu_version: ${{ inputs.pulumi-version }}
       if: inputs.setup-pulumi == 'true'
@@ -458,7 +458,7 @@ runs:
       if: inputs.setup-checkov == 'true'
 
     - name: setup go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: "${{ github.action_path }}/cli/go.mod"
         cache: false
@@ -705,7 +705,7 @@ runs:
         $BIN
         echo "✅ digger completed"
 
-    - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       name: cache-save
       if: ${{ always() && inputs.cache-dependencies == 'true' && steps.restore_cache.outputs.cache-hit != 'true' }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -315,12 +315,12 @@ runs:
         exit 1
       shell: bash
       if: inputs.setup-google-cloud == 'true'
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         clean: false
         ref: refs/pull/${{ github.event.issue.number }}/merge
       if: ${{ github.event_name == 'issue_comment' && inputs.configure-checkout == 'true' }}
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
         clean: false
       if: ${{ github.event_name != 'issue_comment' && inputs.configure-checkout == 'true' }}
@@ -485,7 +485,7 @@ runs:
       if: ${{ steps.determine-binary-mode.outputs.binary-mode != 'prebuilt' }}
 
     - name: Adding required env vars for next step
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         github-token: $GITHUB_TOKEN
       with:


### PR DESCRIPTION
## What

Bumps every Node 20 (or Node 16) action pinned inside `action.yml` to its current Node 24 major, same SHA-pinned style as the existing pins:

| Action | Sites | From | To | Runtime |
|---|---|---|---|---|
| `actions/checkout` | 2 | `34e11487` (v4.3.1) | `d23441a4` (v6.1.0) | node20 → node24 |
| `actions/github-script` | 1 | `f28e40c7` (v7.1.0) | `3a2844b7` (v9.0.0) | node20 → node24 |
| `actions/cache/restore`, `actions/cache/save` | 2 | `0057852b` (v4.3.0) | `55cc8345` (v6.1.0) | node20 → node24 |
| `aws-actions/configure-aws-credentials` | 2 | `7474bc46` (v4.3.1) | `cbe3b392` (v6.2.4) | node20 → node24 |
| `google-github-actions/auth` | 2 | `c200f369` (v2.1.13) | `7c6bc770` (v3.0.0) | node20 → node24 |
| `google-github-actions/setup-gcloud` | 1 | `e427ad8a` (v2.2.1) | `aa5489c8` (v3.0.1) | node20 → node24 |
| `hashicorp/setup-terraform` | 1 | `b9cd54a3` (v3.1.2) | `dfe3c3f8` (v4.0.1) | node20 → node24 |
| `pulumi/actions` | 1 | `a3f382e1` (v4.5.1) | `8e5e406f` (v7.0.0) | node16 → node24 |
| `actions/setup-go` | 1 | `d35c59ab` (v5.5.0) | `b7ad1dad` (v7.0.0) | node20 → node24 |
| `azure/login` | 1 | `a65d910e` (v2.2.0) | `a641126d` (v3.1.0) | node20 → node24 |
| `opentofu/setup-opentofu` | 1 | `592200bd` (v1.0.5) | `a1320f89` (v2.0.2) | node20 → node24 |

**Not bumped** (no Node 24 release exists upstream yet):

- `autero1/action-terragrunt` v3.0.2 (node20) — latest release
- `rhythmictech/actions-setup-tfenv` v0.1.2 (node16) — latest release

These two only run when `setup-terragrunt` / `setup-tfenv` are set to `true`, so they don't affect the default path. They'll need an upstream release or a replacement before 2026-09-23.

## Why

GitHub is removing Node 20 from Actions runners on **2026-09-23** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). After that date any step that declares `runs.using: node20` fails outright. Today every workflow using this action already emits the forced-Node-24 warning for the steps that execute.

All of these bumps are already queued (unchecked) on the Renovate Dependency Dashboard (#191) — this PR just lands them together. Follows the precedent of #2620, which manually bumped checkout to v4.3.1.

## Compatibility review

Checked the major-version release notes and confirmed every input `action.yml` passes still exists at the new SHA:

- `google-github-actions/auth` v3 "removed old parameters" — `credentials_json`, `token_format`, `service_account`, `workload_identity_provider`, `audience` all still present.
- `google-github-actions/setup-gcloud` v3 removed `skip_tool_cache` — not used here.
- `aws-actions/configure-aws-credentials` v5 changed invalid-boolean input handling — no boolean inputs are passed here. v5 is still node20, so went straight to v6.
- `pulumi/actions` v5/v6 are still node20, so went straight to v7. (Pre-existing, unrelated: the step passes `tofu_version:` rather than `pulumi-version:`; left as-is to keep this PR scoped.)
- `actions/cache` v6, `actions/setup-go` v7: ESM migration only, inputs unchanged.
- `azure/login` v3, `opentofu/setup-opentofu` v2, `hashicorp/setup-terraform` v4: Node 24 bump only.

## Notes

- Self-hosted runners need a runner version with Node 24 support (>= 2.327.1), which is already the case for anyone currently seeing the forced-Node-24 warning.
