### PR TITLE
feat: support apply in GitHub merge queue

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -235,15 +235,6 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		os.Exit(1)
 	}
 
-	projectLock := &locking2.PullRequestLock{
-		InternalLock:     lock,
-		Reporter:         reporter,
-		CIService:        prService,
-		ProjectName:      job.ProjectName,
-		ProjectNamespace: projectNamespace,
-		PrNumber:         *job.PullRequestNumber,
-	}
-
 	var terraformExecutor execution.TerraformExecutor
 	var iacUtils iac_utils.IacUtils
 	projectPath := path.Join(workingDir, job.ProjectDir)
@@ -276,28 +267,44 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		ProjectNamespace: projectNamespace,
 		ProjectName:      job.ProjectName,
 		PRNumber:         PRNumber,
+		Identifier:       job.PlanIdentifier,
 	}
 
-	diggerExecutor := execution.LockingExecutorWrapper{
-		ProjectLock: projectLock,
-		Executor: execution.DiggerExecutor{
-			ProjectNamespace:  projectNamespace,
-			ProjectName:       job.ProjectName,
-			ProjectPath:       projectPath,
-			StateEnvVars:      job.StateEnvVars,
-			RunEnvVars:        job.RunEnvVars,
-			CommandEnvVars:    job.CommandEnvVars,
-			ApplyStage:        job.ApplyStage,
-			PlanStage:         job.PlanStage,
-			CommandRunner:     commandRunner,
-			TerraformExecutor: terraformExecutor,
-			Reporter:          reporter,
-			PlanStorage:       planStorage,
-			PlanPathProvider:  planPathProvider,
-			IacUtils:          iacUtils,
-		},
+	executor := execution.DiggerExecutor{
+		ProjectNamespace:  projectNamespace,
+		ProjectName:       job.ProjectName,
+		ProjectPath:       projectPath,
+		StateEnvVars:      job.StateEnvVars,
+		RunEnvVars:        job.RunEnvVars,
+		CommandEnvVars:    job.CommandEnvVars,
+		ApplyStage:        job.ApplyStage,
+		PlanStage:         job.PlanStage,
+		CommandRunner:     commandRunner,
+		TerraformExecutor: terraformExecutor,
+		Reporter:          reporter,
+		PlanStorage:       planStorage,
+		PlanPathProvider:  planPathProvider,
+		IacUtils:          iacUtils,
 	}
-	executor := diggerExecutor.Executor.(execution.DiggerExecutor)
+	var executorToRun execution.Executor = executor
+	var lockingExecutor *execution.LockingExecutorWrapper
+	projectLockID := job.ProjectName
+	if !job.SkipProjectLock {
+		if job.PullRequestNumber == nil {
+			return nil, "missing pull request number", errors.New("cannot use a pull request lock without a pull request number")
+		}
+		projectLock := &locking2.PullRequestLock{
+			InternalLock:     lock,
+			Reporter:         reporter,
+			CIService:        prService,
+			ProjectName:      job.ProjectName,
+			ProjectNamespace: projectNamespace,
+			PrNumber:         *job.PullRequestNumber,
+		}
+		lockingExecutor = &execution.LockingExecutorWrapper{ProjectLock: projectLock, Executor: executor}
+		executorToRun = lockingExecutor
+		projectLockID = projectLock.LockId()
+	}
 
 	switch command {
 
@@ -306,7 +313,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		if err != nil {
 			slog.Error("failed to send usage report", "error", err)
 		}
-		planSummary, planPerformed, isNonEmptyPlan, plan, planJsonOutput, err := diggerExecutor.Plan()
+		planSummary, planPerformed, isNonEmptyPlan, plan, planJsonOutput, err := executorToRun.Plan()
 
 		if err != nil {
 			msg := fmt.Sprintf("Failed to Run digger plan command. %v", err)
@@ -315,7 +322,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			return nil, msg, fmt.Errorf("%s", msg)
 		} else if planPerformed {
 			if isNonEmptyPlan {
-				reportTerraformPlanOutput(reporter, projectLock.LockId(), plan)
+				reportTerraformPlanOutput(reporter, projectLockID, plan)
 
 				planIsAllowed, messages, err := policyChecker.CheckPlanPolicy(SCMrepository, SCMOrganisation, job.ProjectName, job.ProjectDir, requestedBy, teams, approvals, approvalTeams, planJsonOutput)
 				if err != nil {
@@ -363,7 +370,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 					}
 				}
 			} else {
-				reportEmptyPlanOutput(reporter, projectLock.LockId())
+				reportEmptyPlanOutput(reporter, projectLockID)
 			}
 
 			result := execution.DiggerExecutorResult{
@@ -383,17 +390,9 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 			slog.Error("failed to send usage report.", "error", err)
 		}
 
-		isMerged, err := prService.IsMerged(*job.PullRequestNumber)
+		isMergeable, isMerged, err := getPullRequestMergeStatus(job, prService)
 		if err != nil {
-			msg := fmt.Sprintf("Failed to check if PR is merged. %v", err)
-			return nil, msg, fmt.Errorf("%s", msg)
-		}
-
-		// this might go into some sort of "appliability" plugin later
-		isMergeable, err := prService.IsMergeable(*job.PullRequestNumber)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to check if PR is mergeable. %v", err)
-			return nil, msg, fmt.Errorf("%s", msg)
+			return nil, err.Error(), err
 		}
 		slog.Info("PR status Information", "mergeable", isMergeable, "merged", isMerged, "skipMergeCheck", job.SkipMergeCheck)
 		if !isMergeable && !isMerged && !job.SkipMergeCheck {
@@ -505,7 +504,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 
 			// Running apply
 
-			applySummary, applyPerformed, output, err := diggerExecutor.Apply()
+			applySummary, applyPerformed, output, err := executorToRun.Apply()
 			if err != nil {
 				//TODO reuse executor error handling
 				slog.Error("Failed to Run digger apply command.", "error", err)
@@ -529,7 +528,7 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		if err != nil {
 			slog.Error("Failed to send usage report.", "error", err)
 		}
-		_, err = diggerExecutor.Destroy()
+		_, err = executorToRun.Destroy()
 
 		if err != nil {
 			slog.Error("Failed to Run digger destroy command.", "error", err)
@@ -544,7 +543,10 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		if err != nil {
 			slog.Error("failed to send usage report.", "error", err)
 		}
-		err = diggerExecutor.Unlock()
+		if lockingExecutor == nil {
+			return nil, "project lock is disabled", errors.New("cannot unlock when the project lock is disabled")
+		}
+		err = lockingExecutor.Unlock()
 		if err != nil {
 			msg := fmt.Sprintf("Failed to unlock project. %v", err)
 			return nil, msg, fmt.Errorf("%s", msg)
@@ -561,7 +563,10 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		if err != nil {
 			slog.Error("failed to send usage report.", "error", err)
 		}
-		err = diggerExecutor.Lock()
+		if lockingExecutor == nil {
+			return nil, "project lock is disabled", errors.New("cannot lock when the project lock is disabled")
+		}
+		err = lockingExecutor.Lock()
 		if err != nil {
 			msg := fmt.Sprintf("Failed to lock project. %v", err)
 			return nil, msg, fmt.Errorf("%s", msg)
@@ -572,6 +577,27 @@ func run(command string, job orchestrator.Job, policyChecker policy.Checker, org
 		return nil, msg, fmt.Errorf("%s", msg)
 	}
 	return &execution.DiggerExecutorResult{}, "", nil
+}
+
+func getPullRequestMergeStatus(job orchestrator.Job, prService ci.PullRequestService) (bool, bool, error) {
+	if job.EventName == "merge_group" {
+		return true, false, nil
+	}
+	if job.PullRequestNumber == nil {
+		return false, false, errors.New("cannot check mergeability without a pull request number")
+	}
+
+	isMerged, err := prService.IsMerged(*job.PullRequestNumber)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to check if PR is merged: %w", err)
+	}
+
+	// This check can move into an appliability plugin later.
+	isMergeable, err := prService.IsMergeable(*job.PullRequestNumber)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to check if PR is mergeable: %w", err)
+	}
+	return isMergeable, isMerged, nil
 }
 
 func reportApplyMergeabilityError(reporter reporting.Reporter) string {

--- a/cli/pkg/digger/digger_test.go
+++ b/cli/pkg/digger/digger_test.go
@@ -72,6 +72,18 @@ type MockPRManager struct {
 	Commands []RunInfo
 }
 
+func TestGetPullRequestMergeStatusSkipsAPIsForMergeGroup(t *testing.T) {
+	manager := &MockPRManager{}
+	job := orchestrator.Job{EventName: "merge_group", SkipMergeCheck: true, SkipProjectLock: true}
+
+	isMergeable, isMerged, err := getPullRequestMergeStatus(job, manager)
+
+	assert.NoError(t, err)
+	assert.True(t, isMergeable)
+	assert.False(t, isMerged)
+	assert.Empty(t, manager.Commands)
+}
+
 func (m *MockPRManager) GetUserTeams(organisation string, user string) ([]string, error) {
 	return []string{}, nil
 }

--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/diggerhq/digger/cli/pkg/digger"
@@ -281,6 +282,44 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 			usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to flush drift notification. %s", err), 8)
 		}
 	} else {
+		if mergeGroupEvent, ok := ghEvent.(github.MergeGroupEvent); ok {
+			if err := verifyMergeGroupHead(currentDir, mergeGroupEvent.MergeGroup.GetHeadSHA()); err != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Merge group checkout verification failed. %s", err), 6)
+			}
+			impactedProjects, _, err := dg_github.ProcessGitHubMergeGroupEvent(&mergeGroupEvent, diggerConfig, dependencyGraph, &githubPrService)
+			if err != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to process GitHub merge group event. %s", err), 6)
+			}
+			if len(impactedProjects) == 0 {
+				slog.Info("No projects impacted by merge group")
+				return
+			}
+
+			planJobs, applyJobs, err := dg_github.ConvertGithubMergeGroupEventToJobs(&mergeGroupEvent, impactedProjects, *diggerConfig, true)
+			if err != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to convert GitHub merge group event to commands. %s", err), 7)
+			}
+			logCommands(planJobs)
+			logCommands(applyJobs)
+
+			planStorage, err := storage.NewPlanStorage(ghToken, repoOwner, repositoryName, nil)
+			if err != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to get plan storage. %s", err), 4)
+			}
+
+			planJobs = digger.SortedCommandsByDependency(planJobs, &dependencyGraph)
+			applyJobs = digger.SortedCommandsByDependency(applyJobs, &dependencyGraph)
+			reporter := &reporting.StdOutReporter{}
+			runner := func(jobs []scheduler.Job) (bool, bool, error) {
+				return digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "", false, false, "0", currentDir)
+			}
+			if err := runMergeGroupPhases(planJobs, applyJobs, runner); err != nil {
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed to run merge group plan and apply. %s", err), 8)
+			}
+
+			slog.Info("Merge group plan and apply completed successfully", "headSha", mergeGroupEvent.MergeGroup.GetHeadSHA())
+			return
+		}
 
 		impactedProjects, requestedProject, prNumber, err := dg_github.ProcessGitHubEvent(ghEvent, diggerConfig, &githubPrService)
 		if err != nil {
@@ -389,6 +428,43 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 	}
 
 	usage.ReportErrorAndExit(githubActor, "Digger finished successfully", 0)
+}
+
+type mergeGroupPhaseRunner func([]scheduler.Job) (bool, bool, error)
+
+func runMergeGroupPhases(planJobs []scheduler.Job, applyJobs []scheduler.Job, runner mergeGroupPhaseRunner) error {
+	plansSuccessful, _, err := runner(planJobs)
+	if err != nil {
+		return fmt.Errorf("merge group plan phase failed: %w", err)
+	}
+	if !plansSuccessful {
+		return errors.New("merge group plan phase failed")
+	}
+
+	appliesSuccessful, atLeastOneApply, err := runner(applyJobs)
+	if err != nil {
+		return fmt.Errorf("merge group apply phase failed: %w", err)
+	}
+	if !appliesSuccessful || !atLeastOneApply {
+		return errors.New("merge group apply phase failed")
+	}
+	return nil
+}
+
+func verifyMergeGroupHead(workingDir string, expectedHead string) error {
+	if expectedHead == "" {
+		return errors.New("merge group head SHA is empty")
+	}
+	command := exec.Command("git", "-C", workingDir, "rev-parse", "HEAD")
+	output, err := command.Output()
+	if err != nil {
+		return fmt.Errorf("could not read the checked-out commit: %w", err)
+	}
+	actualHead := strings.TrimSpace(string(output))
+	if actualHead != expectedHead {
+		return fmt.Errorf("checked-out commit %s does not match merge group head %s", actualHead, expectedHead)
+	}
+	return nil
 }
 
 // Helper function to search for a project in the configuration

--- a/cli/pkg/github/merge_group_test.go
+++ b/cli/pkg/github/merge_group_test.go
@@ -1,0 +1,69 @@
+package github
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/diggerhq/digger/libs/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMergeGroupPhasesDoesNotApplyAfterPlanFailure(t *testing.T) {
+	planJobs := []scheduler.Job{
+		{ProjectName: "network", Commands: []string{"digger plan"}},
+		{ProjectName: "database", Commands: []string{"digger plan"}},
+	}
+	applyJobs := []scheduler.Job{
+		{ProjectName: "network", Commands: []string{"digger apply"}},
+		{ProjectName: "database", Commands: []string{"digger apply"}},
+	}
+	calls := 0
+	runner := func(jobs []scheduler.Job) (bool, bool, error) {
+		calls++
+		for _, job := range jobs {
+			assert.Equal(t, []string{"digger plan"}, job.Commands)
+		}
+		return false, false, nil
+	}
+
+	err := runMergeGroupPhases(planJobs, applyJobs, runner)
+
+	require.ErrorContains(t, err, "plan phase failed")
+	assert.Equal(t, 1, calls)
+}
+
+func TestRunMergeGroupPhasesPlansAllProjectsBeforeApply(t *testing.T) {
+	planJobs := []scheduler.Job{
+		{ProjectName: "network", Commands: []string{"digger plan"}},
+		{ProjectName: "database", Commands: []string{"digger plan"}},
+	}
+	applyJobs := []scheduler.Job{
+		{ProjectName: "network", Commands: []string{"digger apply"}},
+		{ProjectName: "database", Commands: []string{"digger apply"}},
+	}
+	phaseCommands := make([][]string, 0, 2)
+	runner := func(jobs []scheduler.Job) (bool, bool, error) {
+		commands := make([]string, 0, len(jobs))
+		for _, job := range jobs {
+			commands = append(commands, job.Commands[0])
+		}
+		phaseCommands = append(phaseCommands, commands)
+		return true, jobs[0].Commands[0] == "digger apply", nil
+	}
+
+	err := runMergeGroupPhases(planJobs, applyJobs, runner)
+
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"digger plan", "digger plan"}, {"digger apply", "digger apply"}}, phaseCommands)
+}
+
+func TestVerifyMergeGroupHead(t *testing.T) {
+	output, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	head := strings.TrimSpace(string(output))
+
+	require.NoError(t, verifyMergeGroupHead(".", head))
+	require.ErrorContains(t, verifyMergeGroupHead(".", "not-the-head"), "does not match")
+}

--- a/docs/onboarding/configuring-github-actions-workflow.mdx
+++ b/docs/onboarding/configuring-github-actions-workflow.mdx
@@ -186,6 +186,35 @@ Start with default GitHub Actions cache behavior. If your repositories are large
   For the full set of supported GitHub Action inputs and configuration options, refer to the action source: [diggerhq/digger/action.yml](https://github.com/diggerhq/digger/blob/develop/action.yml).
 </Note>
 
+## 6) Run plan and apply in the merge queue
+
+GitHub Merge Queue can run Digger on the synthetic commit that GitHub will merge. Add the `merge_group` trigger to the Digger workflow:
+
+```yaml
+on:
+  pull_request:
+  issue_comment:
+    types: [created]
+  merge_group:
+    types: [checks_requested]
+```
+
+When GitHub sends this event, Digger compares the merge-group base and head commits. Digger then runs `plan` and `apply` for each changed project. Digger does not run pull-request mergeability checks and does not merge the pull request. GitHub merges the group only after the required workflow succeeds.
+
+Digger uses a fixed two-phase sequence for this event. It plans every changed project first. It starts the apply phase only if all plans pass.
+
+Keep the default Digger checkout enabled. Digger verifies that the checked-out commit is the merge-group head SHA. Digger also fails closed if GitHub returns its 300-file limit for a commit comparison because that file list can be incomplete.
+
+Configure the target branch ruleset as follows:
+
+- Require the Digger merge-group workflow.
+- Require the normal checks and reviews before a user can add a pull request to the queue.
+- Set the merge-queue group size to one pull request.
+- Set merge-queue build concurrency to one.
+- Use a Terraform or OpenTofu backend that supports state locking.
+
+Merge-group jobs have no pull request number. For this reason, Digger does not use its pull-request project lock for these jobs. The queue limits above prevent two merge-group applies from this repository from running at the same time. Backend state locking remains required.
+
 ## Next step
 
 After updating your workflow, open a PR with a change to at least project and verify `plan` and `digger apply` still complete successfully.

--- a/libs/ci/generic/events.go
+++ b/libs/ci/generic/events.go
@@ -169,6 +169,10 @@ func CreateJobsForProjects(projects []digger_config.Project, command string, eve
 		stateEnvVars, commandEnvVars := digger_config.CollectTerraformEnvConfig(workflow.EnvVars, performEnvVarsInterpolations)
 		StateEnvProvider, CommandEnvProvider := scheduler.GetStateAndCommandProviders(project)
 		workspace := project.Workspace
+		planIdentifier := ""
+		if event == "merge_group" && commitSha != nil {
+			planIdentifier = *commitSha
+		}
 		jobs = append(jobs, scheduler.Job{
 			ProjectName:                project.Name,
 			ProjectAlias:               project.Alias,
@@ -195,6 +199,8 @@ func CreateJobsForProjects(projects []digger_config.Project, command string, eve
 			StateRoleArn:               stateRole,
 			CognitoOidcConfig:          project.AwsCognitoOidcConfig,
 			SkipMergeCheck:             skipMerge,
+			PlanIdentifier:             planIdentifier,
+			SkipProjectLock:            event == "merge_group",
 		})
 	}
 	return jobs, nil

--- a/libs/ci/github/github.go
+++ b/libs/ci/github/github.go
@@ -142,6 +142,36 @@ func (svc GithubService) GetChangedFilesForCommit(owner string, repo string, com
 	return fileNames, nil
 }
 
+func (svc GithubService) GetChangedFilesBetweenCommits(base string, head string) ([]string, error) {
+	comparison, _, err := svc.Client.Repositories.CompareCommits(context.Background(), svc.Owner, svc.RepoName, base, head, &github.ListOptions{PerPage: 100})
+	if err != nil {
+		slog.Error("error comparing merge group commits", "error", err, "base", base, "head", head)
+		return nil, fmt.Errorf("error comparing merge group commits: %v", err)
+	}
+
+	return changedFileNamesFromComparison(comparison)
+}
+
+const githubCompareFileLimit = 300
+
+func changedFileNamesFromComparison(comparison *github.CommitsComparison) ([]string, error) {
+	if comparison == nil {
+		return nil, fmt.Errorf("GitHub returned an empty commit comparison")
+	}
+	if len(comparison.Files) >= githubCompareFileLimit {
+		return nil, fmt.Errorf("commit comparison returned %d files, which reached GitHub's limit; refusing an incomplete project selection", len(comparison.Files))
+	}
+
+	fileNames := make([]string, 0, len(comparison.Files))
+	for _, file := range comparison.Files {
+		fileNames = append(fileNames, file.GetFilename())
+		if file.PreviousFilename != nil {
+			fileNames = append(fileNames, file.GetPreviousFilename())
+		}
+	}
+	return fileNames, nil
+}
+
 func (svc GithubService) ListIssues() ([]*ci.Issue, error) {
 	allIssues := make([]*ci.Issue, 0)
 	opts := &github.IssueListByRepoOptions{
@@ -888,6 +918,55 @@ func getWorkflowCommands(config *digger_config.WorkflowConfiguration, commandTyp
 	}
 }
 
+func ConvertGithubMergeGroupEventToJobs(payload *github.MergeGroupEvent, impactedProjects []digger_config.Project, config digger_config.DiggerConfig, performEnvVarInterpolation bool) ([]scheduler.Job, []scheduler.Job, error) {
+	if payload == nil || payload.MergeGroup == nil || payload.Repo == nil {
+		return nil, nil, fmt.Errorf("invalid merge_group payload: missing required fields")
+	}
+	if payload.GetAction() != "checks_requested" {
+		return nil, nil, fmt.Errorf("unsupported merge_group action %q", payload.GetAction())
+	}
+
+	defaultBranch := payload.Repo.GetDefaultBranch()
+	headRef := strings.TrimPrefix(payload.MergeGroup.GetHeadRef(), "refs/heads/")
+	headSHA := payload.MergeGroup.GetHeadSHA()
+	if defaultBranch == "" || headRef == "" || headSHA == "" {
+		return nil, nil, fmt.Errorf("invalid merge_group payload: missing branch or commit data")
+	}
+
+	planJobs := make([]scheduler.Job, 0, len(impactedProjects))
+	applyJobs := make([]scheduler.Job, 0, len(impactedProjects))
+	for _, project := range impactedProjects {
+		projectJobs, err := generic.CreateJobsForProjects(
+			[]digger_config.Project{project},
+			"digger plan",
+			"merge_group",
+			payload.Repo.GetFullName(),
+			payload.Sender.GetLogin(),
+			config.Workflows,
+			nil,
+			&headSHA,
+			defaultBranch,
+			headRef,
+			performEnvVarInterpolation,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(projectJobs) != 1 {
+			return nil, nil, fmt.Errorf("expected one merge_group job for project %s, got %d", project.Name, len(projectJobs))
+		}
+		for i := range projectJobs {
+			projectJobs[i].SkipMergeCheck = true
+			projectJobs[i].Layer = project.Layer
+		}
+		planJobs = append(planJobs, projectJobs...)
+		applyJob := projectJobs[0]
+		applyJob.Commands = []string{"digger apply"}
+		applyJobs = append(applyJobs, applyJob)
+	}
+	return planJobs, applyJobs, nil
+}
+
 func ConvertGithubPullRequestEventToJobs(payload *github.PullRequestEvent, impactedProjects []digger_config.Project, requestedProject *digger_config.Project, config digger_config.DiggerConfig, performEnvVarInterpolation bool) ([]scheduler.Job, bool, error) {
 	workflows := config.Workflows
 	jobs := make([]scheduler.Job, 0)
@@ -1223,6 +1302,44 @@ func ProcessGitHubPullRequestEvent(payload *github.PullRequestEvent, diggerConfi
 	}
 
 	return impactedProjects, impactedProjectsSourceLocations, prNumber, nil
+}
+
+type CommitComparisonService interface {
+	GetChangedFilesBetweenCommits(base string, head string) ([]string, error)
+}
+
+func ProcessGitHubMergeGroupEvent(payload *github.MergeGroupEvent, diggerConfig *digger_config.DiggerConfig, dependencyGraph graph.Graph[string, digger_config.Project], ciService CommitComparisonService) ([]digger_config.Project, map[string]digger_config.ProjectToSourceMapping, error) {
+	if payload == nil || payload.MergeGroup == nil || payload.Repo == nil {
+		return nil, nil, fmt.Errorf("invalid merge_group payload: missing required fields")
+	}
+	if payload.GetAction() != "checks_requested" {
+		return nil, nil, fmt.Errorf("unsupported merge_group action %q", payload.GetAction())
+	}
+
+	baseSHA := payload.MergeGroup.GetBaseSHA()
+	headSHA := payload.MergeGroup.GetHeadSHA()
+	if baseSHA == "" || headSHA == "" {
+		return nil, nil, fmt.Errorf("invalid merge_group payload: missing commit data")
+	}
+
+	changedFiles, err := ciService.GetChangedFilesBetweenCommits(baseSHA, headSHA)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get changed files for merge group: %w", err)
+	}
+
+	impactedProjects, sourceMapping := diggerConfig.GetModifiedProjects(changedFiles)
+	defaultBranch := payload.Repo.GetDefaultBranch()
+	targetBranch := strings.TrimPrefix(payload.MergeGroup.GetBaseRef(), "refs/heads/")
+	impactedProjects = generic.FilterTargetBranchForImpactedProjects(impactedProjects, defaultBranch, targetBranch)
+
+	if diggerConfig.DependencyConfiguration.Mode == digger_config.DependencyConfigurationHard {
+		impactedProjects, err = generic.FindAllProjectsDependantOnImpactedProjects(impactedProjects, dependencyGraph)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to find all projects dependant on impacted projects: %w", err)
+		}
+	}
+
+	return impactedProjects, sourceMapping, nil
 }
 
 func ProcessGitHubPushEvent(payload *github.PushEvent, diggerConfig *digger_config.DiggerConfig, dependencyGraph graph.Graph[string, digger_config.Project], ciService ci.PullRequestService) ([]digger_config.Project, map[string]digger_config.ProjectToSourceMapping, *digger_config.Project, int, error) {

--- a/libs/ci/github/github_test.go
+++ b/libs/ci/github/github_test.go
@@ -1,14 +1,100 @@
 package github
 
 import (
-	"github.com/diggerhq/digger/libs/ci/generic"
 	"testing"
 
+	"github.com/diggerhq/digger/libs/ci/generic"
 	"github.com/diggerhq/digger/libs/digger_config"
 	"github.com/google/go-github/v61/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type mergeGroupChangedFilesServiceStub struct {
+	base  string
+	head  string
+	files []string
+}
+
+func (s *mergeGroupChangedFilesServiceStub) GetChangedFilesBetweenCommits(base, head string) ([]string, error) {
+	s.base = base
+	s.head = head
+	return s.files, nil
+}
+
+func TestProcessGitHubMergeGroupEventUsesSyntheticCommitRange(t *testing.T) {
+	config := &digger_config.DiggerConfig{
+		Projects: []digger_config.Project{
+			{Name: "network", Dir: "infra/network", Workflow: "default", Branch: digger_config.DefaultBranchName},
+			{Name: "database", Dir: "infra/database", Workflow: "default", Branch: digger_config.DefaultBranchName},
+		},
+	}
+	dependencyGraph, err := digger_config.CreateProjectDependencyGraph(config.Projects)
+	require.NoError(t, err)
+
+	service := &mergeGroupChangedFilesServiceStub{files: []string{"infra/network/main.tf"}}
+	event := &github.MergeGroupEvent{
+		Action: github.String("checks_requested"),
+		MergeGroup: &github.MergeGroup{
+			BaseSHA: github.String("base-sha"),
+			HeadSHA: github.String("merge-group-sha"),
+			BaseRef: github.String("refs/heads/main"),
+		},
+		Repo: &github.Repository{DefaultBranch: github.String("main")},
+	}
+
+	projects, _, err := ProcessGitHubMergeGroupEvent(event, config, dependencyGraph, service)
+
+	require.NoError(t, err)
+	assert.Equal(t, "base-sha", service.base)
+	assert.Equal(t, "merge-group-sha", service.head)
+	require.Len(t, projects, 1)
+	assert.Equal(t, "network", projects[0].Name)
+}
+
+func TestConvertGithubMergeGroupEventToJobsPlansAndAppliesExactSyntheticCommit(t *testing.T) {
+	event := &github.MergeGroupEvent{
+		Action: github.String("checks_requested"),
+		MergeGroup: &github.MergeGroup{
+			BaseRef: github.String("refs/heads/main"),
+			HeadRef: github.String("refs/heads/gh-readonly-queue/main/pr-42-deadbeef"),
+			HeadSHA: github.String("merge-group-sha"),
+		},
+		Repo: &github.Repository{
+			DefaultBranch: github.String("main"),
+			FullName:      github.String("acme/infrastructure"),
+		},
+		Sender: &github.User{Login: github.String("github-merge-queue[bot]")},
+	}
+	projects := []digger_config.Project{{Name: "network", Dir: "infra/network", Workflow: "default"}}
+	config := digger_config.DiggerConfig{Workflows: map[string]digger_config.Workflow{"default": {}}}
+
+	planJobs, applyJobs, err := ConvertGithubMergeGroupEventToJobs(event, projects, config, false)
+
+	require.NoError(t, err)
+	require.Len(t, planJobs, 1)
+	require.Len(t, applyJobs, 1)
+	job := planJobs[0]
+	assert.Equal(t, []string{"digger plan"}, job.Commands)
+	assert.Equal(t, []string{"digger apply"}, applyJobs[0].Commands)
+	assert.Equal(t, "merge_group", job.EventName)
+	assert.Equal(t, "merge-group-sha", job.PlanIdentifier)
+	assert.Nil(t, job.PullRequestNumber)
+	assert.True(t, job.SkipMergeCheck)
+	assert.True(t, job.SkipProjectLock)
+}
+
+func TestChangedFileNamesFromComparisonFailsClosedAtGitHubLimit(t *testing.T) {
+	files := make([]*github.CommitFile, githubCompareFileLimit)
+	for i := range files {
+		files[i] = &github.CommitFile{Filename: github.String("infra/file.tf")}
+	}
+
+	_, err := changedFileNamesFromComparison(&github.CommitsComparison{Files: files})
+
+	require.ErrorContains(t, err, "reached GitHub's limit")
+}
 
 func TestFindAllProjectsDependantOnImpactedProjects(t *testing.T) {
 

--- a/libs/execution/execution.go
+++ b/libs/execution/execution.go
@@ -143,6 +143,7 @@ type PlanPathProvider interface {
 
 type ProjectPathProvider struct {
 	PRNumber         *int
+	Identifier       string
 	ProjectPath      string
 	ProjectNamespace string
 	ProjectName      string
@@ -153,7 +154,9 @@ func (d ProjectPathProvider) ArtifactName() string {
 }
 
 func (d ProjectPathProvider) StoredPlanFilePath() string {
-	if d.PRNumber != nil {
+	if d.Identifier != "" {
+		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + d.Identifier + "-" + d.ProjectName + ".tfplan"
+	} else if d.PRNumber != nil {
 		prNumber := strconv.Itoa(*d.PRNumber)
 		return strings.ReplaceAll(d.ProjectNamespace, "/", "-") + "-" + prNumber + "-" + d.ProjectName + ".tfplan"
 	} else {

--- a/libs/execution/execution_test.go
+++ b/libs/execution/execution_test.go
@@ -6,6 +6,17 @@ import (
 	"testing"
 )
 
+func TestProjectPathProviderUsesPlanIdentifierWithoutPullRequest(t *testing.T) {
+	provider := ProjectPathProvider{
+		ProjectNamespace: "acme/infrastructure",
+		ProjectName:      "network",
+		ProjectPath:      "infra/network",
+		Identifier:       "merge-group-sha",
+	}
+
+	assert.Equal(t, "acme-infrastructure-merge-group-sha-network.tfplan", provider.StoredPlanFilePath())
+}
+
 func TestCorrectCleanUpWithoutRegexDoesNotProduceException(t *testing.T) {
 	stdout := `
 Note: Objects have changed outside of Terraform

--- a/libs/scheduler/jobs.go
+++ b/libs/scheduler/jobs.go
@@ -41,6 +41,10 @@ type Job struct {
 	CommandRoleArn             string
 	CognitoOidcConfig          *configuration.AwsCognitoOidcConfig
 	SkipMergeCheck             bool
+	// PlanIdentifier isolates plans that do not belong to a pull request.
+	PlanIdentifier string
+	// SkipProjectLock is for synthetic merge-queue commits that have no pull request number.
+	SkipProjectLock bool
 	// Policy-related fields computed on backend/webhook side
 	Teams         []string
 	Approvals     []string

--- a/libs/scheduler/json_models.go
+++ b/libs/scheduler/json_models.go
@@ -49,6 +49,8 @@ type JobJson struct {
 	BackendOrganisationName    string            `json:"backend_organisation_hostname"`
 	BackendJobToken            string            `json:"backend_job_token"`
 	SkipMergeCheck             bool              `json:"skip_merge_check"`
+	PlanIdentifier             string            `json:"plan_identifier,omitempty"`
+	SkipProjectLock            bool              `json:"skip_project_lock"`
 	CommandRoleArn             string            `json:"command_role_arn"`
 	StateRoleArn               string            `json:"state_role_arn"`
 	CognitoOidcConfig          *cognitoConfig    `json:"aws_cognito_oidc"`
@@ -110,6 +112,8 @@ func JobToJson(job Job, jobType DiggerCommand, organisationName string, branch s
 		BackendJobToken:            jobToken,
 		BackendOrganisationName:    organisationName,
 		SkipMergeCheck:             job.SkipMergeCheck,
+		PlanIdentifier:             job.PlanIdentifier,
+		SkipProjectLock:            job.SkipProjectLock,
 		CommandRoleArn:             job.CommandRoleArn,
 		StateRoleArn:               job.StateRoleArn,
 		CognitoOidcConfig:          job.CognitoOidcConfig,
@@ -144,6 +148,8 @@ func JsonToJob(jobJson JobJson) Job {
 		CommandRoleArn:             jobJson.CommandRoleArn,
 		StateRoleArn:               jobJson.StateRoleArn,
 		SkipMergeCheck:             jobJson.SkipMergeCheck,
+		PlanIdentifier:             jobJson.PlanIdentifier,
+		SkipProjectLock:            jobJson.SkipProjectLock,
 		CognitoOidcConfig:          jobJson.CognitoOidcConfig,
 		Teams:                      jobJson.Teams,
 		Approvals:                  jobJson.Approvals,

--- a/libs/storage/plan_storage.go
+++ b/libs/storage/plan_storage.go
@@ -13,10 +13,10 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/diggerhq/digger/libs/locking/gcp"
 	"github.com/google/go-github/v61/github"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
 type GithubPlanStorage struct {
@@ -352,11 +352,15 @@ func NewPlanStorage(ghToken string, ghRepoOwner string, ghRepositoryName string,
 		}
 		zipManager := Zipper{}
 		slog.Debug("Using GitHub artifacts for plan storage")
+		pullRequestNumber := 0
+		if prNumber != nil {
+			pullRequestNumber = *prNumber
+		}
 		planStorage = &GithubPlanStorage{
 			Client:            github.NewTokenClient(context.Background(), ghToken),
 			Owner:             ghRepoOwner,
 			RepoName:          ghRepositoryName,
-			PullRequestNumber: *prNumber,
+			PullRequestNumber: pullRequestNumber,
 			ZipManager:        zipManager,
 		}
 	case uploadDestination == "gcp":


### PR DESCRIPTION
## Summary

- Handle GitHub `merge_group` `checks_requested` events in the backendless GitHub Actions path.
- Verify that the checkout is the exact synthetic merge-group head SHA.
- Find changed projects from `BaseSHA...HeadSHA` and fail closed at GitHub's 300-file compare limit.
- Plan all changed projects before Digger starts any apply.
- Apply only after every plan and policy check passes.
- Let GitHub Merge Queue perform the final merge.

## Why

#1410 added event parsing but intentionally treated `merge_group` as an ignored, successful event. That behavior prevents teams from making a real Terraform apply a required merge-queue check.

This change lets GitHub remain the merge-policy authority. GitHub checks reviews, required checks, and queue rules before it creates the synthetic commit. Digger then plans and applies that exact commit. A failed plan or apply fails the required workflow, so GitHub removes the group from the queue.

## Safety behavior

- Merge-group jobs do not call pull-request mergeability APIs.
- Merge-group jobs do not call Digger auto-merge.
- Merge-group jobs have no pull-request number and do not use the pull-request project lock.
- Stored plan names include the synthetic head SHA.
- Normal pull-request mergeability behavior is unchanged.
- The documented setup requires one PR per group, build concurrency of one, and Terraform or OpenTofu backend state locking.

Project applies are not transactional as a group. If a later project apply fails, an earlier project can already be applied. Backend state locking is still required.

This PR covers the backendless action path. Hosted orchestrator support also needs its server-side event routing to emit merge-group jobs.

## Validation

- `CI=1 go test` passed for the affected libraries, CLI packages, command package, and integration package.
- `go vet` passed for the affected packages.
- The wider library test run reached unrelated tests that require a live license service and an Azure storage emulator.
- A live merge-queue demo was not run. This PR is a draft until that integration test is complete.

## AI assistance

This PR was written with Codex. The author reviewed the design, code, tests, and safety constraints.
