### PR TITLE
feat(ui): optional single-tenant static auth mode for self-hosted deployments (no WorkOS)

### DIFF
--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -36,6 +36,17 @@ For authentication-specific setup details, see [WorkOS Setup](/self-hosting/work
 | --- | --- | --- | --- | --- |
 | `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, `WORKOS_COOKIE_PASSWORD`, `WORKOS_WEBHOOK_SECRET`, `WORKOS_REDIRECT_URI` | `ui` | WorkOS | Before first login | Required to authenticate into the app UI. `WORKOS_REDIRECT_URI` must match your public app URL callback route. See [WorkOS Setup](/self-hosting/workos-setup). |
 
+#### Static auth mode (no WorkOS)
+
+For single-tenant self-hosted deployments where access to the UI is already controlled in front of it (network perimeter, VPN, or an authenticating reverse proxy), the UI can run as one fixed identity instead of WorkOS. WorkOS remains the default; set `DIGGER_UI_AUTH_MODE=static` to opt in — no `WORKOS_*` variables are required in this mode.
+
+| Variable(s) | Used by | Source system | When required | Notes |
+| --- | --- | --- | --- | --- |
+| `DIGGER_UI_AUTH_MODE` | `ui` | — | Opt-in | Set to `static` to enable static auth mode; unset (or any other value) keeps WorkOS auth. |
+| `DIGGER_STATIC_ORG_ID` | `ui` | Your backend | Static mode only | Required. The backend organisation's external id, used for all backend requests. |
+| `DIGGER_ORG_SOURCE` | `ui` | Your backend | Static mode only | Organisation external source sent to the backend; defaults to `workos`. Set it to match how your organisation was created (e.g. `digger` for the GitHub OAuth path). |
+| `DIGGER_STATIC_USER_ID`, `DIGGER_STATIC_USER_EMAIL`, `DIGGER_STATIC_USER_FIRST_NAME`, `DIGGER_STATIC_USER_LAST_NAME`, `DIGGER_STATIC_ORG_NAME` | `ui` | — | Optional | Identity and organisation name shown in the UI; sensible defaults are provided. |
+
 ### GitHub
 
 For the self-hosted GitHub App flow, see [GitHub App Setup](/self-hosting/github-app-setup).

--- a/ui/src/api/orchestrator_orgs.ts
+++ b/ui/src/api/orchestrator_orgs.ts
@@ -1,3 +1,4 @@
+import { getOrgSource } from '@/authkit/ssr/staticAuth';
 // Helper to generate request IDs for tracing
 function generateRequestId(): string {
     return `ui-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -37,7 +38,7 @@ export async function getOrgSettings(
         'Content-Type': 'application/json',
         'DIGGER_ORG_ID': organizationId || '',
         'DIGGER_USER_ID': userId || '',
-        'DIGGER_ORG_SOURCE': 'workos',
+        'DIGGER_ORG_SOURCE': getOrgSource(),
         'X-Request-ID': generateRequestId(),
       }
     })
@@ -77,7 +78,7 @@ export async function updateOrgSettings(
         'Content-Type': 'application/json',
         'DIGGER_ORG_ID': organizationId || '',
         'DIGGER_USER_ID': userId || '',
-        'DIGGER_ORG_SOURCE': 'workos',
+        'DIGGER_ORG_SOURCE': getOrgSource(),
         'X-Request-ID': generateRequestId(),
       },
       body: JSON.stringify(settings)

--- a/ui/src/api/orchestrator_projects.ts
+++ b/ui/src/api/orchestrator_projects.ts
@@ -1,3 +1,4 @@
+import { getOrgSource } from '@/authkit/ssr/staticAuth';
 // Helper to generate request IDs for tracing
 function generateRequestId(): string {
     return `ui-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -10,7 +11,7 @@ export async function fetchProject(projectId: string, organizationId: string, us
         'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
         'DIGGER_ORG_ID': organizationId,
         'DIGGER_USER_ID': userId,
-        'DIGGER_ORG_SOURCE': 'workos',
+        'DIGGER_ORG_SOURCE': getOrgSource(),
         'X-Request-ID': generateRequestId(),
       },
     });
@@ -30,7 +31,7 @@ export async function fetchProjects(organizationId: string, userId: string) {
         'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
         'DIGGER_ORG_ID': organizationId,
         'DIGGER_USER_ID': userId,
-        'DIGGER_ORG_SOURCE': 'workos',
+        'DIGGER_ORG_SOURCE': getOrgSource(),
         'X-Request-ID': generateRequestId(),
       },
     });
@@ -49,7 +50,7 @@ export async function updateProject(projectId: string, driftEnabled: boolean, or
             'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
             'DIGGER_ORG_ID': organizationId,
             'DIGGER_USER_ID': userId,
-            'DIGGER_ORG_SOURCE': 'workos',
+            'DIGGER_ORG_SOURCE': getOrgSource(),
             'X-Request-ID': generateRequestId(),
         },
         body: JSON.stringify({

--- a/ui/src/api/orchestrator_repos.ts
+++ b/ui/src/api/orchestrator_repos.ts
@@ -1,3 +1,4 @@
+import { getOrgSource } from '@/authkit/ssr/staticAuth';
 // Helper to generate request IDs for tracing
 function generateRequestId(): string {
     return `ui-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -56,7 +57,7 @@ export async function fetchRepos(organizationId: string, userId: string) {
       'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
       'DIGGER_ORG_ID': organizationId,
       'DIGGER_USER_ID': userId,
-      'DIGGER_ORG_SOURCE': 'workos',
+      'DIGGER_ORG_SOURCE': getOrgSource(),
       'X-Request-ID': generateRequestId(),
     },
   });
@@ -75,7 +76,7 @@ export async function fetchRepoDetails(repoId: string, organisationId: string, u
       'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
       'DIGGER_ORG_ID': organisationId,
       'DIGGER_USER_ID': userId,
-      'DIGGER_ORG_SOURCE': 'workos',
+      'DIGGER_ORG_SOURCE': getOrgSource(),
       'X-Request-ID': generateRequestId(),
     },
   });

--- a/ui/src/api/orchestrator_serverFunctions.ts
+++ b/ui/src/api/orchestrator_serverFunctions.ts
@@ -5,6 +5,7 @@ import { getOrgSettings, updateOrgSettings } from "./orchestrator_orgs";
 import { testSlackWebhook } from "./drift_slack";
 import { fetchProjects, updateProject, fetchProject } from "./orchestrator_projects";
 import { requireAuth } from "./helpers";
+import { getOrgSource } from '@/authkit/ssr/staticAuth';
 
 export const getOrgSettingsFn = createServerFn({method: 'GET'})
   .handler(async () => {
@@ -79,7 +80,7 @@ export const getRepoDetailsFn = createServerFn({method: 'GET'})
             'Authorization': `Bearer ${process.env.ORCHESTRATOR_BACKEND_SECRET}`,
             'DIGGER_ORG_ID': auth.organizationId,
             'DIGGER_USER_ID': auth.userId,
-            'DIGGER_ORG_SOURCE': 'workos',
+            'DIGGER_ORG_SOURCE': getOrgSource(),
           },
         });
 

--- a/ui/src/authkit/serverFunctions.ts
+++ b/ui/src/authkit/serverFunctions.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import { deleteCookie } from '@tanstack/react-start/server';
 import { getConfig } from './ssr/config';
+import { getStaticOrganisation, isStaticAuthMode } from './ssr/staticAuth';
 import { terminateSession, withAuth } from './ssr/session';
 import { getWorkOS } from './ssr/workos';
 import type { GetAuthURLOptions, NoUserInfo, UserInfo } from './ssr/interfaces';
@@ -28,6 +29,9 @@ export const getAuthorizationUrl = createServerFn({ method: 'GET' })
 export const getOrganisationDetails = createServerFn({method: 'GET'})
   .inputValidator((data: {organizationId: string}) => data)
   .handler(async ({data: {organizationId}}) : Promise<Organization> => {
+    if (isStaticAuthMode()) {
+      return getStaticOrganisation(organizationId);
+    }
     // Check cache first
     const cached = serverCache.getOrg(organizationId);
     if (cached) {
@@ -103,32 +107,38 @@ export const getAuth = createServerFn({ method: 'GET' }).handler(async (): Promi
 export const getOrganization = createServerFn({method: 'GET'})
     .inputValidator((data: {organizationId: string}) => data)
     .handler(async ({data: {organizationId}}) : Promise<Organization> => {
+  if (isStaticAuthMode()) {
+    return getStaticOrganisation(organizationId);
+  }
   // Check cache first
   const cached = serverCache.getOrg(organizationId);
   if (cached) {
     return cached;
   }
-  
+
   // Cache miss - fetch from WorkOS
   const organization = await getWorkOS().organizations.getOrganization(organizationId);
   serverCache.setOrg(organizationId, organization);
-  
+
   return organization;
 });
 
 export const ensureOrgExists = createServerFn({method: 'GET'})
     .inputValidator((data: {organizationId: string}) => data)
     .handler(async ({data: {organizationId}}) : Promise<Organization> => {
+  if (isStaticAuthMode()) {
+    return getStaticOrganisation(organizationId);
+  }
   // Check cache first
   const cached = serverCache.getOrg(organizationId);
   if (cached) {
     return cached;
   }
-  
+
   // Cache miss - fetch from WorkOS
   const organization = await getWorkOS().organizations.getOrganization(organizationId);
   serverCache.setOrg(organizationId, organization);
-  
+
   return organization;
 });
 

--- a/ui/src/authkit/ssr/session.ts
+++ b/ui/src/authkit/ssr/session.ts
@@ -3,10 +3,11 @@ import { getCookie, setCookie } from '@tanstack/react-start/server';
 import { sealData, unsealData } from 'iron-session';
 import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { getConfig } from './config';
+import { getStaticUserInfo, isStaticAuthMode } from './staticAuth';
 import { lazy } from './utils';
 import { getWorkOS } from './workos';
 import type { AccessToken, AuthenticationResponse } from '@workos-inc/node';
-import type { AuthkitOptions, AuthkitResponse, CookieOptions, GetAuthURLOptions, Session } from './interfaces';
+import type { AuthkitOptions, AuthkitResponse, CookieOptions, GetAuthURLOptions, NoUserInfo, Session, UserInfo } from './interfaces';
 
 const sessionHeaderName = 'x-workos-session';
 const middlewareHeaderName = 'x-workos-middleware';
@@ -55,7 +56,11 @@ export async function encryptSession(session: Session) {
   });
 }
 
-export async function withAuth() {
+export async function withAuth(): Promise<UserInfo | NoUserInfo> {
+  if (isStaticAuthMode()) {
+    return getStaticUserInfo();
+  }
+
   const session = await getSessionFromCookie();
 
   if (!session?.user) {
@@ -258,6 +263,10 @@ export async function updateSession(
 }
 
 export async function terminateSession({ returnTo }: { returnTo?: string } = {}) {
+  if (isStaticAuthMode()) {
+    return redirect({ to: returnTo ?? '/', throw: true, reloadDocument: true });
+  }
+
   const { sessionId } = await withAuth();
   if (sessionId) {
     const href = getWorkOS().userManagement.getLogoutUrl({ sessionId, returnTo });

--- a/ui/src/authkit/ssr/staticAuth.ts
+++ b/ui/src/authkit/ssr/staticAuth.ts
@@ -1,0 +1,56 @@
+import type { Organization, User } from '@workos-inc/node';
+import type { UserInfo } from './interfaces';
+
+/**
+ * Optional single-tenant auth mode for self-hosted deployments that don't use WorkOS.
+ *
+ * Enabled with DIGGER_UI_AUTH_MODE=static. The UI then runs as one fixed identity taken
+ * from DIGGER_STATIC_* env vars and never calls WorkOS, so no WORKOS_* env is required to
+ * boot. Intended for deployments where access is already controlled in front of the UI
+ * (network perimeter, VPN, or an authenticating reverse proxy).
+ *
+ * DIGGER_STATIC_ORG_ID is required: it must be the backend organisation's external id so
+ * org lookups resolve. Deployments whose org was created outside WorkOS (e.g. the GitHub
+ * OAuth path) should also set DIGGER_ORG_SOURCE to match the org's external source.
+ */
+export function isStaticAuthMode(): boolean {
+  return process.env.DIGGER_UI_AUTH_MODE === 'static';
+}
+
+export function getStaticUserInfo(): UserInfo {
+  const organizationId = process.env.DIGGER_STATIC_ORG_ID;
+  if (!organizationId) {
+    throw new Error('DIGGER_UI_AUTH_MODE=static requires DIGGER_STATIC_ORG_ID (the backend organisation external id)');
+  }
+  return {
+    sessionId: 'static-session',
+    user: {
+      id: process.env.DIGGER_STATIC_USER_ID || 'static-user',
+      email: process.env.DIGGER_STATIC_USER_EMAIL || 'admin@example.com',
+      firstName: process.env.DIGGER_STATIC_USER_FIRST_NAME || 'Self-Hosted',
+      lastName: process.env.DIGGER_STATIC_USER_LAST_NAME || 'Admin',
+    } as unknown as User,
+    organizationId,
+    role: 'admin',
+    permissions: [],
+    entitlements: [],
+    impersonator: undefined,
+    accessToken: '',
+  };
+}
+
+export function getStaticOrganisation(organizationId: string): Organization {
+  return {
+    id: organizationId,
+    name: process.env.DIGGER_STATIC_ORG_NAME || 'Self-Hosted',
+  } as unknown as Organization;
+}
+
+/**
+ * Value for the DIGGER_ORG_SOURCE header sent to the backend. Defaults to 'workos';
+ * self-hosted deployments whose org has a different external source (e.g. 'digger' for
+ * orgs created via the GitHub OAuth path) can override it with the DIGGER_ORG_SOURCE env.
+ */
+export function getOrgSource(): string {
+  return process.env.DIGGER_ORG_SOURCE || 'workos';
+}


### PR DESCRIPTION
## Problem
The UI hard-requires WorkOS: without `WORKOS_*` env vars it cannot authenticate anyone, which is a hurdle for self-hosted single-tenant deployments that already control access in front of the UI (network perimeter, VPN, or an authenticating reverse proxy). Related friction exists for any deployment whose backend organisation wasn't created through WorkOS (e.g. the GitHub OAuth path) — the UI's hardcoded `DIGGER_ORG_SOURCE: workos` header can't resolve such orgs.

## Change (fully opt-in — default behavior unchanged)
- New `DIGGER_UI_AUTH_MODE=static` mode: `withAuth()` returns a fixed identity from `DIGGER_STATIC_*` env vars and WorkOS is never called — no `WORKOS_*` env is needed to boot. Unset (or any other value) keeps WorkOS auth exactly as today.
- `getOrganisationDetails` / `getOrganization` / `ensureOrgExists` return a static organisation (`DIGGER_STATIC_ORG_NAME`) in static mode instead of the WorkOS org lookup; `terminateSession` redirects home instead of building a WorkOS logout URL.
- The `DIGGER_ORG_SOURCE` header sent to the backend is now env-configurable (default `workos`, unchanged), so deployments whose org has a different external source can resolve it.
- `withAuth()` now has an explicit `Promise<UserInfo | NoUserInfo>` return type (required for the widened union to typecheck; also tightens the existing inference).
- `DIGGER_STATIC_ORG_ID` is required in static mode and fails loudly with a clear message if missing.
- Docs: new "Static auth mode (no WorkOS)" subsection in `self-hosting/configuration.mdx`.

## Testing
- `vite build` + `tsc --noEmit` clean.
- This mode has been running in our production fork since 2026-08-05 (single-tenant deployment behind a network perimeter): the drift dashboard, projects, and repos pages all resolve real backend data with zero WorkOS configuration.

Happy to rename the env vars / adjust the flag shape if maintainers prefer a different convention.

### :brain: **Ai UsageDetails (if applicable):**
Per the contributing guide: implemented with AI assistance (Claude Code) in our production fork, then human-reviewed and production-validated before being generalized (opt-in flag, neutral defaults) for upstream.

