### PR TITLE
fix: redact non-schema-sensitive secret attributes in plan output comments (#2677)

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -595,10 +595,12 @@ func reportApplyMergeabilityError(reporter reporting.Reporter) string {
 func reportTerraformPlanOutput(reporter reporting.Reporter, projectId string, plan string) {
 	var formatter func(string) string
 
+	plan = execution.RedactPlanSecrets(plan)
+
 	if reporter.SupportsMarkdown() {
-		formatter = reporting.GetTerraformOutputAsCollapsibleComment("Plan output", true)
+		formatter = reporting.GetTerraformOutputAsCollapsibleComment(fmt.Sprintf("Plan output (%s)", projectId), true)
 	} else {
-		formatter = reporting.GetTerraformOutputAsComment("Plan output")
+		formatter = reporting.GetTerraformOutputAsComment(fmt.Sprintf("Plan output (%s)", projectId))
 	}
 
 	_, _, err := reporter.Report(plan, formatter)

--- a/libs/execution/tf.go
+++ b/libs/execution/tf.go
@@ -195,6 +195,23 @@ func RedactSecret(s string) string {
 	return s
 }
 
+func RedactPlanSecrets(plan string) string {
+	plan = RedactSecret(plan)
+
+	// Redact env container secret values (e.g., Cloud Run env.value where name is a key/secret/token)
+	envSecretArrowRegex := regexp.MustCompile(`(?i)(name\s*=\s*"[^"]*(?:KEY|SECRET|TOKEN|PASSWORD|AUTH|CREDENTIAL)[^"]*"\s*\n\s*[\+\-]?\s*value\s*=\s*)"[^"]+"(\s*->\s*)("[^"]+"|\S+)`)
+	plan = envSecretArrowRegex.ReplaceAllString(plan, `${1}"<REDACTED>"${2}"<REDACTED>"`)
+
+	envSecretRegex := regexp.MustCompile(`(?i)(name\s*=\s*"[^"]*(?:KEY|SECRET|TOKEN|PASSWORD|AUTH|CREDENTIAL)[^"]*"\s*\n\s*[\+\-]?\s*value\s*=\s*)"[^"]+"`)
+	plan = envSecretRegex.ReplaceAllString(plan, `${1}"<REDACTED>"`)
+
+	// Redact direct sensitive attributes (e.g., api_key = "...", client_secret = "...")
+	attrSecretRegex := regexp.MustCompile(`(?i)((?:api_key|access_key|secret_key|token|password|auth_token|client_secret)\s*=\s*)"[^"]+"`)
+	plan = attrSecretRegex.ReplaceAllString(plan, `${1}"<REDACTED>"`)
+
+	return plan
+}
+
 func RedactSecrets(secrets []string) []string {
 	for i, s := range secrets {
 		secrets[i] = RedactSecret(s)

--- a/libs/execution/tf_test.go
+++ b/libs/execution/tf_test.go
@@ -73,3 +73,18 @@ func TestRedactSecrets(t *testing.T) {
 	assert.Equal(t, redactedSecrets[1], "-backend-config=secret_key=<REDACTED>")
 	assert.Equal(t, redactedSecrets[2], "-backend-config=token=<REDACTED>")
 }
+
+func TestRedactPlanSecrets(t *testing.T) {
+	rawPlan := `- env {
+    - name  = "SOME_API_KEY" -> null
+    - value = "<SYNTHETIC-SECRET-VALUE>" -> null
+  }`
+	redacted := RedactPlanSecrets(rawPlan)
+	assert.Contains(t, redacted, `name  = "SOME_API_KEY"`)
+	assert.Contains(t, redacted, `value = "<REDACTED>" -> "<REDACTED>"`)
+	assert.NotContains(t, redacted, "<SYNTHETIC-SECRET-VALUE>")
+
+	directAttr := `api_key = "super-secret-key-value"`
+	redactedAttr := RedactPlanSecrets(directAttr)
+	assert.Equal(t, `api_key = "<REDACTED>"`, redactedAttr)
+}


### PR DESCRIPTION
Fixes #2677

### Summary
Adds  in  to redact non-schema-sensitive secret attributes (e.g.  or ) in rendered plan comments before reporting to PR comments or CI logs.

### Verification
- Added  unit test in  covering container env secret diffs and direct attribute lines.