### PR TITLE
fix(backend): include project_name in GetImpactedProjectSingle GORM query (#2665)

### DIFF
--- a/backend/models/storage.go
+++ b/backend/models/storage.go
@@ -772,12 +772,12 @@ func (db *Database) GetImpactedProjects(repoFullName string, commitSha string) (
 
 func (db *Database) GetImpactedProjectSingle(repoFullName string, commitSha string, projectName string) (*ImpactedProject, error) {
 	var impactedProject ImpactedProject
-	err := db.GormDB.Where("repo_full_name=? AND commit_sha = ?", repoFullName, commitSha).Find(&impactedProject).Error
+	err := db.GormDB.Where("repo_full_name = ? AND commit_sha = ? AND project_name = ?", repoFullName, commitSha, projectName).First(&impactedProject).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		slog.Error("failed to get impacted projects", "error", err, "repoFullName", repoFullName, "commitSha", commitSha)
+		slog.Error("failed to get impacted projects", "error", err, "repoFullName", repoFullName, "commitSha", commitSha, "projectName", projectName)
 		return nil, err
 	}
 	return &impactedProject, nil

--- a/backend/models/storage_test.go
+++ b/backend/models/storage_test.go
@@ -268,3 +268,38 @@ func TestDiggerLockFunctionalities(t *testing.T) {
 	assert.Equal(t, "org/repo2#dev", existingLocksAfterDeletion[0].Resource)
 	assert.Equal(t, "org/repo2#prod", existingLocksAfterDeletion[1].Resource)
 }
+
+func TestGetImpactedProjectSingle(t *testing.T) {
+	teardownSuite, db, _ := setupSuite(t)
+	defer teardownSuite(t)
+
+	err := db.GormDB.AutoMigrate(&ImpactedProject{})
+	assert.NoError(t, err)
+
+	repoFullName := "diggerhq/digger"
+	commitSha := "sha123"
+
+	ipA := ImpactedProject{
+		RepoFullName: repoFullName,
+		CommitSHA:    commitSha,
+		ProjectName:  "projectA",
+		Applied:      false,
+	}
+	ipB := ImpactedProject{
+		RepoFullName: repoFullName,
+		CommitSHA:    commitSha,
+		ProjectName:  "projectB",
+		Applied:      false,
+	}
+	assert.NoError(t, db.GormDB.Create(&ipA).Error)
+	assert.NoError(t, db.GormDB.Create(&ipB).Error)
+
+	resB, err := db.GetImpactedProjectSingle(repoFullName, commitSha, "projectB")
+	assert.NoError(t, err)
+	assert.NotNil(t, resB)
+	assert.Equal(t, "projectB", resB.ProjectName)
+
+	resNone, err := db.GetImpactedProjectSingle(repoFullName, commitSha, "projectC")
+	assert.NoError(t, err)
+	assert.Nil(t, resNone)
+}


### PR DESCRIPTION
Fixes #2665

## Description
In `backend/models/storage.go`, `GetImpactedProjectSingle` accepted `projectName string` as an argument but omitted `project_name = ?` from the GORM `.Where(...)` clause. Additionally, using `.Find(&impactedProject)` returned the first row matching `repo_full_name` and `commit_sha` regardless of which project was passed, causing `ImpactedProject.Applied` updates on multi-project PRs to repeatedly update the first project row. As a consequence, `AllImpactedProjectApplied` returned `false` for PRs with ≥2 projects, preventing auto-merge from firing.

This PR updates `GetImpactedProjectSingle` to:
1. Include `project_name = ?` in the GORM `.Where(...)` filter (`repo_full_name = ? AND commit_sha = ? AND project_name = ?`).
2. Use `.First(&impactedProject)` so that missing records correctly trigger `gorm.ErrRecordNotFound` handling to return `nil, nil`.

## Tests
Added `TestGetImpactedProjectSingle` in `backend/models/storage_test.go` verifying that `GetImpactedProjectSingle` correctly retrieves the specific matching `projectName` row and returns `nil, nil` for non-existent projects.