### PR TITLE
fix(drift): surface failed drift checks instead of masquerading as "no drift"

### DIFF
--- a/backend/controllers/projects.go
+++ b/backend/controllers/projects.go
@@ -990,6 +990,20 @@ func (d DiggerController) SetJobStatusForProject(c *gin.Context) {
 			"batchId", batchId,
 		)
 
+		// Record drift-check failure so a failed check is distinguishable from "no drift"
+		// (otherwise the project silently stays at its default "no drift" / never-checked).
+		if isDriftJob, dErr := IsDriftStatusJob(job); dErr != nil {
+			slog.Warn("Could not determine if failed job is a drift job", "jobId", jobId, "error", dErr)
+		} else if isDriftJob {
+			if project, pErr := models.DB.GetProjectByName(orgId, job.Batch.RepoFullName, job.ProjectName); pErr != nil {
+				slog.Warn("Could not load project for drift check-failed update",
+					"jobId", jobId, "projectName", job.ProjectName, "error", pErr)
+			} else if sErr := ProjectDriftCheckFailed(*project, request.TerraformOutput); sErr != nil {
+				slog.Warn("Could not update project drift check-failed state",
+					"jobId", jobId, "projectName", job.ProjectName, "error", sErr)
+			}
+		}
+
 		// Update PR comment with real-time status for failed job
 		go func(ctx context.Context) {
 			defer logging.InheritRequestLogger(ctx)()

--- a/backend/controllers/projects_drift_test.go
+++ b/backend/controllers/projects_drift_test.go
@@ -1,0 +1,59 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/diggerhq/digger/backend/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectDriftCheckFailedRecordsFailureAndRecovers(t *testing.T) {
+	teardownSuite, _ := setupSuite(t)
+	defer teardownSuite(t)
+
+	org := models.Organisation{Name: "test-org", ExternalId: "test-org-external-id"}
+	models.DB.GormDB.Create(&org)
+	project := models.Project{
+		Name:           "test-drift-project",
+		OrganisationID: org.ID,
+		RepoFullName:   "org/repo",
+		DriftEnabled:   true,
+		DriftStatus:    models.DriftStatusNewDrift,
+		DriftToCreate:  2,
+		DriftToUpdate:  1,
+		DriftToDelete:  0,
+	}
+	models.DB.GormDB.Create(&project)
+
+	err := ProjectDriftCheckFailed(project, "Error: plan failed: something broke")
+	assert.NoError(t, err)
+
+	var failed models.Project
+	models.DB.GormDB.First(&failed, project.ID)
+	assert.Equal(t, models.DriftStatusCheckFailed, failed.DriftStatus)
+	assert.Equal(t, "Error: plan failed: something broke", failed.DriftTerraformPlan)
+	assert.Equal(t, uint(0), failed.DriftToCreate)
+	assert.Equal(t, uint(0), failed.DriftToUpdate)
+	assert.Equal(t, uint(0), failed.DriftToDelete)
+	assert.WithinDuration(t, time.Now(), failed.LatestDriftCheck, time.Minute)
+
+	// a later successful empty plan recovers to "no drift"
+	err = ProjectDriftStateMachineApply(failed, "", 0, 0, 0)
+	assert.NoError(t, err)
+	var recovered models.Project
+	models.DB.GormDB.First(&recovered, project.ID)
+	assert.Equal(t, models.DriftStatusNoDrift, recovered.DriftStatus)
+
+	// and from a fresh failure, a successful plan WITH changes surfaces "new drift"
+	// (this is why the failure clears the old counts: wasEmptyPlan must be true)
+	err = ProjectDriftCheckFailed(recovered, "Error: transient provider error")
+	assert.NoError(t, err)
+	var failedAgain models.Project
+	models.DB.GormDB.First(&failedAgain, project.ID)
+	err = ProjectDriftStateMachineApply(failedAgain, "plan with changes", 2, 1, 0)
+	assert.NoError(t, err)
+	var drifted models.Project
+	models.DB.GormDB.First(&drifted, project.ID)
+	assert.Equal(t, models.DriftStatusNewDrift, drifted.DriftStatus)
+}

--- a/backend/controllers/projects_helpers.go
+++ b/backend/controllers/projects_helpers.go
@@ -65,6 +65,25 @@ func ProjectDriftStateMachineApply(project models.Project, tfplan string, resour
 	return nil
 }
 
+// ProjectDriftCheckFailed records that a drift check could not complete (e.g. the plan
+// errored) so a failed check is distinguishable from "no drift". Stamps LatestDriftCheck so
+// the failure isn't treated as stale, and clears the last-known drift counts so the NEXT
+// successful check re-derives drift from a clean baseline (wasEmptyPlan==true) and can
+// transition out of check_failed — otherwise a still-drifting project would stay stuck here.
+func ProjectDriftCheckFailed(project models.Project, errorOutput string) error {
+	project.DriftStatus = models.DriftStatusCheckFailed
+	project.DriftTerraformPlan = errorOutput
+	project.DriftToCreate = 0
+	project.DriftToUpdate = 0
+	project.DriftToDelete = 0
+	project.LatestDriftCheck = time.Now()
+	result := models.DB.GormDB.Save(&project)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
 func GenerateChecksSummaryForBatch(batch *models.DiggerBatch) (string, error) {
 	summaryEndpoint := os.Getenv("DIGGER_AI_SUMMARY_ENDPOINT")
 	if summaryEndpoint == "" {

--- a/backend/models/orgs.go
+++ b/backend/models/orgs.go
@@ -97,6 +97,7 @@ type DriftStatus string
 const DriftStatusNewDrift DriftStatus = "new drift"
 const DriftStatusNoDrift DriftStatus = "no drift"
 const DriftStatusAcknowledgeDrift DriftStatus = "acknowledged drift"
+const DriftStatusCheckFailed DriftStatus = "check failed"
 
 type Project struct {
 	gorm.Model

--- a/drift/controllers/notifications.go
+++ b/drift/controllers/notifications.go
@@ -134,6 +134,16 @@ func sectionBlockForProject(project models.Project) (*slack.SectionBlock, error)
 			nil,
 		)
 		return sectionBlock, nil
+	case models.DriftStatusCheckFailed:
+		sectionBlock := slack.NewSectionBlock(
+			nil,
+			[]*slack.TextBlockObject{
+                slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("<%v/dashboard/projects/%v|%s — %s>", os.Getenv("DIGGER_APP_URL"), project.ID, project.RepoFullName, project.Name), false, false),
+				slack.NewTextBlockObject("mrkdwn", ":red_circle: Check failed", false, false),
+			},
+			nil,
+		)
+		return sectionBlock, nil
 	default:
 		return nil, fmt.Errorf("Could not")
 	}

--- a/libs/execution/opentofu.go
+++ b/libs/execution/opentofu.go
@@ -58,7 +58,7 @@ func (tf OpenTofu) Plan(params []string, envs map[string]string, planArtefactFil
 	params = append(append(append(params, "-input=false"), "-no-color"), "-detailed-exitcode")
 	stdout, stderr, statusCode, err := tf.runOpentofuCommand("plan", true, envs, filterRegex, params...)
 	if err != nil && statusCode != 2 {
-		return false, "", "", err
+		return false, stdout, stderr, err
 	}
 	return statusCode == 2, stdout, stderr, nil
 }


### PR DESCRIPTION
## Problem
When a drift-check job fails (plan/init error), the project's drift status is left untouched — typically `no drift`. A broken drift check is indistinguishable from a clean one, so real drift can go unnoticed for as long as the check keeps failing (we hit exactly this in production: a regression left a subset of projects permanently "clean" while their checks were erroring).

## Change
- New `DriftStatus` value **`check failed`**, set when a drift job's status callback reports failure. The error output is stored in `DriftTerraformPlan` so the UI shows *why*, and `LatestDriftCheck` is stamped.
- The stale to-create/update/delete counts are **cleared** on failure so the next successful run re-derives drift from a clean baseline (`wasEmptyPlan == true`) and correctly transitions to either `no drift` or `new drift` — without this a still-drifting project would stay stuck in `check failed`.
- Drift Slack notification renders check-failed projects as a :red_circle: row.
- `execution.Plan()` now returns the captured stdout/stderr on error (was `"", ""`), so the failure reason is actually available to store.

## Testing
- `TestProjectDriftCheckFailedRecordsFailureAndRecovers` (new, uses the existing sqlite test harness): asserts the failure recording and both recovery paths.
- Full `backend/controllers` test suite passes; `backend`, `drift`, and `libs` all build.
- This change has been running in our production fork since 2026-08-06 across a ~140-project nightly drift fleet; the failure state fires on real plan errors and recovers cleanly on the next successful check.

### :brain: **Ai UsageDetails (if applicable):**
Per the contributing guide: this change was implemented with AI assistance (Claude Code) in our production fork, then human-reviewed, tested, and production-validated before being extracted for upstream.

