### PR TITLE
fix(cli): parse all comment flags with FilterOutProjectsFromComment in backendless mode (#2679)

### DIFF
--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -324,11 +324,9 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			requestedBy := *commentEvent.Sender.Login
 			commentBody := *commentEvent.Comment.Body
 
-			var impactedProjectsForEvent []digger_config.Project
-			if requestedProject != nil {
-				impactedProjectsForEvent = []digger_config.Project{*requestedProject}
-			} else {
-				impactedProjectsForEvent = impactedProjects
+			impactedProjectsForEvent, err := generic.FilterOutProjectsFromComment(impactedProjects, commentBody)
+			if err != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Error while filtering projects from comment: %v", err), 6)
 			}
 			jobs, coversAllImpactedProjects, err = generic.ConvertIssueCommentEventToJobs(repoFullName, requestedBy, prNumber, commentBody, impactedProjectsForEvent, impactedProjects, diggerConfig.Workflows, prBranchName, defaultBranch, true)
 		} else {

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -1143,30 +1143,16 @@ func ProcessGitHubEvent(ghEvent interface{}, diggerConfig *digger_config.DiggerC
 		}
 
 		impactedProjects, _ = diggerConfig.GetModifiedProjects(changedFiles)
-		requestedProject := scheduler.ParseProjectName(*event.Comment.Body)
-
-		if requestedProject == "" {
-			slog.Debug("no specific project requested in comment", "prNumber", prNumber)
-			return impactedProjects, nil, prNumber, nil
+		filteredProjects, err := generic.FilterOutProjectsFromComment(impactedProjects, *event.Comment.Body)
+		if err != nil {
+			slog.Error("error filtering projects from comment", "error", err, "prNumber", prNumber)
+			return nil, nil, 0, err
 		}
 
-		slog.Debug("specific project requested in comment",
-			"requestedProject", requestedProject,
-			"prNumber", prNumber)
-
-		for _, project := range impactedProjects {
-			if project.Name == requestedProject {
-				slog.Debug("found requested project in impacted projects",
-					"project", requestedProject,
-					"prNumber", prNumber)
-				return impactedProjects, &project, prNumber, nil
-			}
+		if len(filteredProjects) == 1 {
+			return impactedProjects, &filteredProjects[0], prNumber, nil
 		}
-
-		slog.Error("requested project not found in modified projects",
-			"requestedProject", requestedProject,
-			"prNumber", prNumber)
-		return nil, nil, 0, fmt.Errorf("requested project not found in modified projects")
+		return impactedProjects, nil, prNumber, nil
 
 	case github.MergeGroupEvent:
 		slog.Debug("merge group event received - not handled")


### PR DESCRIPTION
Fixes #2679

## Description
In `cli/pkg/github/github.go` and `libs/ci/github/github.go`, backendless mode previously relied on legacy regex `scheduler.ParseProjectName` which only recognized a single `-p <name>` flag. Documented multi-project flags (`--project`, repeated `-p`, `-d`, `--directory`, and `--layer`) were ignored, causing `impactedProjectsForEvent` to fall back to running **all** impacted projects in the PR (or truncating multi-project commands).

This PR updates `GitHubCI` and `ProcessGitHubEvent` to utilize `generic.FilterOutProjectsFromComment(impactedProjects, commentBody)`. This aligns backendless mode with the orchestrator backend, supporting:
1. Multi-project selection (`-p dev_vpc -p staging_vpc`).
2. Long-form flags (`--project dev_vpc`, `-d dev/vpc`, `--directory`).
3. Layer filtering (`--layer`).
4. Strict error reporting when requested projects do not exist in the impacted project list, preventing accidental full-PR execution.