### PR TITLE
fix(github): use nil-safe getters in ListIssues to prevent panic on empty issue body (#2675)

### DIFF
--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -160,7 +160,7 @@ func (svc GithubService) ListIssues() ([]*ci.Issue, error) {
 				continue
 			}
 
-			allIssues = append(allIssues, &ci.Issue{ID: int64(*issue.Number), Title: *issue.Title, Body: *issue.Body})
+			allIssues = append(allIssues, &ci.Issue{ID: int64(issue.GetNumber()), Title: issue.GetTitle(), Body: issue.GetBody()})
 		}
 		if resp.NextPage == 0 {
 			break

--- a/libs/ci/github/github_test.go
+++ b/libs/ci/github/github_test.go
@@ -170,3 +170,37 @@ func TestGetApprovalsPaginatesBeyondFirstPage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"alice", "carol"}, approvals)
 }
+
+func TestListIssuesWithNilBody(t *testing.T) {
+	issueNum := 123
+	issueTitle := "Drift Issue Without Body"
+
+	pageOne := []*github.Issue{
+		{
+			Number: &issueNum,
+			Title:  &issueTitle,
+			Body:   nil,
+		},
+	}
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposIssuesByOwnerByRepo,
+			pageOne,
+		),
+	)
+
+	svc := GithubService{
+		Client:   github.NewClient(mockedHTTPClient),
+		Owner:    "diggerhq",
+		RepoName: "digger",
+	}
+
+	issues, err := svc.ListIssues()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(issues))
+	assert.Equal(t, int64(123), issues[0].ID)
+	assert.Equal(t, "Drift Issue Without Body", issues[0].Title)
+	assert.Equal(t, "", issues[0].Body)
+}


### PR DESCRIPTION
Fixes #2675

## Description
In `libs/ci/github/github.go`, `GithubService.ListIssues()` constructed `ci.Issue` items by direct pointer dereference `*issue.Body`. When an open issue in the repository has no body (`Body == nil`), this caused a runtime panic during drift detection runs.

This PR updates `GithubService.ListIssues()` to use `google/go-github`'s nil-safe getters (`issue.GetNumber()`, `issue.GetTitle()`, `issue.GetBody()`), ensuring that an issue without a body safely resolves `Body` to `""` without crashing the drift detection pipeline.

## Tests
Added `TestListIssuesWithNilBody` unit test in `libs/ci/github/github_test.go` verifying that `ListIssues()` safely handles an issue with a `nil` body without panicking.