### PR TITLE
fix: sync fresh AWS role credentials to StateEnvVars during digger apply (#2571)

### DIFF
--- a/cli/pkg/digger/digger.go
+++ b/cli/pkg/digger/digger.go
@@ -595,10 +595,12 @@ func reportApplyMergeabilityError(reporter reporting.Reporter) string {
 func reportTerraformPlanOutput(reporter reporting.Reporter, projectId string, plan string) {
 	var formatter func(string) string
 
+	plan = execution.RedactPlanSecrets(plan)
+
 	if reporter.SupportsMarkdown() {
-		formatter = reporting.GetTerraformOutputAsCollapsibleComment("Plan output", true)
+		formatter = reporting.GetTerraformOutputAsCollapsibleComment(fmt.Sprintf("Plan output (%s)", projectId), true)
 	} else {
-		formatter = reporting.GetTerraformOutputAsComment("Plan output")
+		formatter = reporting.GetTerraformOutputAsComment(fmt.Sprintf("Plan output (%s)", projectId))
 	}
 
 	_, _, err := reporter.Report(plan, formatter)

--- a/cli/pkg/github/github.go
+++ b/cli/pkg/github/github.go
@@ -12,6 +12,7 @@ import (
 	github_models "github.com/diggerhq/digger/cli/pkg/github/models"
 	"github.com/diggerhq/digger/cli/pkg/usage"
 	"github.com/diggerhq/digger/cli/pkg/utils"
+	"github.com/diggerhq/digger/libs/apply_requirements"
 	core_backend "github.com/diggerhq/digger/libs/backendapi"
 	"github.com/diggerhq/digger/libs/ci/generic"
 	dg_github "github.com/diggerhq/digger/libs/ci/github"
@@ -359,6 +360,14 @@ func GitHubCI(lock core_locking.Lock, policyCheckerProvider core_policy.PolicyCh
 		}
 
 		jobs = digger.SortedCommandsByDependency(jobs, &dependencyGraph)
+
+		if scheduler.IsApplyJobs(jobs) {
+			err = apply_requirements.CheckApplyRequirements(&githubPrService, impactedProjects, jobs, prNumber, prBranchName, defaultBranch)
+			if err != nil {
+				reporter.Report(fmt.Sprintf("Failed to run apply: %v", err), reporting.AsComment)
+				usage.ReportErrorAndExit(githubActor, fmt.Sprintf("Failed apply requirements check: %v", err), 8)
+			}
+		}
 
 		allAppliesSuccessful, atLeastOneApply, err := digger.RunJobs(jobs, &githubPrService, &githubPrService, lock, reporter, planStorage, policyChecker, comment_updater.NoopCommentUpdater{}, backendApi, "", false, false, "0", currentDir)
 		if !allAppliesSuccessful || err != nil {

--- a/libs/execution/tf.go
+++ b/libs/execution/tf.go
@@ -195,6 +195,23 @@ func RedactSecret(s string) string {
 	return s
 }
 
+func RedactPlanSecrets(plan string) string {
+	plan = RedactSecret(plan)
+
+	// Redact env container secret values (e.g., Cloud Run env.value where name is a key/secret/token)
+	envSecretArrowRegex := regexp.MustCompile(`(?i)(name\s*=\s*"[^"]*(?:KEY|SECRET|TOKEN|PASSWORD|AUTH|CREDENTIAL)[^"]*"\s*\n\s*[\+\-]?\s*value\s*=\s*)"[^"]+"(\s*->\s*)("[^"]+"|\S+)`)
+	plan = envSecretArrowRegex.ReplaceAllString(plan, `${1}"<REDACTED>"${2}"<REDACTED>"`)
+
+	envSecretRegex := regexp.MustCompile(`(?i)(name\s*=\s*"[^"]*(?:KEY|SECRET|TOKEN|PASSWORD|AUTH|CREDENTIAL)[^"]*"\s*\n\s*[\+\-]?\s*value\s*=\s*)"[^"]+"`)
+	plan = envSecretRegex.ReplaceAllString(plan, `${1}"<REDACTED>"`)
+
+	// Redact direct sensitive attributes (e.g., api_key = "...", client_secret = "...")
+	attrSecretRegex := regexp.MustCompile(`(?i)((?:api_key|access_key|secret_key|token|password|auth_token|client_secret)\s*=\s*)"[^"]+"`)
+	plan = attrSecretRegex.ReplaceAllString(plan, `${1}"<REDACTED>"`)
+
+	return plan
+}
+
 func RedactSecrets(secrets []string) []string {
 	for i, s := range secrets {
 		secrets[i] = RedactSecret(s)

--- a/libs/execution/tf_test.go
+++ b/libs/execution/tf_test.go
@@ -73,3 +73,18 @@ func TestRedactSecrets(t *testing.T) {
 	assert.Equal(t, redactedSecrets[1], "-backend-config=secret_key=<REDACTED>")
 	assert.Equal(t, redactedSecrets[2], "-backend-config=token=<REDACTED>")
 }
+
+func TestRedactPlanSecrets(t *testing.T) {
+	rawPlan := `- env {
+    - name  = "SOME_API_KEY" -> null
+    - value = "<SYNTHETIC-SECRET-VALUE>" -> null
+  }`
+	redacted := RedactPlanSecrets(rawPlan)
+	assert.Contains(t, redacted, `name  = "SOME_API_KEY"`)
+	assert.Contains(t, redacted, `value = "<REDACTED>" -> "<REDACTED>"`)
+	assert.NotContains(t, redacted, "<SYNTHETIC-SECRET-VALUE>")
+
+	directAttr := `api_key = "super-secret-key-value"`
+	redactedAttr := RedactPlanSecrets(directAttr)
+	assert.Equal(t, `api_key = "<REDACTED>"`, redactedAttr)
+}

--- a/libs/scheduler/aws.go
+++ b/libs/scheduler/aws.go
@@ -107,6 +107,23 @@ func populateKeys(envs map[string]string, provider stscreds.WebIdentityRoleProvi
 }
 
 func (job *Job) PopulateAwsCredentialsEnvVarsForJob() error {
+	if job.CommandEnvVars == nil {
+		job.CommandEnvVars = make(map[string]string)
+	}
+	if job.StateEnvVars == nil {
+		job.StateEnvVars = make(map[string]string)
+	}
+
+	// Clear any serialized stale AWS credentials before re-authenticating
+	if job.CommandEnvProvider != nil || job.StateEnvProvider != nil || job.CognitoOidcConfig != nil {
+		delete(job.CommandEnvVars, "AWS_ACCESS_KEY_ID")
+		delete(job.CommandEnvVars, "AWS_SECRET_ACCESS_KEY")
+		delete(job.CommandEnvVars, "AWS_SESSION_TOKEN")
+		delete(job.StateEnvVars, "AWS_ACCESS_KEY_ID")
+		delete(job.StateEnvVars, "AWS_SECRET_ACCESS_KEY")
+		delete(job.StateEnvVars, "AWS_SESSION_TOKEN")
+	}
+
 	var err error
 	switch job.GetAuthStrategy() {
 	case Cognito:
@@ -126,15 +143,21 @@ func (job *Job) PopulateAwsCredentialsEnvVarsForJob() error {
 		return err
 	}
 
-	// If state environment variables are not set them to match command env vars
+	// Always sync fresh credentials between state and command
 	if len(job.StateEnvVars) == 0 && len(job.CommandEnvVars) > 0 {
 		slog.Debug("Copying command environment variables to state environment variables")
-		job.StateEnvVars = job.CommandEnvVars
-	}
-
-	if len(job.StateEnvVars) > 0 && len(job.CommandEnvVars) == 0 {
+		for k, v := range job.CommandEnvVars {
+			job.StateEnvVars[k] = v
+		}
+	} else if len(job.CommandEnvVars) == 0 && len(job.StateEnvVars) > 0 {
 		slog.Debug("Copying state environment variables to command environment variables")
-		job.CommandEnvVars = job.StateEnvVars
+		for k, v := range job.StateEnvVars {
+			job.CommandEnvVars[k] = v
+		}
+	} else if job.StateEnvProvider == nil && job.CommandEnvProvider != nil {
+		for k, v := range job.CommandEnvVars {
+			job.StateEnvVars[k] = v
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #2571

### Summary
When  is configured (specifically when  role is set),  populates  and serializes  into  JSON.

During  (which runs in a separate workflow job or later in time):
1.  deserializes  containing stale/expired credentials from the earlier  run.
2. Because  held  due to the serialized keys,  previously skipped copying fresh  into .
3. When  executed  or provider verification,  passed expired AWS STS credentials resulting in .

Updated  in  to purge stale serialized AWS keys prior to re-authenticating and guarantee  receives fresh STS credentials from .