### PR TITLE
feat: make git clone timeout configurable via digger.yml

### DIFF
--- a/docs/ce/reference/digger.yml.mdx
+++ b/docs/ce/reference/digger.yml.mdx
@@ -215,6 +215,10 @@ workflows:
   Include Terraform outputs in the PR comment after apply.
 </ParamField>
 
+<ParamField path="git_timeout" type="integer" default="30">
+  Timeout in seconds for each git command (clone, checkout) Digger runs when it clones a repository. Increase this for large repositories that take longer than 30 seconds to clone.
+</ParamField>
+
 <ParamField path="projects" type="array">
   List of projects to manage. See [Project Configuration](#project-configuration).
 </ParamField>

--- a/libs/digger_config/config.go
+++ b/libs/digger_config/config.go
@@ -11,6 +11,9 @@ const AutomergeStrategyRebase AutomergeStrategy = "rebase"
 
 const DefaultBranchName = "__default__"
 
+// DefaultGitTimeoutSeconds is the default per-command git timeout used when git_timeout is not set in digger.yml
+const DefaultGitTimeoutSeconds = 30
+
 type DiggerConfig struct {
 	ApplyAfterMerge               bool
 	AllowDraftPRs                 bool
@@ -31,12 +34,13 @@ type DiggerConfig struct {
 	TraverseToNestedProjects      bool
 	Reporting                     ReporterConfig
 	ReportTerraformOutputs        bool
+	GitTimeout                    int // seconds, per git command when cloning
 	DriftExcludePatterns          []string
 	DriftIncludePatterns          []string
 }
 
 type ReporterConfig struct {
-	AiSummary bool
+	AiSummary       bool
 	CommentsEnabled bool
 }
 

--- a/libs/digger_config/converters.go
+++ b/libs/digger_config/converters.go
@@ -240,6 +240,12 @@ func ConvertDiggerYamlToConfig(diggerYaml *DiggerConfigYaml) (*DiggerConfig, gra
 		diggerConfig.ReportTerraformOutputs = true
 	}
 
+	if diggerYaml.GitTimeout != nil && *diggerYaml.GitTimeout > 0 {
+		diggerConfig.GitTimeout = *diggerYaml.GitTimeout
+	} else {
+		diggerConfig.GitTimeout = DefaultGitTimeoutSeconds
+	}
+
 	diggerConfig.Reporting = copyReporterConfig(diggerYaml.Reporting)
 
 	if diggerYaml.AutoMerge != nil {

--- a/libs/digger_config/yaml.go
+++ b/libs/digger_config/yaml.go
@@ -27,11 +27,12 @@ type DiggerConfigYaml struct {
 	TraverseToNestedProjects      *bool                        `yaml:"traverse_to_nested_projects"`
 	MentionDriftedProjectsInPR    *bool                        `yaml:"mention_drifted_projects_in_pr"`
 	ReportTerraformOutputs        *bool                        `yaml:"report_terraform_outputs"`
+	GitTimeout                    *int                         `yaml:"git_timeout,omitempty"`
 	Reporting                     *ReportingConfigYaml         `yaml:"reporting"`
 }
 
 type ReportingConfigYaml struct {
-	AiSummary bool `yaml:"ai_summary"`
+	AiSummary       bool `yaml:"ai_summary"`
 	CommentsEnabled bool `yaml:"comments_enabled"`
 }
 

--- a/libs/git_utils/clone_utils.go
+++ b/libs/git_utils/clone_utils.go
@@ -23,7 +23,14 @@ func createTempDir() (string, error) {
 
 type action func(string) error
 
+const defaultGitTimeout = 30 * time.Second
+
 func CloneGitRepoAndDoAction(repoUrl string, branch string, commitHash string, token string, tokenUsername string, action action) error {
+	return CloneGitRepoAndDoActionWithTimeout(repoUrl, branch, commitHash, token, tokenUsername, defaultGitTimeout, action)
+}
+
+// CloneGitRepoAndDoActionWithTimeout is CloneGitRepoAndDoAction with a per-git-command timeout (digger.yml git_timeout, in seconds)
+func CloneGitRepoAndDoActionWithTimeout(repoUrl string, branch string, commitHash string, token string, tokenUsername string, timeout time.Duration, action action) error {
 	dir, err := createTempDir()
 	if err != nil {
 		slog.Error("Failed to create temporary directory", "error", err)
@@ -38,6 +45,9 @@ func CloneGitRepoAndDoAction(repoUrl string, branch string, commitHash string, t
 	)
 
 	git := NewGitShellWithTokenAuth(dir, token, tokenUsername)
+	if timeout > 0 {
+		git.timeout = timeout
+	}
 	err = git.Clone(repoUrl, branch)
 	if err != nil {
 		slog.Error("Failed to clone repository",
@@ -101,7 +111,7 @@ func NewGitShell(workDir string, auth *GitAuth) *GitShell {
 
 	return &GitShell{
 		workDir:     workDir,
-		timeout:     30 * time.Second,
+		timeout:     defaultGitTimeout,
 		environment: env,
 		auth:        auth,
 	}


### PR DESCRIPTION
Add a top-level git_timeout key (integer, seconds, default 30) to digger.yml and expose CloneGitRepoAndDoActionWithTimeout so the per-git-command timeout in libs/git_utils is no longer hard-coded.


### :brain: **Ai UsageDetails (if applicable):**

IMPORTANT: Please disclose any usage of ai tooling while making this change. If you did not use any AI write "NA" below
> _Example: Used ChatGPT to help with doc phrasing._  
> _Example: Code generated by Copilot; reviewed and verified manually._

