### PR TITLE
fix(action): auto-detect digger-os and digger-arch from runner.os and runner.arch (#2608)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -255,13 +255,13 @@ inputs:
     required: false
     default: ""
   digger-os:
-    description: "OS variant of the digger CLI to install. Valid configurable values are: windows, linux, darwin, freebsd."
+    description: "OS variant of the digger CLI to install. Valid configurable values are: windows, linux, darwin, freebsd. Defaults to auto-detect from runner.os."
     required: false
-    default: "Linux"
+    default: ""
   digger-arch:
-    description: "Architecture of the digger CLI to install. Valid configurable values are: amd64, arm64, 386."
+    description: "Architecture of the digger CLI to install. Valid configurable values are: amd64, arm64, 386. Defaults to auto-detect from runner.arch."
     required: false
-    default: "X64"
+    default: ""
   log-level:
     description: "Log level for digger CLI. Valid values are: DEBUG, INFO, WARN, ERROR."
     required: false
@@ -594,8 +594,31 @@ runs:
       run: |
         set -euo pipefail
 
+        if [[ -z "$DIGGER_OS" || "$DIGGER_OS" == "Linux" ]]; then
+          case "${{ runner.os }}" in
+            Linux) DIGGER_OS="linux" ;;
+            macOS) DIGGER_OS="darwin" ;;
+            Windows) DIGGER_OS="windows" ;;
+            *) DIGGER_OS="$(echo "${DIGGER_OS:-linux}" | tr '[:upper:]' '[:lower:]')" ;;
+          esac
+        else
+          DIGGER_OS="$(echo "$DIGGER_OS" | tr '[:upper:]' '[:lower:]')"
+        fi
+
+        if [[ -z "$DIGGER_ARCH" || "$DIGGER_ARCH" == "X64" ]]; then
+          case "${{ runner.arch }}" in
+            X64) DIGGER_ARCH="amd64" ;;
+            ARM64) DIGGER_ARCH="arm64" ;;
+            ARM) DIGGER_ARCH="arm" ;;
+            X86) DIGGER_ARCH="386" ;;
+            *) DIGGER_ARCH="$(echo "${DIGGER_ARCH:-amd64}" | tr '[:upper:]' '[:lower:]')" ;;
+          esac
+        else
+          DIGGER_ARCH="$(echo "$DIGGER_ARCH" | tr '[:upper:]' '[:lower:]')"
+        fi
+
         echo "🔧 Downloading Digger CLI..."
-        echo "Runner OS: ${{ runner.os }}, Arch: ${{ runner.arch }}, Digger Version: ${DIGGER_VERSION}"
+        echo "Runner OS: ${{ runner.os }}, Arch: ${{ runner.arch }}, Resolved OS: ${DIGGER_OS}, Arch: ${DIGGER_ARCH}, Digger Version: ${DIGGER_VERSION}"
 
         if [[ ${{ inputs.ee }} == "true" ]]; then
           if [[ ${{ inputs.fips }} == "true" ]]; then


### PR DESCRIPTION
Fixes #2608

## Description
In `action.yml`, `digger-os` and `digger-arch` defaulted to hardcoded `"Linux"` and `"X64"`, causing self-hosted macOS, Windows, and ARM64 runners to attempt downloading the wrong binary variant unless manually overridden.

This PR updates `action.yml` to:
1. Change default inputs for `digger-os` and `digger-arch` to empty strings (`""`) to indicate auto-detection mode.
2. Auto-detect target OS (`linux`, `darwin`, `windows`) from `${{ runner.os }}` and architecture (`amd64`, `arm64`, `arm`, `386`) from `${{ runner.arch }}` when `DIGGER_OS` / `DIGGER_ARCH` are unconfigured or left at defaults.
3. Lowercase explicit input values for compatibility with Go-convention binary release asset names.

## Backward Compatibility
- Default Linux X64 runners continue to resolve to `linux` / `amd64` (`digger-cli-linux-amd64`).
- Explicitly setting `digger-os` or `digger-arch` continues to work as expected.